### PR TITLE
Upgrade JimFS 1.1 to 1.3.0

### DIFF
--- a/statefun-flink/statefun-flink-core/pom.xml
+++ b/statefun-flink/statefun-flink-core/pom.xml
@@ -142,7 +142,7 @@ under the License.
         <dependency>
             <groupId>com.google.jimfs</groupId>
             <artifactId>jimfs</artifactId>
-            <version>1.1</version>
+            <version>1.3.0</version>
             <scope>test</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
## Summary
- Upgrade Google JimFS from 1.1 (2015) to 1.3.0 (latest)
- Test-only dependency, no runtime impact
- Local build passes

## Test plan
- [ ] CI Build passes