### PR TITLE
Fix FlinkDeployment example: flinkVersion v2_2 to v2_0

### DIFF
--- a/statefun-flink-runner/example-flinkdeployment.yaml
+++ b/statefun-flink-runner/example-flinkdeployment.yaml
@@ -21,7 +21,8 @@ metadata:
   name: statefun-app
 spec:
   image: ghcr.io/kzmlabs/flink-statefun:3.4.0-KZM-2.0-RC4-k8s
-  flinkVersion: "v2_2"
+  # Flink K8s Operator 1.11 only supports up to v2_0 (not v2_2)
+  flinkVersion: "v2_0"
   flinkConfiguration:
     taskmanager.numberOfTaskSlots: "1"
     state.backend.type: hashmap


### PR DESCRIPTION
## Summary
- Change `flinkVersion: "v2_2"` to `flinkVersion: "v2_0"` in `example-flinkdeployment.yaml`
- Flink K8s Operator 1.11 only supports up to `v2_0`

## Test plan
- [x] Example file only — no build impact