### PR TITLE
Add concurrency limits to workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [ release, master ]
 
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -8,6 +8,10 @@ on:
         required: true
         default: 'latest'
 
+concurrency:
+  group: docker-release-${{ github.ref }}
+  cancel-in-progress: false
+
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: kzmlabs/flink-statefun

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,10 @@ on:
         description: 'Version (e.g. 3.4.0-KZM-2.0-RC5)'
         required: true
 
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: kzmlabs/flink-statefun


### PR DESCRIPTION
## Summary
- Add concurrency groups to prevent overlapping workflow runs
- CI: `cancel-in-progress: true` — newer pushes cancel old builds
- Release/Docker-release: `cancel-in-progress: false` — queues releases

## Test plan
- [ ] CI passes