### PR TITLE
Update copyright year in NOTICE

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,5 +1,5 @@
 Apache Flink Stateful Functions (flink-statefun)
-Copyright 2014-2023 The Apache Software Foundation
+Copyright 2014-2025 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).


### PR DESCRIPTION
## Summary
- Update copyright year from 2014-2023 to 2014-2025

## Test plan
- [ ] CI passes