### PR TITLE
Remove UnixDomainSocketITCase exclusion from surefire

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -463,7 +463,6 @@ under the License.
                             </includes>
                             <excludes>
                                 <exclude>${test.unit.pattern}</exclude>
-                                <exclude>**/UnixDomainSocketITCase.*</exclude>
                             </excludes>
                             <reuseForks>false</reuseForks>
                         </configuration>


### PR DESCRIPTION
## Summary
- Remove `**/UnixDomainSocketITCase.*` exclusion from surefire integration-test config
- Test self-skips on Windows via `assumeFalse(isWindows())` (line 53) with 10s timeout

## Test plan
- [x] Test runs on Linux CI (Ubuntu runners)
- [x] Test auto-skips on Windows via JUnit Assume