### PR TITLE
Upgrade JMH 1.21 to 1.37

### DIFF
--- a/statefun-flink/pom.xml
+++ b/statefun-flink/pom.xml
@@ -46,7 +46,7 @@ under the License.
 
     <properties>
         <jsr305.version>3.0.2</jsr305.version>
-        <jmh.version>1.21</jmh.version>
+        <jmh.version>1.37</jmh.version>
         <jsr305-version>1.3.9</jsr305-version>
     </properties>
 


### PR DESCRIPTION
## Summary
- Upgrade JMH benchmarking library from 1.21 (2019) to 1.37 (latest)
- Test/benchmark-only dependency, no runtime impact
- Local build passes

## Test plan
- [ ] CI Build passes