### PR TITLE
Remove empty non-Java SDK modules from reactor

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,9 +78,9 @@ jobs:
       - name: Deploy to Maven Central
         if: steps.release_type.outputs.type == 'full'
         run: |
-          # Exclude e2e tests and non-Java SDKs from deployment
+          # Exclude e2e tests from deployment
           mvn deploy -Prelease -DskipTests -B \
-            -pl '!:statefun-flink-runner,!:statefun-e2e-tests,!:statefun-e2e-tests-common,!:statefun-smoke-e2e-common,!:statefun-smoke-e2e-driver,!:statefun-smoke-e2e-embedded,!:statefun-smoke-e2e-multilang-base,!:statefun-smoke-e2e-multilang-harness,!:statefun-smoke-e2e-java,!:statefun-smoke-e2e-golang,!:statefun-smoke-e2e-js,!:statefun-k8s-native-e2e,!:statefun-sdk-python,!:statefun-sdk-go,!:statefun-sdk-js'
+            -pl '!:statefun-flink-runner,!:statefun-e2e-tests,!:statefun-e2e-tests-common,!:statefun-smoke-e2e-common,!:statefun-smoke-e2e-driver,!:statefun-smoke-e2e-embedded,!:statefun-smoke-e2e-multilang-base,!:statefun-smoke-e2e-multilang-harness,!:statefun-smoke-e2e-java,!:statefun-smoke-e2e-golang,!:statefun-smoke-e2e-js,!:statefun-k8s-native-e2e'
         env:
           CENTRAL_USERNAME: ${{ secrets.OSSRH_USERNAME }}
           CENTRAL_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}

--- a/pom.xml
+++ b/pom.xml
@@ -67,9 +67,8 @@ under the License.
         <module>statefun-sdk-embedded</module>
         <module>statefun-sdk-protos</module>
         <module>statefun-sdk-java</module>
-        <module>statefun-sdk-python</module>
-        <module>statefun-sdk-go</module>
-        <module>statefun-sdk-js</module>
+        <!-- Non-Java SDKs removed from reactor (empty pass-through modules) -->
+        <!-- Directories kept for reference: statefun-sdk-python, statefun-sdk-go, statefun-sdk-js -->
         <module>statefun-kafka-io</module>
         <module>statefun-kinesis-io</module>
         <module>statefun-flink</module>


### PR DESCRIPTION
## Summary
- Remove `statefun-sdk-python`, `statefun-sdk-go`, `statefun-sdk-js` from `<modules>` in root `pom.xml`
- Remove corresponding exclusions from `release.yml` deploy command
- Directories kept for reference

## Test plan
- [x] Local build passes (3 fewer modules in reactor)
- [x] Deploy command no longer needs non-Java SDK exclusions