### PR TITLE
Upgrade JUnit 4.12 to 4.13.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -116,7 +116,7 @@ under the License.
             <dependency>
                 <groupId>junit</groupId>
                 <artifactId>junit</artifactId>
-                <version>4.12</version>
+                <version>4.13.2</version>
                 <scope>test</scope>
             </dependency>
             <dependency>


### PR DESCRIPTION
## Summary
- Upgrade JUnit from 4.12 (2014) to 4.13.2 (latest JUnit 4.x)
- Drop-in replacement, no API changes required

## Test plan
- [ ] CI Build passes