### PR TITLE
Upgrade maven-enforcer-plugin to 3.5.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -411,7 +411,7 @@ under the License.
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-enforcer-plugin</artifactId>
-                <version>3.0.0-M2</version>
+                <version>3.5.0</version>
                 <executions>
                     <execution>
                         <id>enforce</id>


### PR DESCRIPTION
## Summary
- Upgrade maven-enforcer-plugin from 3.0.0-M2 (milestone) to 3.5.0 (latest stable)
- Local build passes

## Test plan
- [ ] CI Build passes