### PR TITLE
Update doc-check.yml to actions/checkout@v4

### DIFF
--- a/.github/workflows/doc-check.yml
+++ b/.github/workflows/doc-check.yml
@@ -7,6 +7,6 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Build and Check Documentation
         run: ./tools/ci/docs.sh


### PR DESCRIPTION
## Summary
- Update deprecated `actions/checkout@v2` to `@v4` in doc-check workflow
- v2 no longer receives security updates (deprecated since Nov 2022)

## Test plan
- [ ] CI passes (workflow-only change)