### PR TITLE
Remove stale TODO about Flink 1.12.x

### DIFF
--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/logger/InputStreamUtils.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/logger/InputStreamUtils.java
@@ -37,9 +37,6 @@ final class InputStreamUtils {
    *   <li>EOF of the input stream is reached.
    * </ul>
    *
-   * <p>TODO we can remove this once we upgrade to Flink 1.12.x, since {@link
-   * org.apache.flink.util.IOUtils} would have a new utility for exactly this.
-   *
    * @param in the input stream to read from
    * @param readBuffer the read buffer to fill
    * @return the total number of bytes read into the read buffer


### PR DESCRIPTION
## Summary
- Remove outdated TODO comment referencing Flink 1.12.x in InputStreamUtils.java
- Project is already on Flink 2.2.0, the comment is 3 major versions behind

## Test plan
- [ ] CI passes