### PR TITLE
Upgrade Surefire, Failsafe and exec-maven-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -431,7 +431,7 @@ under the License.
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.22.1</version>
+                <version>3.5.2</version>
                 <configuration>
                     <trimStackTrace>false</trimStackTrace>
                     <systemPropertyVariables>

--- a/statefun-e2e-tests/pom.xml
+++ b/statefun-e2e-tests/pom.xml
@@ -99,7 +99,7 @@ under the License.
                     <plugin>
                         <groupId>org.codehaus.mojo</groupId>
                         <artifactId>exec-maven-plugin</artifactId>
-                        <version>1.6.0</version>
+                        <version>3.5.0</version>
                         <executions>
                             <execution>
                                 <id>build-statefun-base-image</id>
@@ -127,7 +127,7 @@ under the License.
                     </plugin>
                     <plugin>
                         <artifactId>maven-failsafe-plugin</artifactId>
-                        <version>2.22.0</version>
+                        <version>3.5.2</version>
                         <executions>
                             <execution>
                                 <goals>


### PR DESCRIPTION
## Summary
- Upgrade maven-surefire-plugin 2.22.1 → 3.5.2 (root pom)
- Upgrade maven-failsafe-plugin 2.22.0 → 3.5.2 (e2e tests)
- Upgrade exec-maven-plugin 1.6.0 → 3.5.0 (e2e tests)
- Better Java 21 support and parallel test execution
- Local build passes (all 33 modules, only k8s-native-e2e skipped — needs Docker)

## Test plan
- [ ] CI Build passes