### PR TITLE
Remove misleading TODO in UniverseValidator

### DIFF
--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/StatefulFunctionsUniverseValidator.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/StatefulFunctionsUniverseValidator.java
@@ -20,7 +20,6 @@ package org.apache.flink.statefun.flink.core;
 final class StatefulFunctionsUniverseValidator {
 
   void validate(StatefulFunctionsUniverse statefulFunctionsUniverse) {
-    // TODO: complete this
     if (statefulFunctionsUniverse.ingress().isEmpty()) {
       throw new IllegalStateException("There are no ingress defined.");
     }


### PR DESCRIPTION
## Summary
- Remove `// TODO: complete this` from StatefulFunctionsUniverseValidator
- The validator already has complete validation (ingress, sources, routers, functions)
- Misleading comment suggesting incomplete implementation

## Test plan
- [ ] CI passes