### PR TITLE
Fix SLF4J version inconsistency

### DIFF
--- a/statefun-flink/pom.xml
+++ b/statefun-flink/pom.xml
@@ -138,12 +138,12 @@ under the License.
             <dependency>
                 <groupId>org.slf4j</groupId>
                 <artifactId>slf4j-api</artifactId>
-                <version>1.7.7</version>
+                <version>${slf4j-log4j12.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.slf4j</groupId>
                 <artifactId>slf4j-log4j12</artifactId>
-                <version>1.7.7</version>
+                <version>${slf4j-log4j12.version}</version>
             </dependency>
             <dependency>
                 <groupId>log4j</groupId>


### PR DESCRIPTION
## Summary
- Fix SLF4J version override in statefun-flink/pom.xml
- Was hardcoded to 1.7.7 (2013), now uses `${slf4j-log4j12.version}` = 1.7.36 from root
- Local build passes

## Test plan
- [ ] CI Build passes