### PR TITLE
Bump version to 3.4.0-KZM-2.0-RC6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,39 @@
 
 All notable changes to the Kzmlabs StateFun fork are documented in this file.
 
+## [3.4.0-KZM-2.0-RC6] - 2025-02-25
+
+### Dependencies
+- Upgrade JUnit 4.12 → 4.13.2
+- Upgrade Hamcrest 1.3 → 2.2 (artifact rename: hamcrest-all → hamcrest)
+- Upgrade Auto-Service 1.0-rc6 → 1.1.1
+- Upgrade OkHttp 3.14.6 → 4.12.0
+- Upgrade Kafka clients 2.4.1 → 3.9.1 (aligned with Flink connector)
+- Upgrade Testcontainers 1.15.2 → 1.20.4
+- Upgrade JMH 1.21 → 1.37
+- Upgrade JimFS 1.1 → 1.3.0
+- Fix SLF4J version inconsistency (1.7.7 → 1.7.36 via parent property)
+
+### Maven Plugins
+- Unify maven-shade-plugin to 3.6.0 across all modules
+- Upgrade maven-surefire/failsafe 2.22.x → 3.5.2
+- Upgrade maven-enforcer-plugin 3.0.0-M2 → 3.5.0
+- Upgrade exec-maven-plugin 1.6.0 → 3.5.0
+- Fix protoc-jar-maven-plugin version inconsistency (3.11.1 → 3.11.4)
+
+### CI/CD
+- Upgrade actions/checkout v2 → v4 in doc-check workflow
+- Add 20-minute timeout to CI build
+- Add concurrency limits to all workflows
+
+### Cleanup
+- Remove unused Helm chart (tools/k8s/)
+- Remove stale Flink 1.12 TODO in InputStreamUtils
+- Remove misleading TODO in StatefulFunctionsUniverseValidator
+- Update docs/config.toml for Kzmlabs fork
+- Add CODEOWNERS file
+- Update copyright year to 2025
+
 ## [3.4.0-KZM-2.0-RC5] - 2025-02-25
 
 - Add CHANGELOG.md with release history

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@ under the License.
     <groupId>io.github.kzmlabs.flinkstatefun</groupId>
     <artifactId>statefun-parent</artifactId>
     <name>Kzmlabs StateFun Parent</name>
-    <version>3.4.0-KZM-2.0-RC5</version>
+    <version>3.4.0-KZM-2.0-RC6</version>
     <packaging>pom</packaging>
     <description>Kzmlabs fork of Apache Flink Stateful Functions</description>
 

--- a/statefun-bom/pom.xml
+++ b/statefun-bom/pom.xml
@@ -23,7 +23,7 @@ under the License.
     <parent>
         <groupId>io.github.kzmlabs.flinkstatefun</groupId>
         <artifactId>statefun-parent</artifactId>
-        <version>3.4.0-KZM-2.0-RC5</version>
+        <version>3.4.0-KZM-2.0-RC6</version>
     </parent>
 
     <artifactId>statefun-bom</artifactId>

--- a/statefun-e2e-tests/pom.xml
+++ b/statefun-e2e-tests/pom.xml
@@ -21,7 +21,7 @@ under the License.
     <parent>
         <artifactId>statefun-parent</artifactId>
         <groupId>io.github.kzmlabs.flinkstatefun</groupId>
-        <version>3.4.0-KZM-2.0-RC5</version>
+        <version>3.4.0-KZM-2.0-RC6</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/statefun-e2e-tests/statefun-e2e-tests-common/pom.xml
+++ b/statefun-e2e-tests/statefun-e2e-tests-common/pom.xml
@@ -21,7 +21,7 @@ under the License.
     <parent>
         <artifactId>statefun-e2e-tests</artifactId>
         <groupId>io.github.kzmlabs.flinkstatefun</groupId>
-        <version>3.4.0-KZM-2.0-RC5</version>
+        <version>3.4.0-KZM-2.0-RC6</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/statefun-e2e-tests/statefun-smoke-e2e-common/pom.xml
+++ b/statefun-e2e-tests/statefun-smoke-e2e-common/pom.xml
@@ -21,7 +21,7 @@ under the License.
     <parent>
         <artifactId>statefun-e2e-tests</artifactId>
         <groupId>io.github.kzmlabs.flinkstatefun</groupId>
-        <version>3.4.0-KZM-2.0-RC5</version>
+        <version>3.4.0-KZM-2.0-RC6</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/statefun-e2e-tests/statefun-smoke-e2e-driver/pom.xml
+++ b/statefun-e2e-tests/statefun-smoke-e2e-driver/pom.xml
@@ -21,7 +21,7 @@ under the License.
     <parent>
         <artifactId>statefun-e2e-tests</artifactId>
         <groupId>io.github.kzmlabs.flinkstatefun</groupId>
-        <version>3.4.0-KZM-2.0-RC5</version>
+        <version>3.4.0-KZM-2.0-RC6</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/statefun-e2e-tests/statefun-smoke-e2e-embedded/pom.xml
+++ b/statefun-e2e-tests/statefun-smoke-e2e-embedded/pom.xml
@@ -21,7 +21,7 @@ under the License.
     <parent>
         <artifactId>statefun-e2e-tests</artifactId>
         <groupId>io.github.kzmlabs.flinkstatefun</groupId>
-        <version>3.4.0-KZM-2.0-RC5</version>
+        <version>3.4.0-KZM-2.0-RC6</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -61,7 +61,7 @@ under the License.
         <dependency>
             <groupId>io.github.kzmlabs.flinkstatefun</groupId>
             <artifactId>statefun-smoke-e2e-driver</artifactId>
-            <version>3.4.0-KZM-2.0-RC5</version>
+            <version>3.4.0-KZM-2.0-RC6</version>
         </dependency>
     </dependencies>
 

--- a/statefun-e2e-tests/statefun-smoke-e2e-golang/pom.xml
+++ b/statefun-e2e-tests/statefun-smoke-e2e-golang/pom.xml
@@ -21,7 +21,7 @@ under the License.
     <parent>
         <groupId>io.github.kzmlabs.flinkstatefun</groupId>
         <artifactId>statefun-smoke-e2e-multilang-base</artifactId>
-        <version>3.4.0-KZM-2.0-RC5</version>
+        <version>3.4.0-KZM-2.0-RC6</version>
         <relativePath>../statefun-smoke-e2e-multilang-base/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/statefun-e2e-tests/statefun-smoke-e2e-java/pom.xml
+++ b/statefun-e2e-tests/statefun-smoke-e2e-java/pom.xml
@@ -21,7 +21,7 @@ under the License.
     <parent>
         <groupId>io.github.kzmlabs.flinkstatefun</groupId>
         <artifactId>statefun-smoke-e2e-multilang-base</artifactId>
-        <version>3.4.0-KZM-2.0-RC5</version>
+        <version>3.4.0-KZM-2.0-RC6</version>
         <relativePath>../statefun-smoke-e2e-multilang-base/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/statefun-e2e-tests/statefun-smoke-e2e-js/pom.xml
+++ b/statefun-e2e-tests/statefun-smoke-e2e-js/pom.xml
@@ -21,7 +21,7 @@ under the License.
     <parent>
         <groupId>io.github.kzmlabs.flinkstatefun</groupId>
         <artifactId>statefun-smoke-e2e-multilang-base</artifactId>
-        <version>3.4.0-KZM-2.0-RC5</version>
+        <version>3.4.0-KZM-2.0-RC6</version>
         <relativePath>../statefun-smoke-e2e-multilang-base/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/statefun-e2e-tests/statefun-smoke-e2e-multilang-base/pom.xml
+++ b/statefun-e2e-tests/statefun-smoke-e2e-multilang-base/pom.xml
@@ -21,7 +21,7 @@ under the License.
     <parent>
         <artifactId>statefun-e2e-tests</artifactId>
         <groupId>io.github.kzmlabs.flinkstatefun</groupId>
-        <version>3.4.0-KZM-2.0-RC5</version>
+        <version>3.4.0-KZM-2.0-RC6</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/statefun-e2e-tests/statefun-smoke-e2e-multilang-harness/pom.xml
+++ b/statefun-e2e-tests/statefun-smoke-e2e-multilang-harness/pom.xml
@@ -21,7 +21,7 @@ under the License.
     <parent>
         <artifactId>statefun-e2e-tests</artifactId>
         <groupId>io.github.kzmlabs.flinkstatefun</groupId>
-        <version>3.4.0-KZM-2.0-RC5</version>
+        <version>3.4.0-KZM-2.0-RC6</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -50,7 +50,7 @@ under the License.
         <dependency>
             <groupId>io.github.kzmlabs.flinkstatefun</groupId>
             <artifactId>statefun-smoke-e2e-driver</artifactId>
-            <version>3.4.0-KZM-2.0-RC5</version>
+            <version>3.4.0-KZM-2.0-RC6</version>
         </dependency>
 
         <!-- Test scope dependencies -->

--- a/statefun-flink-runner/pom.xml
+++ b/statefun-flink-runner/pom.xml
@@ -23,7 +23,7 @@ under the License.
     <parent>
         <groupId>io.github.kzmlabs.flinkstatefun</groupId>
         <artifactId>statefun-parent</artifactId>
-        <version>3.4.0-KZM-2.0-RC5</version>
+        <version>3.4.0-KZM-2.0-RC6</version>
     </parent>
 
     <artifactId>statefun-flink-runner</artifactId>

--- a/statefun-flink/pom.xml
+++ b/statefun-flink/pom.xml
@@ -22,7 +22,7 @@ under the License.
     <parent>
         <artifactId>statefun-parent</artifactId>
         <groupId>io.github.kzmlabs.flinkstatefun</groupId>
-        <version>3.4.0-KZM-2.0-RC5</version>
+        <version>3.4.0-KZM-2.0-RC6</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/statefun-flink/statefun-flink-common/pom.xml
+++ b/statefun-flink/statefun-flink-common/pom.xml
@@ -23,7 +23,7 @@ under the License.
     <parent>
         <groupId>io.github.kzmlabs.flinkstatefun</groupId>
         <artifactId>statefun-flink</artifactId>
-        <version>3.4.0-KZM-2.0-RC5</version>
+        <version>3.4.0-KZM-2.0-RC6</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/statefun-flink/statefun-flink-core/pom.xml
+++ b/statefun-flink/statefun-flink-core/pom.xml
@@ -23,7 +23,7 @@ under the License.
     <parent>
         <groupId>io.github.kzmlabs.flinkstatefun</groupId>
         <artifactId>statefun-flink</artifactId>
-        <version>3.4.0-KZM-2.0-RC5</version>
+        <version>3.4.0-KZM-2.0-RC6</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/statefun-flink/statefun-flink-datastream/pom.xml
+++ b/statefun-flink/statefun-flink-datastream/pom.xml
@@ -23,7 +23,7 @@ under the License.
     <parent>
         <groupId>io.github.kzmlabs.flinkstatefun</groupId>
         <artifactId>statefun-flink</artifactId>
-        <version>3.4.0-KZM-2.0-RC5</version>
+        <version>3.4.0-KZM-2.0-RC6</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/statefun-flink/statefun-flink-distribution/pom.xml
+++ b/statefun-flink/statefun-flink-distribution/pom.xml
@@ -23,7 +23,7 @@ under the License.
     <parent>
         <groupId>io.github.kzmlabs.flinkstatefun</groupId>
         <artifactId>statefun-flink</artifactId>
-        <version>3.4.0-KZM-2.0-RC5</version>
+        <version>3.4.0-KZM-2.0-RC6</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/statefun-flink/statefun-flink-extensions/pom.xml
+++ b/statefun-flink/statefun-flink-extensions/pom.xml
@@ -23,7 +23,7 @@ under the License.
     <parent>
         <groupId>io.github.kzmlabs.flinkstatefun</groupId>
         <artifactId>statefun-flink</artifactId>
-        <version>3.4.0-KZM-2.0-RC5</version>
+        <version>3.4.0-KZM-2.0-RC6</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/statefun-flink/statefun-flink-harness/pom.xml
+++ b/statefun-flink/statefun-flink-harness/pom.xml
@@ -23,7 +23,7 @@ under the License.
     <parent>
         <groupId>io.github.kzmlabs.flinkstatefun</groupId>
         <artifactId>statefun-flink</artifactId>
-        <version>3.4.0-KZM-2.0-RC5</version>
+        <version>3.4.0-KZM-2.0-RC6</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/statefun-flink/statefun-flink-io-bundle/pom.xml
+++ b/statefun-flink/statefun-flink-io-bundle/pom.xml
@@ -23,7 +23,7 @@ under the License.
     <parent>
         <groupId>io.github.kzmlabs.flinkstatefun</groupId>
         <artifactId>statefun-flink</artifactId>
-        <version>3.4.0-KZM-2.0-RC5</version>
+        <version>3.4.0-KZM-2.0-RC6</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/statefun-flink/statefun-flink-io/pom.xml
+++ b/statefun-flink/statefun-flink-io/pom.xml
@@ -23,7 +23,7 @@ under the License.
     <parent>
         <groupId>io.github.kzmlabs.flinkstatefun</groupId>
         <artifactId>statefun-flink</artifactId>
-        <version>3.4.0-KZM-2.0-RC5</version>
+        <version>3.4.0-KZM-2.0-RC6</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/statefun-flink/statefun-flink-launcher/pom.xml
+++ b/statefun-flink/statefun-flink-launcher/pom.xml
@@ -23,7 +23,7 @@ under the License.
     <parent>
         <groupId>io.github.kzmlabs.flinkstatefun</groupId>
         <artifactId>statefun-flink</artifactId>
-        <version>3.4.0-KZM-2.0-RC5</version>
+        <version>3.4.0-KZM-2.0-RC6</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/statefun-flink/statefun-flink-state-processor/pom.xml
+++ b/statefun-flink/statefun-flink-state-processor/pom.xml
@@ -21,7 +21,7 @@ under the License.
     <parent>
         <artifactId>statefun-flink</artifactId>
         <groupId>io.github.kzmlabs.flinkstatefun</groupId>
-        <version>3.4.0-KZM-2.0-RC5</version>
+        <version>3.4.0-KZM-2.0-RC6</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/statefun-k8s-native-e2e/pom.xml
+++ b/statefun-k8s-native-e2e/pom.xml
@@ -21,7 +21,7 @@ under the License.
     <parent>
         <artifactId>statefun-parent</artifactId>
         <groupId>io.github.kzmlabs.flinkstatefun</groupId>
-        <version>3.4.0-KZM-2.0-RC5</version>
+        <version>3.4.0-KZM-2.0-RC6</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/statefun-kafka-io/pom.xml
+++ b/statefun-kafka-io/pom.xml
@@ -21,7 +21,7 @@ under the License.
     <parent>
         <artifactId>statefun-parent</artifactId>
         <groupId>io.github.kzmlabs.flinkstatefun</groupId>
-        <version>3.4.0-KZM-2.0-RC5</version>
+        <version>3.4.0-KZM-2.0-RC6</version>
         <relativePath>..</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/statefun-kinesis-io/pom.xml
+++ b/statefun-kinesis-io/pom.xml
@@ -21,7 +21,7 @@ under the License.
     <parent>
         <artifactId>statefun-parent</artifactId>
         <groupId>io.github.kzmlabs.flinkstatefun</groupId>
-        <version>3.4.0-KZM-2.0-RC5</version>
+        <version>3.4.0-KZM-2.0-RC6</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/statefun-sdk-embedded/pom.xml
+++ b/statefun-sdk-embedded/pom.xml
@@ -21,7 +21,7 @@ under the License.
     <parent>
         <artifactId>statefun-parent</artifactId>
         <groupId>io.github.kzmlabs.flinkstatefun</groupId>
-        <version>3.4.0-KZM-2.0-RC5</version>
+        <version>3.4.0-KZM-2.0-RC6</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/statefun-sdk-java/pom.xml
+++ b/statefun-sdk-java/pom.xml
@@ -21,7 +21,7 @@ under the License.
     <parent>
         <artifactId>statefun-parent</artifactId>
         <groupId>io.github.kzmlabs.flinkstatefun</groupId>
-        <version>3.4.0-KZM-2.0-RC5</version>
+        <version>3.4.0-KZM-2.0-RC6</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>statefun-sdk-java</artifactId>

--- a/statefun-sdk-protos/pom.xml
+++ b/statefun-sdk-protos/pom.xml
@@ -21,7 +21,7 @@ under the License.
     <parent>
         <artifactId>statefun-parent</artifactId>
         <groupId>io.github.kzmlabs.flinkstatefun</groupId>
-        <version>3.4.0-KZM-2.0-RC5</version>
+        <version>3.4.0-KZM-2.0-RC6</version>
         <relativePath>..</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/statefun-shaded/pom.xml
+++ b/statefun-shaded/pom.xml
@@ -23,7 +23,7 @@ under the License.
     <parent>
         <artifactId>statefun-parent</artifactId>
         <groupId>io.github.kzmlabs.flinkstatefun</groupId>
-        <version>3.4.0-KZM-2.0-RC5</version>
+        <version>3.4.0-KZM-2.0-RC6</version>
     </parent>
 
     <artifactId>statefun-shaded</artifactId>

--- a/statefun-shaded/statefun-protobuf-shaded/pom.xml
+++ b/statefun-shaded/statefun-protobuf-shaded/pom.xml
@@ -23,7 +23,7 @@ under the License.
     <parent>
         <artifactId>statefun-shaded</artifactId>
         <groupId>io.github.kzmlabs.flinkstatefun</groupId>
-        <version>3.4.0-KZM-2.0-RC5</version>
+        <version>3.4.0-KZM-2.0-RC6</version>
     </parent>
 
     <artifactId>statefun-protobuf-shaded</artifactId>

--- a/statefun-shaded/statefun-protocol-shaded/pom.xml
+++ b/statefun-shaded/statefun-protocol-shaded/pom.xml
@@ -23,7 +23,7 @@ under the License.
     <parent>
         <artifactId>statefun-shaded</artifactId>
         <groupId>io.github.kzmlabs.flinkstatefun</groupId>
-        <version>3.4.0-KZM-2.0-RC5</version>
+        <version>3.4.0-KZM-2.0-RC6</version>
     </parent>
 
     <artifactId>statefun-protocol-shaded</artifactId>

--- a/statefun-testutil/pom.xml
+++ b/statefun-testutil/pom.xml
@@ -21,7 +21,7 @@ under the License.
     <parent>
         <artifactId>statefun-parent</artifactId>
         <groupId>io.github.kzmlabs.flinkstatefun</groupId>
-        <version>3.4.0-KZM-2.0-RC5</version>
+        <version>3.4.0-KZM-2.0-RC6</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 


### PR DESCRIPTION
## Summary
- Bump all module versions from `3.4.0-KZM-2.0-RC5` to `3.4.0-KZM-2.0-RC6`
- Update CHANGELOG with RC6 release notes (dependency upgrades, plugin upgrades, CI/CD improvements, cleanup)

## Changes since RC5
### Dependencies
- JUnit 4.12 → 4.13.2, Hamcrest 1.3 → 2.2, Auto-Service 1.0-rc6 → 1.1.1
- OkHttp 3.14.6 → 4.12.0, Kafka clients 2.4.1 → 3.9.1, Testcontainers 1.15.2 → 1.20.4
- JMH 1.21 → 1.37, JimFS 1.1 → 1.3.0, SLF4J 1.7.7 → 1.7.36

### Maven Plugins
- Unify maven-shade-plugin to 3.6.0, surefire/failsafe → 3.5.2, enforcer → 3.5.0, exec → 3.5.0

### CI/CD
- actions/checkout v2 → v4, 20-min timeout, concurrency limits

### Cleanup
- Remove unused Helm chart, stale TODOs, add CODEOWNERS, update docs/config.toml