### PR TITLE
Upgrade maven-compiler-plugin 3.8.1 to 3.13.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -307,7 +307,7 @@ under the License.
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.8.1</version>
+                <version>3.13.0</version>
                 <configuration>
                     <source>21</source>
                     <target>21</target>

--- a/statefun-k8s-native-e2e/remote-function/pom.xml
+++ b/statefun-k8s-native-e2e/remote-function/pom.xml
@@ -51,7 +51,7 @@ under the License.
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.8.1</version>
+                <version>3.13.0</version>
                 <configuration>
                     <source>21</source>
                     <target>21</target>


### PR DESCRIPTION
## Summary
- Upgrade `maven-compiler-plugin` from 3.8.1 to 3.13.0 in root `pom.xml` and `remote-function/pom.xml`

## Test plan
- [x] Plugin version bump only — no behavioral changes expected