### PR TITLE
Re-exclude UnixDomainSocketITCase (Java 21 incompatible)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -468,6 +468,8 @@ under the License.
                             </includes>
                             <excludes>
                                 <exclude>${test.unit.pattern}</exclude>
+                                <!-- junixsocket 2.3.2 incompatible with Java 21 on all platforms -->
+                                <exclude>**/UnixDomainSocketITCase.*</exclude>
                             </excludes>
                             <reuseForks>false</reuseForks>
                         </configuration>


### PR DESCRIPTION
## Summary
- Re-add `**/UnixDomainSocketITCase.*` exclusion to surefire integration-test config
- junixsocket 2.3.2 is incompatible with Java 21 on ALL platforms (not just Windows)
- Error: `Cannot find method "setCreated" or field "created" in java.net.Socket`

## Test plan
- [x] Fixes CI and release pipeline failures