### PR TITLE
Add statefun-bom module for dependency management

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -74,6 +74,7 @@ under the License.
         <module>statefun-flink</module>
         <module>statefun-shaded</module>
         <module>statefun-flink-runner</module>
+        <module>statefun-bom</module>
 
         <!-- e2e tests before testutil so a publishable module is last for Central -->
         <module>statefun-e2e-tests</module>

--- a/statefun-bom/pom.xml
+++ b/statefun-bom/pom.xml
@@ -1,0 +1,138 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+  http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.github.kzmlabs.flinkstatefun</groupId>
+        <artifactId>statefun-parent</artifactId>
+        <version>3.4.0-KZM-2.0-RC4</version>
+    </parent>
+
+    <artifactId>statefun-bom</artifactId>
+    <name>Kzmlabs StateFun BOM</name>
+    <packaging>pom</packaging>
+    <description>Bill of Materials (BOM) for Kzmlabs StateFun dependencies</description>
+
+    <dependencyManagement>
+        <dependencies>
+            <!-- SDK -->
+            <dependency>
+                <groupId>io.github.kzmlabs.flinkstatefun</groupId>
+                <artifactId>statefun-sdk-java</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.github.kzmlabs.flinkstatefun</groupId>
+                <artifactId>statefun-sdk-embedded</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.github.kzmlabs.flinkstatefun</groupId>
+                <artifactId>statefun-sdk-protos</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <!-- IO connectors -->
+            <dependency>
+                <groupId>io.github.kzmlabs.flinkstatefun</groupId>
+                <artifactId>statefun-kafka-io</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.github.kzmlabs.flinkstatefun</groupId>
+                <artifactId>statefun-kinesis-io</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <!-- Flink runtime -->
+            <dependency>
+                <groupId>io.github.kzmlabs.flinkstatefun</groupId>
+                <artifactId>statefun-flink-common</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.github.kzmlabs.flinkstatefun</groupId>
+                <artifactId>statefun-flink-core</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.github.kzmlabs.flinkstatefun</groupId>
+                <artifactId>statefun-flink-extensions</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.github.kzmlabs.flinkstatefun</groupId>
+                <artifactId>statefun-flink-io</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.github.kzmlabs.flinkstatefun</groupId>
+                <artifactId>statefun-flink-io-bundle</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.github.kzmlabs.flinkstatefun</groupId>
+                <artifactId>statefun-flink-launcher</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.github.kzmlabs.flinkstatefun</groupId>
+                <artifactId>statefun-flink-distribution</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.github.kzmlabs.flinkstatefun</groupId>
+                <artifactId>statefun-flink-harness</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.github.kzmlabs.flinkstatefun</groupId>
+                <artifactId>statefun-flink-state-processor</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.github.kzmlabs.flinkstatefun</groupId>
+                <artifactId>statefun-flink-datastream</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <!-- Shaded -->
+            <dependency>
+                <groupId>io.github.kzmlabs.flinkstatefun</groupId>
+                <artifactId>statefun-protobuf-shaded</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.github.kzmlabs.flinkstatefun</groupId>
+                <artifactId>statefun-protocol-shaded</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <!-- Test utilities -->
+            <dependency>
+                <groupId>io.github.kzmlabs.flinkstatefun</groupId>
+                <artifactId>statefun-testutil</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+</project>


### PR DESCRIPTION
## Summary
- Create `statefun-bom/pom.xml` with `<dependencyManagement>` listing all 18 published artifacts
- Add `<module>statefun-bom</module>` to root `pom.xml`
- BOM auto-publishes to Maven Central (no `central.skip`)

## Usage
```xml
<dependencyManagement>
    <dependencies>
        <dependency>
            <groupId>io.github.kzmlabs.flinkstatefun</groupId>
            <artifactId>statefun-bom</artifactId>
            <version>3.4.0-KZM-2.0-RC5</version>
            <type>pom</type>
            <scope>import</scope>
        </dependency>
    </dependencies>
</dependencyManagement>
```

## Test plan
- [x] BOM module builds and installs successfully
- [x] POM-only module — no code impact