### PR TITLE
Fix CI: run all tests without -Dtest override

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,5 +22,5 @@ jobs:
           distribution: 'temurin'
           cache: 'maven'
 
-      - name: Build and test (skip E2E)
-        run: mvn clean install -B -Dtest="!UnixDomainSocketITCase" -DfailIfNoTests=false -pl '!:statefun-smoke-e2e-embedded,!:statefun-smoke-e2e-multilang-base,!:statefun-smoke-e2e-multilang-harness,!:statefun-smoke-e2e-java,!:statefun-smoke-e2e-golang,!:statefun-smoke-e2e-js,!:statefun-k8s-native-e2e'
+      - name: Build and test
+        run: mvn clean install -B

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -36,8 +36,8 @@ jobs:
           distribution: 'temurin'
           cache: 'maven'
 
-      - name: Build and test (skip E2E)
-        run: mvn clean install -B -Dtest="!UnixDomainSocketITCase" -DfailIfNoTests=false -pl '!:statefun-smoke-e2e-embedded,!:statefun-smoke-e2e-multilang-base,!:statefun-smoke-e2e-multilang-harness,!:statefun-smoke-e2e-java,!:statefun-smoke-e2e-golang,!:statefun-smoke-e2e-js,!:statefun-k8s-native-e2e'
+      - name: Build and test
+        run: mvn clean install -B
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,8 +72,8 @@ jobs:
           gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
           gpg-passphrase: GPG_PASSPHRASE
 
-      - name: Build and test (skip E2E)
-        run: mvn clean install -B -Dtest="!UnixDomainSocketITCase" -DfailIfNoTests=false -pl '!:statefun-smoke-e2e-embedded,!:statefun-smoke-e2e-multilang-base,!:statefun-smoke-e2e-multilang-harness,!:statefun-smoke-e2e-java,!:statefun-smoke-e2e-golang,!:statefun-smoke-e2e-js,!:statefun-k8s-native-e2e'
+      - name: Build and test
+        run: mvn clean install -B
 
       - name: Deploy to Maven Central
         if: steps.release_type.outputs.type == 'full'

--- a/pom.xml
+++ b/pom.xml
@@ -464,6 +464,7 @@ under the License.
                             </includes>
                             <excludes>
                                 <exclude>${test.unit.pattern}</exclude>
+                                <exclude>**/UnixDomainSocketITCase.*</exclude>
                             </excludes>
                             <reuseForks>false</reuseForks>
                         </configuration>


### PR DESCRIPTION
## Summary
- Remove `-Dtest='!UnixDomainSocketITCase'` from all CI workflows — this flag overrides surefire's includes, causing Testcontainers E2E tests to run during unit test phase and fail without Docker
- Exclude `UnixDomainSocketITCase` in root pom surefire integration-test config instead
- Simplify all workflow build commands to plain `mvn clean install -B`
- All 36 modules pass locally with `mvn clean install -B`

## Test plan
- [ ] CI Build passes on this PR (all unit/integration tests, no exclusions)
- [ ] K8s E2E gate passes in release workflow