### PR TITLE
Upgrade Kafka clients 2.4.1 to 3.9.1

### DIFF
--- a/statefun-kafka-io/pom.xml
+++ b/statefun-kafka-io/pom.xml
@@ -27,7 +27,7 @@ under the License.
     <modelVersion>4.0.0</modelVersion>
 
     <properties>
-        <kafka.version>2.4.1</kafka.version>
+        <kafka.version>3.9.1</kafka.version>
     </properties>
 
     <artifactId>statefun-kafka-io</artifactId>


### PR DESCRIPTION
## Summary
- Upgrade kafka-clients from 2.4.1 (2020, known CVEs) to 3.9.1
- Aligns with the version brought transitively by flink-connector-kafka 4.0.1-2.0
- All used APIs (ProducerRecord, ConsumerRecord, ConsumerConfig) are stable since Kafka 0.10
- Local build passes

## Test plan
- [ ] CI Build passes
- [ ] K8s E2E passes (tests Kafka ingress/egress)