### PR TITLE
Release 3.4.0-KZM-2.0-RC5

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ on:
           - full
           - docker-only
       version:
-        description: 'Version (e.g. 3.4.0-KZM-2.0-RC4)'
+        description: 'Version (e.g. 3.4.0-KZM-2.0-RC5)'
         required: true
 
 env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to the Kzmlabs StateFun fork are documented in this file.
 
+## [3.4.0-KZM-2.0-RC5] - 2025-02-25
+
+- Add CHANGELOG.md with release history
+- Only push Docker `latest` tag for stable (non-RC) releases
+- Remove empty non-Java SDK modules from Maven reactor
+- Fix FlinkDeployment example: `flinkVersion` v2_2 → v2_0 (Operator 1.11 limit)
+- Remove `UnixDomainSocketITCase` exclusion from surefire (self-skips on Windows)
+- Re-enable `EmbeddedSmokeHarnessTest` with reduced params and Flink 2.2 config fixes
+- Upgrade `maven-compiler-plugin` 3.8.1 → 3.13.0
+- Upgrade `protobuf` 3.7.1 → 3.25.5 and `protoc-jar-maven-plugin` 3.11.1 → 3.11.4
+- Add `statefun-bom` module for dependency management
+
 ## [3.4.0-KZM-2.0-RC4] - 2025-02-25
 
 - Fix CI: remove `-Dtest` override, exclude `UnixDomainSocketITCase` in pom.xml
@@ -29,6 +41,7 @@ All notable changes to the Kzmlabs StateFun fork are documented in this file.
 - Add Docker image publishing to GitHub Container Registry
 - Add release setup guide and release script
 
+[3.4.0-KZM-2.0-RC5]: https://github.com/kzmlabs/flink-statefun/releases/tag/v3.4.0-KZM-2.0-RC5
 [3.4.0-KZM-2.0-RC4]: https://github.com/kzmlabs/flink-statefun/releases/tag/v3.4.0-KZM-2.0-RC4
 [3.4.0-KZM-2.0-RC3]: https://github.com/kzmlabs/flink-statefun/releases/tag/v3.4.0-KZM-2.0-RC3
 [3.4.0-KZM-2.0-RC2]: https://github.com/kzmlabs/flink-statefun/releases/tag/v3.4.0-KZM-2.0-RC2

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@ under the License.
     <groupId>io.github.kzmlabs.flinkstatefun</groupId>
     <artifactId>statefun-parent</artifactId>
     <name>Kzmlabs StateFun Parent</name>
-    <version>3.4.0-KZM-2.0-RC4</version>
+    <version>3.4.0-KZM-2.0-RC5</version>
     <packaging>pom</packaging>
     <description>Kzmlabs fork of Apache Flink Stateful Functions</description>
 

--- a/statefun-bom/pom.xml
+++ b/statefun-bom/pom.xml
@@ -23,7 +23,7 @@ under the License.
     <parent>
         <groupId>io.github.kzmlabs.flinkstatefun</groupId>
         <artifactId>statefun-parent</artifactId>
-        <version>3.4.0-KZM-2.0-RC4</version>
+        <version>3.4.0-KZM-2.0-RC5</version>
     </parent>
 
     <artifactId>statefun-bom</artifactId>

--- a/statefun-e2e-tests/pom.xml
+++ b/statefun-e2e-tests/pom.xml
@@ -21,7 +21,7 @@ under the License.
     <parent>
         <artifactId>statefun-parent</artifactId>
         <groupId>io.github.kzmlabs.flinkstatefun</groupId>
-        <version>3.4.0-KZM-2.0-RC4</version>
+        <version>3.4.0-KZM-2.0-RC5</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/statefun-e2e-tests/statefun-e2e-tests-common/pom.xml
+++ b/statefun-e2e-tests/statefun-e2e-tests-common/pom.xml
@@ -21,7 +21,7 @@ under the License.
     <parent>
         <artifactId>statefun-e2e-tests</artifactId>
         <groupId>io.github.kzmlabs.flinkstatefun</groupId>
-        <version>3.4.0-KZM-2.0-RC4</version>
+        <version>3.4.0-KZM-2.0-RC5</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/statefun-e2e-tests/statefun-smoke-e2e-common/pom.xml
+++ b/statefun-e2e-tests/statefun-smoke-e2e-common/pom.xml
@@ -21,7 +21,7 @@ under the License.
     <parent>
         <artifactId>statefun-e2e-tests</artifactId>
         <groupId>io.github.kzmlabs.flinkstatefun</groupId>
-        <version>3.4.0-KZM-2.0-RC4</version>
+        <version>3.4.0-KZM-2.0-RC5</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/statefun-e2e-tests/statefun-smoke-e2e-driver/pom.xml
+++ b/statefun-e2e-tests/statefun-smoke-e2e-driver/pom.xml
@@ -21,7 +21,7 @@ under the License.
     <parent>
         <artifactId>statefun-e2e-tests</artifactId>
         <groupId>io.github.kzmlabs.flinkstatefun</groupId>
-        <version>3.4.0-KZM-2.0-RC4</version>
+        <version>3.4.0-KZM-2.0-RC5</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/statefun-e2e-tests/statefun-smoke-e2e-embedded/pom.xml
+++ b/statefun-e2e-tests/statefun-smoke-e2e-embedded/pom.xml
@@ -21,7 +21,7 @@ under the License.
     <parent>
         <artifactId>statefun-e2e-tests</artifactId>
         <groupId>io.github.kzmlabs.flinkstatefun</groupId>
-        <version>3.4.0-KZM-2.0-RC4</version>
+        <version>3.4.0-KZM-2.0-RC5</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -61,7 +61,7 @@ under the License.
         <dependency>
             <groupId>io.github.kzmlabs.flinkstatefun</groupId>
             <artifactId>statefun-smoke-e2e-driver</artifactId>
-            <version>3.4.0-KZM-2.0-RC4</version>
+            <version>3.4.0-KZM-2.0-RC5</version>
         </dependency>
     </dependencies>
 

--- a/statefun-e2e-tests/statefun-smoke-e2e-golang/pom.xml
+++ b/statefun-e2e-tests/statefun-smoke-e2e-golang/pom.xml
@@ -21,7 +21,7 @@ under the License.
     <parent>
         <groupId>io.github.kzmlabs.flinkstatefun</groupId>
         <artifactId>statefun-smoke-e2e-multilang-base</artifactId>
-        <version>3.4.0-KZM-2.0-RC4</version>
+        <version>3.4.0-KZM-2.0-RC5</version>
         <relativePath>../statefun-smoke-e2e-multilang-base/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/statefun-e2e-tests/statefun-smoke-e2e-java/pom.xml
+++ b/statefun-e2e-tests/statefun-smoke-e2e-java/pom.xml
@@ -21,7 +21,7 @@ under the License.
     <parent>
         <groupId>io.github.kzmlabs.flinkstatefun</groupId>
         <artifactId>statefun-smoke-e2e-multilang-base</artifactId>
-        <version>3.4.0-KZM-2.0-RC4</version>
+        <version>3.4.0-KZM-2.0-RC5</version>
         <relativePath>../statefun-smoke-e2e-multilang-base/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/statefun-e2e-tests/statefun-smoke-e2e-js/pom.xml
+++ b/statefun-e2e-tests/statefun-smoke-e2e-js/pom.xml
@@ -21,7 +21,7 @@ under the License.
     <parent>
         <groupId>io.github.kzmlabs.flinkstatefun</groupId>
         <artifactId>statefun-smoke-e2e-multilang-base</artifactId>
-        <version>3.4.0-KZM-2.0-RC4</version>
+        <version>3.4.0-KZM-2.0-RC5</version>
         <relativePath>../statefun-smoke-e2e-multilang-base/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/statefun-e2e-tests/statefun-smoke-e2e-multilang-base/pom.xml
+++ b/statefun-e2e-tests/statefun-smoke-e2e-multilang-base/pom.xml
@@ -21,7 +21,7 @@ under the License.
     <parent>
         <artifactId>statefun-e2e-tests</artifactId>
         <groupId>io.github.kzmlabs.flinkstatefun</groupId>
-        <version>3.4.0-KZM-2.0-RC4</version>
+        <version>3.4.0-KZM-2.0-RC5</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/statefun-e2e-tests/statefun-smoke-e2e-multilang-harness/pom.xml
+++ b/statefun-e2e-tests/statefun-smoke-e2e-multilang-harness/pom.xml
@@ -21,7 +21,7 @@ under the License.
     <parent>
         <artifactId>statefun-e2e-tests</artifactId>
         <groupId>io.github.kzmlabs.flinkstatefun</groupId>
-        <version>3.4.0-KZM-2.0-RC4</version>
+        <version>3.4.0-KZM-2.0-RC5</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -50,7 +50,7 @@ under the License.
         <dependency>
             <groupId>io.github.kzmlabs.flinkstatefun</groupId>
             <artifactId>statefun-smoke-e2e-driver</artifactId>
-            <version>3.4.0-KZM-2.0-RC4</version>
+            <version>3.4.0-KZM-2.0-RC5</version>
         </dependency>
 
         <!-- Test scope dependencies -->

--- a/statefun-flink-runner/example-flinkdeployment.yaml
+++ b/statefun-flink-runner/example-flinkdeployment.yaml
@@ -20,7 +20,7 @@ kind: FlinkDeployment
 metadata:
   name: statefun-app
 spec:
-  image: ghcr.io/kzmlabs/flink-statefun:3.4.0-KZM-2.0-RC4-k8s
+  image: ghcr.io/kzmlabs/flink-statefun:3.4.0-KZM-2.0-RC5-k8s
   # Flink K8s Operator 1.11 only supports up to v2_0 (not v2_2)
   flinkVersion: "v2_0"
   flinkConfiguration:

--- a/statefun-flink-runner/pom.xml
+++ b/statefun-flink-runner/pom.xml
@@ -23,7 +23,7 @@ under the License.
     <parent>
         <groupId>io.github.kzmlabs.flinkstatefun</groupId>
         <artifactId>statefun-parent</artifactId>
-        <version>3.4.0-KZM-2.0-RC4</version>
+        <version>3.4.0-KZM-2.0-RC5</version>
     </parent>
 
     <artifactId>statefun-flink-runner</artifactId>

--- a/statefun-flink/pom.xml
+++ b/statefun-flink/pom.xml
@@ -22,7 +22,7 @@ under the License.
     <parent>
         <artifactId>statefun-parent</artifactId>
         <groupId>io.github.kzmlabs.flinkstatefun</groupId>
-        <version>3.4.0-KZM-2.0-RC4</version>
+        <version>3.4.0-KZM-2.0-RC5</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/statefun-flink/statefun-flink-common/pom.xml
+++ b/statefun-flink/statefun-flink-common/pom.xml
@@ -23,7 +23,7 @@ under the License.
     <parent>
         <groupId>io.github.kzmlabs.flinkstatefun</groupId>
         <artifactId>statefun-flink</artifactId>
-        <version>3.4.0-KZM-2.0-RC4</version>
+        <version>3.4.0-KZM-2.0-RC5</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/statefun-flink/statefun-flink-core/pom.xml
+++ b/statefun-flink/statefun-flink-core/pom.xml
@@ -23,7 +23,7 @@ under the License.
     <parent>
         <groupId>io.github.kzmlabs.flinkstatefun</groupId>
         <artifactId>statefun-flink</artifactId>
-        <version>3.4.0-KZM-2.0-RC4</version>
+        <version>3.4.0-KZM-2.0-RC5</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/statefun-flink/statefun-flink-datastream/pom.xml
+++ b/statefun-flink/statefun-flink-datastream/pom.xml
@@ -23,7 +23,7 @@ under the License.
     <parent>
         <groupId>io.github.kzmlabs.flinkstatefun</groupId>
         <artifactId>statefun-flink</artifactId>
-        <version>3.4.0-KZM-2.0-RC4</version>
+        <version>3.4.0-KZM-2.0-RC5</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/statefun-flink/statefun-flink-distribution/pom.xml
+++ b/statefun-flink/statefun-flink-distribution/pom.xml
@@ -23,7 +23,7 @@ under the License.
     <parent>
         <groupId>io.github.kzmlabs.flinkstatefun</groupId>
         <artifactId>statefun-flink</artifactId>
-        <version>3.4.0-KZM-2.0-RC4</version>
+        <version>3.4.0-KZM-2.0-RC5</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/statefun-flink/statefun-flink-extensions/pom.xml
+++ b/statefun-flink/statefun-flink-extensions/pom.xml
@@ -23,7 +23,7 @@ under the License.
     <parent>
         <groupId>io.github.kzmlabs.flinkstatefun</groupId>
         <artifactId>statefun-flink</artifactId>
-        <version>3.4.0-KZM-2.0-RC4</version>
+        <version>3.4.0-KZM-2.0-RC5</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/statefun-flink/statefun-flink-harness/pom.xml
+++ b/statefun-flink/statefun-flink-harness/pom.xml
@@ -23,7 +23,7 @@ under the License.
     <parent>
         <groupId>io.github.kzmlabs.flinkstatefun</groupId>
         <artifactId>statefun-flink</artifactId>
-        <version>3.4.0-KZM-2.0-RC4</version>
+        <version>3.4.0-KZM-2.0-RC5</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/statefun-flink/statefun-flink-io-bundle/pom.xml
+++ b/statefun-flink/statefun-flink-io-bundle/pom.xml
@@ -23,7 +23,7 @@ under the License.
     <parent>
         <groupId>io.github.kzmlabs.flinkstatefun</groupId>
         <artifactId>statefun-flink</artifactId>
-        <version>3.4.0-KZM-2.0-RC4</version>
+        <version>3.4.0-KZM-2.0-RC5</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/statefun-flink/statefun-flink-io/pom.xml
+++ b/statefun-flink/statefun-flink-io/pom.xml
@@ -23,7 +23,7 @@ under the License.
     <parent>
         <groupId>io.github.kzmlabs.flinkstatefun</groupId>
         <artifactId>statefun-flink</artifactId>
-        <version>3.4.0-KZM-2.0-RC4</version>
+        <version>3.4.0-KZM-2.0-RC5</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/statefun-flink/statefun-flink-launcher/pom.xml
+++ b/statefun-flink/statefun-flink-launcher/pom.xml
@@ -23,7 +23,7 @@ under the License.
     <parent>
         <groupId>io.github.kzmlabs.flinkstatefun</groupId>
         <artifactId>statefun-flink</artifactId>
-        <version>3.4.0-KZM-2.0-RC4</version>
+        <version>3.4.0-KZM-2.0-RC5</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/statefun-flink/statefun-flink-state-processor/pom.xml
+++ b/statefun-flink/statefun-flink-state-processor/pom.xml
@@ -21,7 +21,7 @@ under the License.
     <parent>
         <artifactId>statefun-flink</artifactId>
         <groupId>io.github.kzmlabs.flinkstatefun</groupId>
-        <version>3.4.0-KZM-2.0-RC4</version>
+        <version>3.4.0-KZM-2.0-RC5</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/statefun-k8s-native-e2e/pom.xml
+++ b/statefun-k8s-native-e2e/pom.xml
@@ -21,7 +21,7 @@ under the License.
     <parent>
         <artifactId>statefun-parent</artifactId>
         <groupId>io.github.kzmlabs.flinkstatefun</groupId>
-        <version>3.4.0-KZM-2.0-RC4</version>
+        <version>3.4.0-KZM-2.0-RC5</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/statefun-k8s-native-e2e/remote-function/pom.xml
+++ b/statefun-k8s-native-e2e/remote-function/pom.xml
@@ -22,13 +22,13 @@ under the License.
 
     <groupId>io.github.kzmlabs.flinkstatefun</groupId>
     <artifactId>statefun-k8s-native-e2e-remote-function</artifactId>
-    <version>3.4.0-KZM-2.0-RC4</version>
+    <version>3.4.0-KZM-2.0-RC5</version>
     <name>statefun-k8s-native-e2e-remote-function</name>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>21</java.version>
-        <statefun.version>3.4.0-KZM-2.0-RC4</statefun.version>
+        <statefun.version>3.4.0-KZM-2.0-RC5</statefun.version>
         <protobuf.version>3.25.5</protobuf.version>
         <protoc-jar-maven-plugin.version>3.11.4</protoc-jar-maven-plugin.version>
     </properties>

--- a/statefun-kafka-io/pom.xml
+++ b/statefun-kafka-io/pom.xml
@@ -21,7 +21,7 @@ under the License.
     <parent>
         <artifactId>statefun-parent</artifactId>
         <groupId>io.github.kzmlabs.flinkstatefun</groupId>
-        <version>3.4.0-KZM-2.0-RC4</version>
+        <version>3.4.0-KZM-2.0-RC5</version>
         <relativePath>..</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/statefun-kinesis-io/pom.xml
+++ b/statefun-kinesis-io/pom.xml
@@ -21,7 +21,7 @@ under the License.
     <parent>
         <artifactId>statefun-parent</artifactId>
         <groupId>io.github.kzmlabs.flinkstatefun</groupId>
-        <version>3.4.0-KZM-2.0-RC4</version>
+        <version>3.4.0-KZM-2.0-RC5</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/statefun-sdk-embedded/pom.xml
+++ b/statefun-sdk-embedded/pom.xml
@@ -21,7 +21,7 @@ under the License.
     <parent>
         <artifactId>statefun-parent</artifactId>
         <groupId>io.github.kzmlabs.flinkstatefun</groupId>
-        <version>3.4.0-KZM-2.0-RC4</version>
+        <version>3.4.0-KZM-2.0-RC5</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/statefun-sdk-go/pom.xml
+++ b/statefun-sdk-go/pom.xml
@@ -21,7 +21,7 @@ under the License.
     <parent>
         <artifactId>statefun-parent</artifactId>
         <groupId>io.github.kzmlabs.flinkstatefun</groupId>
-        <version>3.4.0-KZM-2.0-RC4</version>
+        <version>3.4.0-KZM-2.0-RC5</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>statefun-sdk-go</artifactId>

--- a/statefun-sdk-java/pom.xml
+++ b/statefun-sdk-java/pom.xml
@@ -21,7 +21,7 @@ under the License.
     <parent>
         <artifactId>statefun-parent</artifactId>
         <groupId>io.github.kzmlabs.flinkstatefun</groupId>
-        <version>3.4.0-KZM-2.0-RC4</version>
+        <version>3.4.0-KZM-2.0-RC5</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>statefun-sdk-java</artifactId>

--- a/statefun-sdk-js/pom.xml
+++ b/statefun-sdk-js/pom.xml
@@ -21,7 +21,7 @@ under the License.
     <parent>
         <artifactId>statefun-parent</artifactId>
         <groupId>io.github.kzmlabs.flinkstatefun</groupId>
-        <version>3.4.0-KZM-2.0-RC4</version>
+        <version>3.4.0-KZM-2.0-RC5</version>
         <relativePath>..</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/statefun-sdk-protos/pom.xml
+++ b/statefun-sdk-protos/pom.xml
@@ -21,7 +21,7 @@ under the License.
     <parent>
         <artifactId>statefun-parent</artifactId>
         <groupId>io.github.kzmlabs.flinkstatefun</groupId>
-        <version>3.4.0-KZM-2.0-RC4</version>
+        <version>3.4.0-KZM-2.0-RC5</version>
         <relativePath>..</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/statefun-sdk-python/pom.xml
+++ b/statefun-sdk-python/pom.xml
@@ -21,7 +21,7 @@ under the License.
     <parent>
         <artifactId>statefun-parent</artifactId>
         <groupId>io.github.kzmlabs.flinkstatefun</groupId>
-        <version>3.4.0-KZM-2.0-RC4</version>
+        <version>3.4.0-KZM-2.0-RC5</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/statefun-shaded/pom.xml
+++ b/statefun-shaded/pom.xml
@@ -23,7 +23,7 @@ under the License.
     <parent>
         <artifactId>statefun-parent</artifactId>
         <groupId>io.github.kzmlabs.flinkstatefun</groupId>
-        <version>3.4.0-KZM-2.0-RC4</version>
+        <version>3.4.0-KZM-2.0-RC5</version>
     </parent>
 
     <artifactId>statefun-shaded</artifactId>

--- a/statefun-shaded/statefun-protobuf-shaded/pom.xml
+++ b/statefun-shaded/statefun-protobuf-shaded/pom.xml
@@ -23,7 +23,7 @@ under the License.
     <parent>
         <artifactId>statefun-shaded</artifactId>
         <groupId>io.github.kzmlabs.flinkstatefun</groupId>
-        <version>3.4.0-KZM-2.0-RC4</version>
+        <version>3.4.0-KZM-2.0-RC5</version>
     </parent>
 
     <artifactId>statefun-protobuf-shaded</artifactId>

--- a/statefun-shaded/statefun-protocol-shaded/pom.xml
+++ b/statefun-shaded/statefun-protocol-shaded/pom.xml
@@ -23,7 +23,7 @@ under the License.
     <parent>
         <artifactId>statefun-shaded</artifactId>
         <groupId>io.github.kzmlabs.flinkstatefun</groupId>
-        <version>3.4.0-KZM-2.0-RC4</version>
+        <version>3.4.0-KZM-2.0-RC5</version>
     </parent>
 
     <artifactId>statefun-protocol-shaded</artifactId>

--- a/statefun-testutil/pom.xml
+++ b/statefun-testutil/pom.xml
@@ -21,7 +21,7 @@ under the License.
     <parent>
         <artifactId>statefun-parent</artifactId>
         <groupId>io.github.kzmlabs.flinkstatefun</groupId>
-        <version>3.4.0-KZM-2.0-RC4</version>
+        <version>3.4.0-KZM-2.0-RC5</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/tools/docker/build-stateful-functions.sh
+++ b/tools/docker/build-stateful-functions.sh
@@ -17,7 +17,7 @@
 
 set -e
 
-VERSION_TAG=${1:-3.4.0-KZM-2.0-RC4}
+VERSION_TAG=${1:-3.4.0-KZM-2.0-RC5}
 
 #
 # setup the environment


### PR DESCRIPTION
## Summary
- Bump version to `3.4.0-KZM-2.0-RC5` across all modules
- Update `CHANGELOG.md` with RC5 changes
- Update `build-stateful-functions.sh`, `example-flinkdeployment.yaml`, `remote-function/pom.xml`
- Update `release.yml` version example

## Changes since RC4
- Add CHANGELOG.md with release history
- Only push Docker `latest` tag for stable (non-RC) releases
- Remove empty non-Java SDK modules from Maven reactor
- Fix FlinkDeployment example: `flinkVersion` v2_2 → v2_0
- Remove `UnixDomainSocketITCase` surefire exclusion
- Re-enable `EmbeddedSmokeHarnessTest` with Flink 2.2 config fixes
- Upgrade `maven-compiler-plugin` 3.8.1 → 3.13.0
- Upgrade `protobuf` 3.7.1 → 3.25.5
- Add `statefun-bom` module

## Test plan
- [x] Full build passes (34 modules)
- [x] `grep -r "RC4"` returns only CHANGELOG history and cipher names