### PR TITLE
Upgrade OkHttp 3.14.6 to 4.12.0

### DIFF
--- a/statefun-flink/statefun-flink-core/pom.xml
+++ b/statefun-flink/statefun-flink-core/pom.xml
@@ -31,7 +31,7 @@ under the License.
     <name>statefun-flink-core</name>
 
     <properties>
-        <okhttp.version>3.14.6</okhttp.version>
+        <okhttp.version>4.12.0</okhttp.version>
         <additional-sources.dir>target/additional-sources</additional-sources.dir>
         <flink-shaded-netty.version>4.1.91.Final-17.0</flink-shaded-netty.version>
     </properties>
@@ -86,6 +86,17 @@ under the License.
             <groupId>com.squareup.okhttp3</groupId>
             <artifactId>okhttp</artifactId>
             <version>${okhttp.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.jetbrains.kotlin</groupId>
+                    <artifactId>kotlin-stdlib-jdk8</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.jetbrains.kotlin</groupId>
+            <artifactId>kotlin-stdlib-jdk8</artifactId>
+            <version>1.9.10</version>
         </dependency>
         <dependency>
             <groupId>com.kohlschutter.junixsocket</groupId>


### PR DESCRIPTION
## Summary
- Upgrade OkHttp from 3.14.6 (EOL, 2019) to 4.12.0 (latest)
- OkHttp 3.x no longer receives security patches
- Added kotlin-stdlib-jdk8 pin to resolve dependency convergence
- OkHttp 4.x maintains backward Java API compatibility
- Local build passes

## Test plan
- [ ] CI Build passes