### PR TITLE
Fix protoc-jar-maven-plugin version inconsistency

### DIFF
--- a/statefun-shaded/statefun-protocol-shaded/pom.xml
+++ b/statefun-shaded/statefun-protocol-shaded/pom.xml
@@ -33,7 +33,7 @@ under the License.
     <properties>
         <protocol-messages.dir>${generated-sources.basedir}/protocol-messages/</protocol-messages.dir>
         <proto-sources.dir>target/proto-sources</proto-sources.dir>
-        <protoc-jar-maven-plugin.version>3.11.1</protoc-jar-maven-plugin.version>
+        <protoc-jar-maven-plugin.version>3.11.4</protoc-jar-maven-plugin.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
## Summary
- Fix protoc-jar-maven-plugin version override in statefun-protocol-shaded (3.11.1 → 3.11.4)
- All other modules inherit 3.11.4 from root, this was the only inconsistency
- Local build passes

## Test plan
- [ ] CI Build passes