### PR TITLE
Upgrade Testcontainers 1.15.2 to 1.20.4

### DIFF
--- a/statefun-e2e-tests/pom.xml
+++ b/statefun-e2e-tests/pom.xml
@@ -29,7 +29,7 @@ under the License.
     <packaging>pom</packaging>
 
     <properties>
-        <testcontainers.version>1.15.2</testcontainers.version>
+        <testcontainers.version>1.20.4</testcontainers.version>
         <central.skip>true</central.skip>
     </properties>
 


### PR DESCRIPTION
## Summary
- Upgrade Testcontainers from 1.15.2 (2021) to 1.20.4 (latest 1.x)
- Test-only dependency used by e2e tests
- Local compilation passes

## Test plan
- [ ] CI Build passes
- [ ] E2E tests pass (uses Testcontainers for Docker-based tests)