### PR TITLE
Add timeout to CI build workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     name: Build & Test
+    timeout-minutes: 20
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
## Summary
- Add `timeout-minutes: 20` to CI build job
- Default is 360 minutes (6 hours) which wastes resources if a build hangs
- 20 minutes is enough for the full compile + test cycle (~10 min typical)

## Test plan
- [ ] CI passes