### PR TITLE
Migrate from JUnit 4 to JUnit Jupiter 5.11.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -114,9 +114,9 @@ under the License.
     <dependencyManagement>
         <dependencies>
             <dependency>
-                <groupId>junit</groupId>
-                <artifactId>junit</artifactId>
-                <version>4.13.2</version>
+                <groupId>org.junit.jupiter</groupId>
+                <artifactId>junit-jupiter</artifactId>
+                <version>5.11.4</version>
                 <scope>test</scope>
             </dependency>
             <dependency>

--- a/statefun-e2e-tests/statefun-e2e-tests-common/pom.xml
+++ b/statefun-e2e-tests/statefun-e2e-tests-common/pom.xml
@@ -117,8 +117,13 @@ under the License.
 
         <!-- Junit -->
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest</artifactId>
             <scope>compile</scope>
         </dependency>
     </dependencies>

--- a/statefun-e2e-tests/statefun-e2e-tests-common/src/main/java/org/apache/flink/statefun/e2e/common/StatefulFunctionsAppContainers.java
+++ b/statefun-e2e-tests/statefun-e2e-tests-common/src/main/java/org/apache/flink/statefun/e2e/common/StatefulFunctionsAppContainers.java
@@ -35,7 +35,9 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.GlobalConfiguration;
 import org.apache.flink.statefun.flink.core.StatefulFunctionsConfig;
 import org.apache.flink.util.FileUtils;
-import org.junit.rules.ExternalResource;
+import org.junit.jupiter.api.extension.AfterAllCallback;
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.BindMode;
@@ -45,19 +47,18 @@ import org.testcontainers.containers.output.Slf4jLogConsumer;
 import org.testcontainers.images.builder.ImageFromDockerfile;
 
 /**
- * A JUnit {@link org.junit.rules.TestRule} that setups a containerized Stateful Functions
- * application using <a href="https://www.testcontainers.org/">Testcontainers</a>. This allows
- * composing end-to-end tests for Stateful Functions applications easier, by managing the
- * containerized application as an external test resource whose lifecycle is integrated with the
- * JUnit test framework.
+ * A JUnit 5 extension that sets up a containerized Stateful Functions application using <a
+ * href="https://www.testcontainers.org/">Testcontainers</a>. This allows composing end-to-end tests
+ * for Stateful Functions applications easier, by managing the containerized application as an
+ * external test resource whose lifecycle is integrated with the JUnit test framework.
  *
  * <h2>Example usage</h2>
  *
  * <pre>{@code
  * public class MyE2E {
  *
- *     {@code @Rule}
- *     public StatefulFunctionsAppContainers myApp =
+ *     {@code @RegisterExtension}
+ *     static StatefulFunctionsAppContainers myApp =
  *         StatefulFunctionsAppContainers.builder("app-name", 3).build();
  *
  *     {@code @Test}
@@ -75,11 +76,8 @@ import org.testcontainers.images.builder.ImageFromDockerfile;
  * <pre>{@code
  * public class MyKafkaE2E {
  *
- *     {@code @Rule}
- *     public KafkaContainer kafka = new KafkaContainer();
- *
- *     {@code @Rule}
- *     public StatefulFunctionsAppContainers myApp =
+ *     {@code @RegisterExtension}
+ *     static StatefulFunctionsAppContainers myApp =
  *         StatefulFunctionsAppContainers.builder("app-name", 3)
  *             .dependsOn(kafka)
  *             .build();
@@ -95,8 +93,8 @@ import org.testcontainers.images.builder.ImageFromDockerfile;
  *
  * <h2>Prerequisites</h2>
  *
- * <p>Since Testcontainers uses Docker, it is required that you have Docker installed for this test
- * rule to work.
+ * <p>Since Testcontainers uses Docker, it is required that you have Docker installed for this
+ * extension to work.
  *
  * <p>When building the Docker image for the Stateful Functions application under test, the
  * following files are added to the build context:
@@ -114,7 +112,7 @@ import org.testcontainers.images.builder.ImageFromDockerfile;
  *       Docker image build context.
  * </uL>
  */
-public final class StatefulFunctionsAppContainers extends ExternalResource {
+public final class StatefulFunctionsAppContainers implements BeforeAllCallback, AfterAllCallback {
 
   private static final Logger LOG = LoggerFactory.getLogger(StatefulFunctionsAppContainers.class);
 
@@ -141,7 +139,7 @@ public final class StatefulFunctionsAppContainers extends ExternalResource {
   }
 
   @Override
-  protected void before() throws Throwable {
+  public void beforeAll(ExtensionContext context) throws Exception {
     checkpointDir = temporaryCheckpointDir();
 
     master.withFileSystemBind(
@@ -156,7 +154,7 @@ public final class StatefulFunctionsAppContainers extends ExternalResource {
   }
 
   @Override
-  protected void after() {
+  public void afterAll(ExtensionContext context) {
     master.stop();
     workers.forEach(GenericContainer::stop);
 

--- a/statefun-e2e-tests/statefun-smoke-e2e-common/pom.xml
+++ b/statefun-e2e-tests/statefun-smoke-e2e-common/pom.xml
@@ -49,9 +49,14 @@ under the License.
 
         <!-- Junit -->
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
             <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest</artifactId>
+            <scope>test</scope>
         </dependency>
 
         <!-- Protobuf Commands messages -->

--- a/statefun-e2e-tests/statefun-smoke-e2e-common/src/main/java/org/apache/flink/statefun/e2e/smoke/SmokeRunner.java
+++ b/statefun-e2e-tests/statefun-smoke-e2e-common/src/main/java/org/apache/flink/statefun/e2e/smoke/SmokeRunner.java
@@ -24,8 +24,6 @@ import java.util.function.Supplier;
 import org.apache.flink.statefun.e2e.common.StatefulFunctionsAppContainers;
 import org.apache.flink.statefun.e2e.smoke.generated.VerificationResult;
 import org.apache.flink.util.function.ThrowingRunnable;
-import org.junit.runner.Description;
-import org.junit.runners.model.Statement;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testcontainers.Testcontainers;
@@ -57,17 +55,12 @@ public final class SmokeRunner {
 
   private static void run(StatefulFunctionsAppContainers app, ThrowingRunnable<Throwable> r)
       throws Throwable {
-    Statement statement =
-        app.apply(
-            new Statement() {
-              @Override
-              public void evaluate() throws Throwable {
-                r.run();
-              }
-            },
-            Description.EMPTY);
-
-    statement.evaluate();
+    try {
+      app.beforeAll(null);
+      r.run();
+    } finally {
+      app.afterAll(null);
+    }
   }
 
   public static void awaitVerificationSuccess(

--- a/statefun-e2e-tests/statefun-smoke-e2e-common/src/test/java/org/apache/flink/statefun/e2e/smoke/SmokeRunnerParametersTest.java
+++ b/statefun-e2e-tests/statefun-smoke-e2e-common/src/test/java/org/apache/flink/statefun/e2e/smoke/SmokeRunnerParametersTest.java
@@ -19,11 +19,11 @@
 package org.apache.flink.statefun.e2e.smoke;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.util.Collections;
 import java.util.Map;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class SmokeRunnerParametersTest {
 

--- a/statefun-e2e-tests/statefun-smoke-e2e-driver/pom.xml
+++ b/statefun-e2e-tests/statefun-smoke-e2e-driver/pom.xml
@@ -75,6 +75,17 @@ under the License.
             <version>${protobuf.version}</version>
         </dependency>
 
+        <!-- Test -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest</artifactId>
+            <scope>test</scope>
+        </dependency>
+
         <!-- streaming runtime -->
         <dependency>
             <groupId>org.apache.flink</groupId>

--- a/statefun-e2e-tests/statefun-smoke-e2e-driver/src/test/java/org/apache/flink/statefun/e2e/smoke/driver/CommandGeneratorTest.java
+++ b/statefun-e2e-tests/statefun-smoke-e2e-driver/src/test/java/org/apache/flink/statefun/e2e/smoke/driver/CommandGeneratorTest.java
@@ -24,7 +24,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import org.apache.commons.math3.random.JDKRandomGenerator;
 import org.apache.flink.statefun.e2e.smoke.SmokeRunnerParameters;
 import org.apache.flink.statefun.e2e.smoke.generated.SourceCommand;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class CommandGeneratorTest {
 

--- a/statefun-e2e-tests/statefun-smoke-e2e-driver/src/test/java/org/apache/flink/statefun/e2e/smoke/driver/FunctionStateTrackerTest.java
+++ b/statefun-e2e-tests/statefun-smoke-e2e-driver/src/test/java/org/apache/flink/statefun/e2e/smoke/driver/FunctionStateTrackerTest.java
@@ -23,7 +23,7 @@ import static org.apache.flink.statefun.e2e.smoke.testutils.Utils.aStateModifica
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class FunctionStateTrackerTest {
 

--- a/statefun-e2e-tests/statefun-smoke-e2e-embedded/src/test/java/org/apache/flink/statefun/e2e/smoke/embedded/EmbeddedSmokeHarnessTest.java
+++ b/statefun-e2e-tests/statefun-smoke-e2e-embedded/src/test/java/org/apache/flink/statefun/e2e/smoke/embedded/EmbeddedSmokeHarnessTest.java
@@ -20,10 +20,12 @@ package org.apache.flink.statefun.e2e.smoke.embedded;
 
 import static org.apache.flink.statefun.e2e.smoke.SmokeRunner.awaitVerificationSuccess;
 
+import java.util.concurrent.TimeUnit;
 import org.apache.flink.statefun.e2e.smoke.SimpleVerificationServer;
 import org.apache.flink.statefun.e2e.smoke.SmokeRunnerParameters;
 import org.apache.flink.statefun.flink.harness.Harness;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -31,7 +33,8 @@ public class EmbeddedSmokeHarnessTest {
 
   private static final Logger LOG = LoggerFactory.getLogger(EmbeddedSmokeHarnessTest.class);
 
-  @Test(timeout = 1_000 * 60)
+  @Test
+  @Timeout(value = 1_000 * 60, unit = TimeUnit.MILLISECONDS)
   public void miniClusterTest() throws Exception {
     Harness harness = new Harness();
 

--- a/statefun-e2e-tests/statefun-smoke-e2e-embedded/src/test/java/org/apache/flink/statefun/e2e/smoke/embedded/SmokeVerificationEmbeddedE2E.java
+++ b/statefun-e2e-tests/statefun-smoke-e2e-embedded/src/test/java/org/apache/flink/statefun/e2e/smoke/embedded/SmokeVerificationEmbeddedE2E.java
@@ -18,16 +18,19 @@
 
 package org.apache.flink.statefun.e2e.smoke.embedded;
 
+import java.util.concurrent.TimeUnit;
 import org.apache.flink.statefun.e2e.common.StatefulFunctionsAppContainers;
 import org.apache.flink.statefun.e2e.smoke.SmokeRunner;
 import org.apache.flink.statefun.e2e.smoke.SmokeRunnerParameters;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 public class SmokeVerificationEmbeddedE2E {
 
   private static final int NUM_WORKERS = 2;
 
-  @Test(timeout = 1_000 * 60 * 10)
+  @Test
+  @Timeout(value = 1_000 * 60 * 10, unit = TimeUnit.MILLISECONDS)
   public void run() throws Throwable {
     SmokeRunnerParameters parameters = new SmokeRunnerParameters();
     parameters.setNumberOfFunctionInstances(128);

--- a/statefun-e2e-tests/statefun-smoke-e2e-golang/src/test/java/org/apache/flink/statefun/e2e/smoke/golang/SmokeVerificationGolangE2E.java
+++ b/statefun-e2e-tests/statefun-smoke-e2e-golang/src/test/java/org/apache/flink/statefun/e2e/smoke/golang/SmokeVerificationGolangE2E.java
@@ -20,10 +20,12 @@ package org.apache.flink.statefun.e2e.smoke.golang;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.concurrent.TimeUnit;
 import org.apache.flink.statefun.e2e.common.StatefulFunctionsAppContainers;
 import org.apache.flink.statefun.e2e.smoke.SmokeRunner;
 import org.apache.flink.statefun.e2e.smoke.SmokeRunnerParameters;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.GenericContainer;
@@ -35,7 +37,8 @@ public class SmokeVerificationGolangE2E {
   private static final Logger LOG = LoggerFactory.getLogger(SmokeVerificationGolangE2E.class);
   private static final int NUM_WORKERS = 2;
 
-  @Test(timeout = 1_000 * 60 * 10)
+  @Test
+  @Timeout(value = 1_000 * 60 * 10, unit = TimeUnit.MILLISECONDS)
   public void runWith() throws Throwable {
     SmokeRunnerParameters parameters = new SmokeRunnerParameters();
     parameters.setNumberOfFunctionInstances(128);

--- a/statefun-e2e-tests/statefun-smoke-e2e-java/src/test/java/org/apache/flink/statefun/e2e/smoke/java/SmokeVerificationJavaE2E.java
+++ b/statefun-e2e-tests/statefun-smoke-e2e-java/src/test/java/org/apache/flink/statefun/e2e/smoke/java/SmokeVerificationJavaE2E.java
@@ -20,10 +20,12 @@ package org.apache.flink.statefun.e2e.smoke.java;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.concurrent.TimeUnit;
 import org.apache.flink.statefun.e2e.common.StatefulFunctionsAppContainers;
 import org.apache.flink.statefun.e2e.smoke.SmokeRunner;
 import org.apache.flink.statefun.e2e.smoke.SmokeRunnerParameters;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.GenericContainer;
@@ -35,7 +37,8 @@ public class SmokeVerificationJavaE2E {
   private static final Logger LOG = LoggerFactory.getLogger(SmokeVerificationJavaE2E.class);
   private static final int NUM_WORKERS = 2;
 
-  @Test(timeout = 1_000 * 60 * 10)
+  @Test
+  @Timeout(value = 1_000 * 60 * 10, unit = TimeUnit.MILLISECONDS)
   public void runWith() throws Throwable {
     SmokeRunnerParameters parameters = new SmokeRunnerParameters();
     parameters.setNumberOfFunctionInstances(128);

--- a/statefun-e2e-tests/statefun-smoke-e2e-js/src/test/java/org/apache/flink/statefun/e2e/smoke/js/SmokeVerificationJsE2E.java
+++ b/statefun-e2e-tests/statefun-smoke-e2e-js/src/test/java/org/apache/flink/statefun/e2e/smoke/js/SmokeVerificationJsE2E.java
@@ -20,10 +20,12 @@ package org.apache.flink.statefun.e2e.smoke.js;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.concurrent.TimeUnit;
 import org.apache.flink.statefun.e2e.common.StatefulFunctionsAppContainers;
 import org.apache.flink.statefun.e2e.smoke.SmokeRunner;
 import org.apache.flink.statefun.e2e.smoke.SmokeRunnerParameters;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.GenericContainer;
@@ -35,7 +37,8 @@ public class SmokeVerificationJsE2E {
   private static final Logger LOG = LoggerFactory.getLogger(SmokeVerificationJsE2E.class);
   private static final int NUM_WORKERS = 2;
 
-  @Test(timeout = 1_000 * 60 * 10)
+  @Test
+  @Timeout(value = 1_000 * 60 * 10, unit = TimeUnit.MILLISECONDS)
   public void runWith() throws Throwable {
     SmokeRunnerParameters parameters = new SmokeRunnerParameters();
     parameters.setNumberOfFunctionInstances(128);

--- a/statefun-e2e-tests/statefun-smoke-e2e-multilang-harness/pom.xml
+++ b/statefun-e2e-tests/statefun-smoke-e2e-multilang-harness/pom.xml
@@ -61,8 +61,8 @@ under the License.
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
         </dependency>
     </dependencies>
 </project>

--- a/statefun-e2e-tests/statefun-smoke-e2e-multilang-harness/src/test/java/org/apache/flink/statefun/e2e/smoke/multilang/harness/MultiLangSmokeHarnessTest.java
+++ b/statefun-e2e-tests/statefun-smoke-e2e-multilang-harness/src/test/java/org/apache/flink/statefun/e2e/smoke/multilang/harness/MultiLangSmokeHarnessTest.java
@@ -20,13 +20,15 @@ package org.apache.flink.statefun.e2e.smoke.multilang.harness;
 
 import static org.apache.flink.statefun.e2e.smoke.SmokeRunner.awaitVerificationSuccess;
 
+import java.util.concurrent.TimeUnit;
 import org.apache.flink.statefun.e2e.smoke.SimpleVerificationServer;
 import org.apache.flink.statefun.e2e.smoke.SmokeRunnerParameters;
 import org.apache.flink.statefun.e2e.smoke.driver.DriverModule;
 import org.apache.flink.statefun.flink.harness.Harness;
 import org.apache.flink.statefun.sdk.spi.StatefulFunctionModule;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -51,7 +53,7 @@ import org.slf4j.LoggerFactory;
  * <ul>
  *   <li>1. Start the remote function process locally in the IDE. It should be reachable at {@code
  *       http://localhost:8000}.
- *   <li>2. Remove the {@code @Ignore} annotation from the test.
+ *   <li>2. Remove the {@code @Disabled} annotation from the test.
  *   <li>3. Run the {@code miniClusterTest()} JUnit test method.
  * </ul>
  */
@@ -59,8 +61,9 @@ public final class MultiLangSmokeHarnessTest {
 
   private static final Logger LOG = LoggerFactory.getLogger(MultiLangSmokeHarnessTest.class);
 
-  @Ignore
-  @Test(timeout = 1_000 * 60 * 2)
+  @Disabled
+  @Test
+  @Timeout(value = 1_000 * 60 * 2, unit = TimeUnit.MILLISECONDS)
   public void miniClusterTest() throws Exception {
     Harness harness = new Harness();
 

--- a/statefun-flink/statefun-flink-common/pom.xml
+++ b/statefun-flink/statefun-flink-common/pom.xml
@@ -65,8 +65,8 @@ under the License.
 
         <!-- tests -->
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
         </dependency>
         <dependency>
             <groupId>org.hamcrest</groupId>

--- a/statefun-flink/statefun-flink-common/src/test/java/org/apache/flink/statefun/flink/common/ResourceLocatorTest.java
+++ b/statefun-flink/statefun-flink-common/src/test/java/org/apache/flink/statefun/flink/common/ResourceLocatorTest.java
@@ -17,8 +17,8 @@
  */
 package org.apache.flink.statefun.flink.common;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.assertThat;
 
 import com.google.common.jimfs.Configuration;
 import com.google.common.jimfs.Jimfs;
@@ -32,29 +32,23 @@ import java.nio.file.FileSystem;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Arrays;
-import java.util.Collection;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
-@RunWith(Parameterized.class)
 public class ResourceLocatorTest {
 
-  @Parameterized.Parameters
-  public static Collection<Configuration> filesystemTypes() {
-    return Arrays.asList(Configuration.unix(), Configuration.osX(), Configuration.windows());
+  static Stream<Configuration> filesystemTypes() {
+    return Stream.of(Configuration.unix(), Configuration.osX(), Configuration.windows());
   }
 
-  private final FileSystem fileSystem;
-
-  public ResourceLocatorTest(Configuration filesystemConfiguration) {
-    this.fileSystem = Jimfs.newFileSystem(filesystemConfiguration);
-  }
-
-  @Test
-  public void classPathExample() throws IOException {
-    final Path firstModuleDir = createDirectoryWithAFile("first", "module.yaml");
-    final Path secondModuleDir = createDirectoryWithAFile("second", "module.yaml");
+  @ParameterizedTest
+  @MethodSource("filesystemTypes")
+  void classPathExample(Configuration filesystemConfiguration) throws IOException {
+    FileSystem fileSystem = Jimfs.newFileSystem(filesystemConfiguration);
+    final Path firstModuleDir = createDirectoryWithAFile(fileSystem, "first", "module.yaml");
+    final Path secondModuleDir = createDirectoryWithAFile(fileSystem, "second", "module.yaml");
 
     ClassLoader urlClassLoader = urlClassLoader(firstModuleDir, secondModuleDir);
 
@@ -71,15 +65,18 @@ public class ResourceLocatorTest {
   }
 
   @Test
-  public void classPathSingleResourceExample() {
+  void classPathSingleResourceExample() {
     URL url = ResourceLocator.findNamedResource("classpath:dummy-file.txt");
 
     assertThat(url, notNullValue());
   }
 
-  @Test
-  public void absolutePathExample() throws IOException {
-    Path modulePath = createDirectoryWithAFile("some-module", "module.yaml").resolve("module.yaml");
+  @ParameterizedTest
+  @MethodSource("filesystemTypes")
+  void absolutePathExample(Configuration filesystemConfiguration) throws IOException {
+    FileSystem fileSystem = Jimfs.newFileSystem(filesystemConfiguration);
+    Path modulePath =
+        createDirectoryWithAFile(fileSystem, "some-module", "module.yaml").resolve("module.yaml");
 
     URL url = ResourceLocator.findNamedResource(modulePath.toUri().toString());
 
@@ -87,7 +84,7 @@ public class ResourceLocatorTest {
   }
 
   @Test
-  public void nonAbosultePath() throws MalformedURLException {
+  void nonAbosultePath() throws MalformedURLException {
     URL url = ResourceLocator.findNamedResource("/tmp/a.txt");
 
     assertThat(url, is(url("file:/tmp/a.txt")));
@@ -97,8 +94,11 @@ public class ResourceLocatorTest {
     return URI.create(url).toURL();
   }
 
-  private Path createDirectoryWithAFile(
-      String basedir, @SuppressWarnings("SameParameterValue") String filename) throws IOException {
+  private static Path createDirectoryWithAFile(
+      FileSystem fileSystem,
+      String basedir,
+      @SuppressWarnings("SameParameterValue") String filename)
+      throws IOException {
     final Path dir = fileSystem.getPath(basedir);
     Files.createDirectories(dir);
 

--- a/statefun-flink/statefun-flink-common/src/test/java/org/apache/flink/statefun/flink/common/json/SelectorsTest.java
+++ b/statefun-flink/statefun-flink-common/src/test/java/org/apache/flink/statefun/flink/common/json/SelectorsTest.java
@@ -19,9 +19,9 @@ package org.apache.flink.statefun.flink.common.json;
 
 import static org.hamcrest.CoreMatchers.allOf;
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.hasEntry;
-import static org.junit.Assert.assertThat;
 
 import java.time.Duration;
 import java.util.List;
@@ -33,7 +33,7 @@ import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.JsonNode;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.node.IntNode;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.node.ObjectNode;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class SelectorsTest {
 

--- a/statefun-flink/statefun-flink-common/src/test/java/org/apache/flink/statefun/flink/common/protobuf/ProtobufSerializerTest.java
+++ b/statefun-flink/statefun-flink-common/src/test/java/org/apache/flink/statefun/flink/common/protobuf/ProtobufSerializerTest.java
@@ -27,7 +27,7 @@ import org.apache.flink.core.memory.DataInputDeserializer;
 import org.apache.flink.core.memory.DataOutputSerializer;
 import org.apache.flink.statefun.flink.common.generated.ProtobufSerializerSnapshot;
 import org.apache.flink.statefun.flink.common.protobuf.generated.TestProtos.SimpleMessage;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class ProtobufSerializerTest {
 

--- a/statefun-flink/statefun-flink-common/src/test/java/org/apache/flink/statefun/flink/common/protobuf/ProtobufTypeSerializerTest.java
+++ b/statefun-flink/statefun-flink-common/src/test/java/org/apache/flink/statefun/flink/common/protobuf/ProtobufTypeSerializerTest.java
@@ -20,8 +20,8 @@ package org.apache.flink.statefun.flink.common.protobuf;
 import org.apache.flink.api.common.typeutils.SerializerTestBase;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.statefun.flink.common.protobuf.generated.TestProtos;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 public class ProtobufTypeSerializerTest extends SerializerTestBase<TestProtos.SimpleMessage> {
 
@@ -30,7 +30,7 @@ public class ProtobufTypeSerializerTest extends SerializerTestBase<TestProtos.Si
     return new ProtobufTypeSerializer<>(TestProtos.SimpleMessage.class);
   }
 
-  @Ignore
+  @Disabled
   @Test()
   @Override
   public void testInstantiate() {

--- a/statefun-flink/statefun-flink-core/pom.xml
+++ b/statefun-flink/statefun-flink-core/pom.xml
@@ -113,8 +113,8 @@ under the License.
 
         <!-- tests -->
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
         </dependency>
         <dependency>
             <groupId>org.hamcrest</groupId>

--- a/statefun-flink/statefun-flink-core/src/test/java/org/apache/flink/statefun/flink/core/StatefulFunctionsConfigTest.java
+++ b/statefun-flink/statefun-flink-core/src/test/java/org/apache/flink/statefun/flink/core/StatefulFunctionsConfigTest.java
@@ -17,6 +17,10 @@
  */
 package org.apache.flink.statefun.flink.core;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 import java.util.Arrays;
 import java.util.Optional;
 import org.apache.flink.configuration.CheckpointingOptions;
@@ -26,8 +30,7 @@ import org.apache.flink.configuration.MemorySize;
 import org.apache.flink.statefun.flink.core.exceptions.StatefulFunctionsInvalidConfigException;
 import org.apache.flink.statefun.flink.core.message.MessageFactoryType;
 import org.hamcrest.Matchers;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class StatefulFunctionsConfigTest {
 
@@ -57,18 +60,15 @@ public class StatefulFunctionsConfigTest {
     StatefulFunctionsConfig stateFunConfig =
         StatefulFunctionsConfig.fromFlinkConfiguration(configuration);
 
-    Assert.assertEquals(stateFunConfig.getFlinkJobName(), testName);
-    Assert.assertEquals(
-        stateFunConfig.getFactoryKey().getType(), MessageFactoryType.WITH_CUSTOM_PAYLOADS);
-    Assert.assertEquals(
+    assertEquals(stateFunConfig.getFlinkJobName(), testName);
+    assertEquals(stateFunConfig.getFactoryKey().getType(), MessageFactoryType.WITH_CUSTOM_PAYLOADS);
+    assertEquals(
         stateFunConfig.getFactoryKey().getCustomPayloadSerializerClassName(),
         Optional.of(serializerClassName));
-    Assert.assertEquals(stateFunConfig.getFeedbackBufferSize(), MemorySize.ofMebiBytes(100));
-    Assert.assertEquals(stateFunConfig.getMaxAsyncOperationsPerTask(), 100);
-    Assert.assertThat(
-        stateFunConfig.getGlobalConfigurations(), Matchers.hasEntry("key1", "value1"));
-    Assert.assertThat(
-        stateFunConfig.getGlobalConfigurations(), Matchers.hasEntry("key2", "value2"));
+    assertEquals(stateFunConfig.getFeedbackBufferSize(), MemorySize.ofMebiBytes(100));
+    assertEquals(stateFunConfig.getMaxAsyncOperationsPerTask(), 100);
+    assertThat(stateFunConfig.getGlobalConfigurations(), Matchers.hasEntry("key1", "value1"));
+    assertThat(stateFunConfig.getGlobalConfigurations(), Matchers.hasEntry("key2", "value2"));
   }
 
   private static Configuration baseConfiguration() {
@@ -87,21 +87,32 @@ public class StatefulFunctionsConfigTest {
     return configuration;
   }
 
-  @Test(expected = StatefulFunctionsInvalidConfigException.class)
+  @Test
   public void invalidCustomSerializerThrows() {
-    Configuration configuration = baseConfiguration();
-    configuration.set(
-        StatefulFunctionsConfig.USER_MESSAGE_SERIALIZER, MessageFactoryType.WITH_CUSTOM_PAYLOADS);
-    StatefulFunctionsConfigValidator.validate(false, configuration);
+    assertThrows(
+        StatefulFunctionsInvalidConfigException.class,
+        () -> {
+          Configuration configuration = baseConfiguration();
+          configuration.set(
+              StatefulFunctionsConfig.USER_MESSAGE_SERIALIZER,
+              MessageFactoryType.WITH_CUSTOM_PAYLOADS);
+          StatefulFunctionsConfigValidator.validate(false, configuration);
+        });
   }
 
-  @Test(expected = StatefulFunctionsInvalidConfigException.class)
+  @Test
   public void invalidNonCustomSerializerThrows() {
-    Configuration configuration = baseConfiguration();
-    configuration.set(
-        StatefulFunctionsConfig.USER_MESSAGE_SERIALIZER, MessageFactoryType.WITH_KRYO_PAYLOADS);
-    configuration.set(
-        StatefulFunctionsConfig.USER_MESSAGE_CUSTOM_PAYLOAD_SERIALIZER_CLASS, serializerClassName);
-    StatefulFunctionsConfigValidator.validate(false, configuration);
+    assertThrows(
+        StatefulFunctionsInvalidConfigException.class,
+        () -> {
+          Configuration configuration = baseConfiguration();
+          configuration.set(
+              StatefulFunctionsConfig.USER_MESSAGE_SERIALIZER,
+              MessageFactoryType.WITH_KRYO_PAYLOADS);
+          configuration.set(
+              StatefulFunctionsConfig.USER_MESSAGE_CUSTOM_PAYLOAD_SERIALIZER_CLASS,
+              serializerClassName);
+          StatefulFunctionsConfigValidator.validate(false, configuration);
+        });
   }
 }

--- a/statefun-flink/statefun-flink-core/src/test/java/org/apache/flink/statefun/flink/core/StatefulFunctionsUniverseTest.java
+++ b/statefun-flink/statefun-flink-core/src/test/java/org/apache/flink/statefun/flink/core/StatefulFunctionsUniverseTest.java
@@ -18,13 +18,13 @@
 
 package org.apache.flink.statefun.flink.core;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.IsSame.sameInstance;
-import static org.junit.Assert.assertThat;
 
 import org.apache.flink.statefun.flink.core.message.MessageFactoryKey;
 import org.apache.flink.statefun.flink.core.message.MessageFactoryType;
 import org.apache.flink.statefun.sdk.TypeName;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class StatefulFunctionsUniverseTest {
 

--- a/statefun-flink/statefun-flink-core/src/test/java/org/apache/flink/statefun/flink/core/backpressure/BoundedExponentialBackoffTest.java
+++ b/statefun-flink/statefun-flink-core/src/test/java/org/apache/flink/statefun/flink/core/backpressure/BoundedExponentialBackoffTest.java
@@ -17,12 +17,12 @@
  */
 package org.apache.flink.statefun.flink.core.backpressure;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertThat;
 
 import java.time.Duration;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class BoundedExponentialBackoffTest {
   private final FakeNanoClock fakeTime = new FakeNanoClock();

--- a/statefun-flink/statefun-flink-core/src/test/java/org/apache/flink/statefun/flink/core/backpressure/ThresholdBackPressureValveTest.java
+++ b/statefun-flink/statefun-flink-core/src/test/java/org/apache/flink/statefun/flink/core/backpressure/ThresholdBackPressureValveTest.java
@@ -18,11 +18,11 @@
 
 package org.apache.flink.statefun.flink.core.backpressure;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.apache.flink.statefun.flink.core.TestUtils;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class ThresholdBackPressureValveTest {
 

--- a/statefun-flink/statefun-flink-core/src/test/java/org/apache/flink/statefun/flink/core/cache/SingleThreadedLruCacheTest.java
+++ b/statefun-flink/statefun-flink-core/src/test/java/org/apache/flink/statefun/flink/core/cache/SingleThreadedLruCacheTest.java
@@ -19,9 +19,9 @@ package org.apache.flink.statefun.flink.core.cache;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class SingleThreadedLruCacheTest {
 

--- a/statefun-flink/statefun-flink-core/src/test/java/org/apache/flink/statefun/flink/core/di/ObjectContainerTest.java
+++ b/statefun-flink/statefun-flink-core/src/test/java/org/apache/flink/statefun/flink/core/di/ObjectContainerTest.java
@@ -20,7 +20,7 @@ package org.apache.flink.statefun.flink.core.di;
 import static org.hamcrest.CoreMatchers.theInstance;
 import static org.hamcrest.MatcherAssert.assertThat;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class ObjectContainerTest {
 

--- a/statefun-flink/statefun-flink-core/src/test/java/org/apache/flink/statefun/flink/core/feedback/CheckpointsTest.java
+++ b/statefun-flink/statefun-flink-core/src/test/java/org/apache/flink/statefun/flink/core/feedback/CheckpointsTest.java
@@ -17,9 +17,9 @@
  */
 package org.apache.flink.statefun.flink.core.feedback;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
 
 import java.io.ByteArrayOutputStream;
 import java.io.OutputStream;
@@ -28,7 +28,7 @@ import java.util.List;
 import java.util.function.Supplier;
 import org.apache.flink.statefun.flink.core.logger.FeedbackLogger;
 import org.apache.flink.util.Preconditions;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class CheckpointsTest {
 

--- a/statefun-flink/statefun-flink-core/src/test/java/org/apache/flink/statefun/flink/core/feedback/FeedbackChannelTest.java
+++ b/statefun-flink/statefun-flink-core/src/test/java/org/apache/flink/statefun/flink/core/feedback/FeedbackChannelTest.java
@@ -24,8 +24,8 @@ import java.util.ArrayList;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Mode;
@@ -60,7 +60,7 @@ public class FeedbackChannelTest {
     assertThat(results, contains("hello", "world"));
   }
 
-  @Ignore("benchmarks are not run as part of a regular test suite.")
+  @Disabled("benchmarks are not run as part of a regular test suite.")
   @Test
   public void launchBenchmark() throws Exception {
     // The following is the result of comparing 3 different queue implementations for a spsc

--- a/statefun-flink/statefun-flink-core/src/test/java/org/apache/flink/statefun/flink/core/functions/LocalStatefulFunctionGroupTest.java
+++ b/statefun-flink/statefun-flink-core/src/test/java/org/apache/flink/statefun/flink/core/functions/LocalStatefulFunctionGroupTest.java
@@ -19,7 +19,7 @@ package org.apache.flink.statefun.flink.core.functions;
 
 import static org.apache.flink.statefun.flink.core.TestUtils.ENVELOPE_FACTORY;
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.time.Duration;
 import java.util.ArrayList;
@@ -33,7 +33,7 @@ import org.apache.flink.statefun.sdk.Context;
 import org.apache.flink.statefun.sdk.FunctionType;
 import org.apache.flink.statefun.sdk.io.EgressIdentifier;
 import org.apache.flink.statefun.sdk.metrics.Metrics;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class LocalStatefulFunctionGroupTest {
   // test constants

--- a/statefun-flink/statefun-flink-core/src/test/java/org/apache/flink/statefun/flink/core/functions/PendingAsyncOperationsTest.java
+++ b/statefun-flink/statefun-flink-core/src/test/java/org/apache/flink/statefun/flink/core/functions/PendingAsyncOperationsTest.java
@@ -21,8 +21,8 @@ import static org.apache.flink.statefun.flink.core.TestUtils.FUNCTION_1_ADDR;
 import static org.apache.flink.statefun.flink.core.TestUtils.FUNCTION_2_ADDR;
 import static org.hamcrest.CoreMatchers.allOf;
 import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasKey;
-import static org.junit.Assert.assertThat;
 
 import java.util.HashMap;
 import java.util.Iterator;
@@ -36,7 +36,7 @@ import org.apache.flink.statefun.sdk.Address;
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
 import org.hamcrest.TypeSafeMatcher;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class PendingAsyncOperationsTest {
   private final MemoryMapState<Long, Message> miniStateBackend = new MemoryMapState<>();

--- a/statefun-flink/statefun-flink-core/src/test/java/org/apache/flink/statefun/flink/core/functions/PredefinedFunctionLoaderTest.java
+++ b/statefun-flink/statefun-flink-core/src/test/java/org/apache/flink/statefun/flink/core/functions/PredefinedFunctionLoaderTest.java
@@ -21,13 +21,14 @@ package org.apache.flink.statefun.flink.core.functions;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.IsNull.notNullValue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import org.apache.flink.statefun.sdk.*;
 import org.apache.flink.statefun.sdk.StatefulFunction;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class PredefinedFunctionLoaderTest {
 
@@ -63,12 +64,16 @@ public class PredefinedFunctionLoaderTest {
     assertThat(function, instanceOf(StatefulFunctionA.class));
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void nullLoadedFunctions() {
-    PredefinedFunctionLoader loader =
-        new PredefinedFunctionLoader(specificFunctionProviders(), Collections.emptyMap());
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> {
+          PredefinedFunctionLoader loader =
+              new PredefinedFunctionLoader(specificFunctionProviders(), Collections.emptyMap());
 
-    loader.load(new FunctionType("doesn't", "exist"));
+          loader.load(new FunctionType("doesn't", "exist"));
+        });
   }
 
   private static Map<FunctionType, StatefulFunctionProvider> specificFunctionProviders() {

--- a/statefun-flink/statefun-flink-core/src/test/java/org/apache/flink/statefun/flink/core/functions/ReductionsTest.java
+++ b/statefun-flink/statefun-flink-core/src/test/java/org/apache/flink/statefun/flink/core/functions/ReductionsTest.java
@@ -18,7 +18,7 @@
 package org.apache.flink.statefun.flink.core.functions;
 
 import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.io.Serializable;
 import java.util.*;
@@ -59,7 +59,7 @@ import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.streaming.runtime.watermarkstatus.WatermarkStatus;
 import org.apache.flink.util.OutputTag;
 import org.apache.flink.util.function.BiConsumerWithException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class ReductionsTest {
 

--- a/statefun-flink/statefun-flink-core/src/test/java/org/apache/flink/statefun/flink/core/httpfn/DefaultHttpRequestReplyClientSpecTest.java
+++ b/statefun-flink/statefun-flink-core/src/test/java/org/apache/flink/statefun/flink/core/httpfn/DefaultHttpRequestReplyClientSpecTest.java
@@ -1,6 +1,6 @@
 package org.apache.flink.statefun.flink.core.httpfn;
 
-import static org.junit.Assert.*;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.time.Duration;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.core.JsonProcessingException;
@@ -9,7 +9,7 @@ import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.node.Obje
 import org.apache.flink.statefun.flink.common.json.StateFunObjectMapper;
 import org.hamcrest.Description;
 import org.hamcrest.TypeSafeDiagnosingMatcher;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class DefaultHttpRequestReplyClientSpecTest {
 

--- a/statefun-flink/statefun-flink-core/src/test/java/org/apache/flink/statefun/flink/core/httpfn/UnixDomainHttpEndpointTest.java
+++ b/statefun-flink/statefun-flink-core/src/test/java/org/apache/flink/statefun/flink/core/httpfn/UnixDomainHttpEndpointTest.java
@@ -17,12 +17,13 @@
  */
 package org.apache.flink.statefun.flink.core.httpfn;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.File;
 import java.net.URI;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class UnixDomainHttpEndpointTest {
 
@@ -46,9 +47,11 @@ public class UnixDomainHttpEndpointTest {
     assertEquals("/hello", out.pathSegment);
   }
 
-  @Test(expected = IllegalStateException.class)
+  @Test
   public void missingSockFile() {
-    UnixDomainHttpEndpoint.parseFrom(URI.create("http+unix:///some/path/hello"));
+    assertThrows(
+        IllegalStateException.class,
+        () -> UnixDomainHttpEndpoint.parseFrom(URI.create("http+unix:///some/path/hello")));
   }
 
   @Test
@@ -56,8 +59,10 @@ public class UnixDomainHttpEndpointTest {
     assertFalse(UnixDomainHttpEndpoint.validate(URI.create("http:///bar.foo.com/some/path")));
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void parseNonUdsEndpoint() {
-    UnixDomainHttpEndpoint.parseFrom(URI.create("http:///bar.foo.com/some/path"));
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> UnixDomainHttpEndpoint.parseFrom(URI.create("http:///bar.foo.com/some/path")));
   }
 }

--- a/statefun-flink/statefun-flink-core/src/test/java/org/apache/flink/statefun/flink/core/httpfn/UnixDomainSocketITCase.java
+++ b/statefun-flink/statefun-flink-core/src/test/java/org/apache/flink/statefun/flink/core/httpfn/UnixDomainSocketITCase.java
@@ -20,15 +20,16 @@ package org.apache.flink.statefun.flink.core.httpfn;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assume.assumeFalse;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
 import java.io.File;
 import java.io.IOException;
 import java.net.InetAddress;
 import java.net.ServerSocket;
 import java.util.Locale;
+import java.util.concurrent.TimeUnit;
 import javax.net.ServerSocketFactory;
 import okhttp3.OkHttpClient;
 import okhttp3.OkHttpClient.Builder;
@@ -36,8 +37,9 @@ import okhttp3.Request;
 import okhttp3.Response;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.newsclub.net.unix.AFUNIXServerSocket;
 import org.newsclub.net.unix.AFUNIXSocketAddress;
 
@@ -47,13 +49,14 @@ public class UnixDomainSocketITCase {
     return System.getProperty("os.name").toLowerCase(Locale.ROOT).contains("windows");
   }
 
-  @Before
+  @BeforeEach
   public void skipOnWindows() {
     // Unix domain sockets are not supported on Windows
-    assumeFalse("Skipping Unix domain socket test on Windows", isWindows());
+    assumeFalse(isWindows(), "Skipping Unix domain socket test on Windows");
   }
 
-  @Test(timeout = 10 * 1_000)
+  @Test
+  @Timeout(value = 10 * 1_000, unit = TimeUnit.MILLISECONDS)
   public void unixDomainSocket() throws IOException {
     final File sockFile = new File("/tmp/uds-" + System.nanoTime() + ".sock");
     sockFile.deleteOnExit();

--- a/statefun-flink/statefun-flink-core/src/test/java/org/apache/flink/statefun/flink/core/httpfn/binders/v1/HttpEndpointBinderV1Test.java
+++ b/statefun-flink/statefun-flink-core/src/test/java/org/apache/flink/statefun/flink/core/httpfn/binders/v1/HttpEndpointBinderV1Test.java
@@ -18,8 +18,8 @@
 
 package org.apache.flink.statefun.flink.core.httpfn.binders.v1;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasKey;
-import static org.junit.Assert.assertThat;
 
 import java.net.URL;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.ObjectMapper;
@@ -31,7 +31,7 @@ import org.apache.flink.statefun.flink.core.httpfn.DefaultHttpRequestReplyClient
 import org.apache.flink.statefun.flink.core.httpfn.TransportClientConstants;
 import org.apache.flink.statefun.flink.core.message.MessageFactoryKey;
 import org.apache.flink.statefun.flink.core.message.MessageFactoryType;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public final class HttpEndpointBinderV1Test {
   private static final ObjectMapper OBJ_MAPPER = new ObjectMapper(new YAMLFactory());

--- a/statefun-flink/statefun-flink-core/src/test/java/org/apache/flink/statefun/flink/core/httpfn/binders/v2/HttpEndpointBinderV2Test.java
+++ b/statefun-flink/statefun-flink-core/src/test/java/org/apache/flink/statefun/flink/core/httpfn/binders/v2/HttpEndpointBinderV2Test.java
@@ -18,8 +18,8 @@
 
 package org.apache.flink.statefun.flink.core.httpfn.binders.v2;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasKey;
-import static org.junit.Assert.assertThat;
 
 import java.net.URL;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.ObjectMapper;
@@ -31,7 +31,7 @@ import org.apache.flink.statefun.flink.core.httpfn.DefaultHttpRequestReplyClient
 import org.apache.flink.statefun.flink.core.httpfn.TransportClientConstants;
 import org.apache.flink.statefun.flink.core.message.MessageFactoryKey;
 import org.apache.flink.statefun.flink.core.message.MessageFactoryType;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public final class HttpEndpointBinderV2Test {
   private static final ObjectMapper OBJ_MAPPER = new ObjectMapper(new YAMLFactory());

--- a/statefun-flink/statefun-flink-core/src/test/java/org/apache/flink/statefun/flink/core/jsonmodule/RemoteModuleTest.java
+++ b/statefun-flink/statefun-flink-core/src/test/java/org/apache/flink/statefun/flink/core/jsonmodule/RemoteModuleTest.java
@@ -45,7 +45,7 @@ import org.apache.flink.statefun.sdk.io.EgressSpec;
 import org.apache.flink.statefun.sdk.io.IngressIdentifier;
 import org.apache.flink.statefun.sdk.io.IngressSpec;
 import org.apache.flink.statefun.sdk.spi.StatefulFunctionModule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public final class RemoteModuleTest {
 

--- a/statefun-flink/statefun-flink-core/src/test/java/org/apache/flink/statefun/flink/core/logger/InputStreamUtilsTest.java
+++ b/statefun-flink/statefun-flink-core/src/test/java/org/apache/flink/statefun/flink/core/logger/InputStreamUtilsTest.java
@@ -20,15 +20,14 @@ package org.apache.flink.statefun.flink.core.logger;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import java.io.IOException;
 import java.io.InputStream;
 import java.util.Arrays;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import java.util.stream.Stream;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
-@RunWith(Parameterized.class)
 public final class InputStreamUtilsTest {
 
   private enum InputStreamType {
@@ -36,23 +35,17 @@ public final class InputStreamUtilsTest {
     ONE_BYTE_PER_READ
   }
 
-  private final InputStreamType testInputStreamType;
-
-  public InputStreamUtilsTest(InputStreamType testInputStreamType) {
-    this.testInputStreamType = testInputStreamType;
+  static Stream<InputStreamType> testInputStreamTypes() {
+    return Stream.of(InputStreamType.RANDOM_LENGTH_PER_READ, InputStreamType.ONE_BYTE_PER_READ);
   }
 
-  @Parameterized.Parameters(name = "{0}")
-  public static Iterable<InputStreamType> testInputStreamTypes() throws IOException {
-    return Arrays.asList(InputStreamType.RANDOM_LENGTH_PER_READ, InputStreamType.ONE_BYTE_PER_READ);
-  }
-
-  @Test
-  public void tryReadFullyExampleUsage() throws Exception {
+  @ParameterizedTest
+  @MethodSource("testInputStreamTypes")
+  void tryReadFullyExampleUsage(InputStreamType testInputStreamType) throws Exception {
     final byte[] testBytes = "test-data".getBytes();
     final byte[] readBuffer = new byte[testBytes.length];
 
-    try (InputStream in = testInputStream(testBytes)) {
+    try (InputStream in = testInputStream(testInputStreamType, testBytes)) {
       final int numReadBytes = InputStreamUtils.tryReadFully(in, readBuffer);
 
       assertThat(numReadBytes, is(testBytes.length));
@@ -61,12 +54,13 @@ public final class InputStreamUtilsTest {
     }
   }
 
-  @Test
-  public void tryReadFullyEmptyInputStream() throws Exception {
+  @ParameterizedTest
+  @MethodSource("testInputStreamTypes")
+  void tryReadFullyEmptyInputStream(InputStreamType testInputStreamType) throws Exception {
     final byte[] testBytes = new byte[0];
     final byte[] readBuffer = new byte[10];
 
-    try (InputStream in = testInputStream(testBytes)) {
+    try (InputStream in = testInputStream(testInputStreamType, testBytes)) {
       final int numReadBytes = InputStreamUtils.tryReadFully(in, readBuffer);
 
       assertThat(numReadBytes, is(0));
@@ -75,13 +69,15 @@ public final class InputStreamUtilsTest {
     }
   }
 
-  @Test
-  public void tryReadFullyReadBufferSizeLargerThanInputStream() throws Exception {
+  @ParameterizedTest
+  @MethodSource("testInputStreamTypes")
+  void tryReadFullyReadBufferSizeLargerThanInputStream(InputStreamType testInputStreamType)
+      throws Exception {
     final byte[] testBytes = new byte[] {-91, 11, 8};
     // read buffer has larger size than the test data
     final byte[] readBuffer = new byte[testBytes.length + 20];
 
-    try (InputStream in = testInputStream(testBytes)) {
+    try (InputStream in = testInputStream(testInputStreamType, testBytes)) {
       final int numReadBytes = InputStreamUtils.tryReadFully(in, readBuffer);
 
       assertThat(numReadBytes, is(testBytes.length));
@@ -90,13 +86,15 @@ public final class InputStreamUtilsTest {
     }
   }
 
-  @Test
-  public void tryReadFullyReadBufferSizeSmallerThanInputStream() throws Exception {
+  @ParameterizedTest
+  @MethodSource("testInputStreamTypes")
+  void tryReadFullyReadBufferSizeSmallerThanInputStream(InputStreamType testInputStreamType)
+      throws Exception {
     final byte[] testBytes = new byte[] {-91, 11, 8, 53, 100, 5, -100, 102, 56, 95};
     // read buffer has smaller size than the test data
     final byte[] readBuffer = new byte[testBytes.length - 2];
 
-    try (InputStream in = testInputStream(testBytes)) {
+    try (InputStream in = testInputStream(testInputStreamType, testBytes)) {
       final int numReadBytes = InputStreamUtils.tryReadFully(in, readBuffer);
 
       assertThat(numReadBytes, is(readBuffer.length));
@@ -109,12 +107,18 @@ public final class InputStreamUtilsTest {
     }
   }
 
-  @Test(expected = IllegalStateException.class)
-  public void tryReadFullyEmptyReadBuffer() throws Exception {
-    InputStreamUtils.tryReadFully(testInputStream("test-data".getBytes()), new byte[0]);
+  @ParameterizedTest
+  @MethodSource("testInputStreamTypes")
+  void tryReadFullyEmptyReadBuffer(InputStreamType testInputStreamType) {
+    assertThrows(
+        IllegalStateException.class,
+        () ->
+            InputStreamUtils.tryReadFully(
+                testInputStream(testInputStreamType, "test-data".getBytes()), new byte[0]));
   }
 
-  private InputStream testInputStream(byte[] streamBytes) {
+  private static InputStream testInputStream(
+      InputStreamType testInputStreamType, byte[] streamBytes) {
     switch (testInputStreamType) {
       case ONE_BYTE_PER_READ:
         return new OneBytePerReadByteArrayInputStream(

--- a/statefun-flink/statefun-flink-core/src/test/java/org/apache/flink/statefun/flink/core/logger/MemorySegmentPoolTest.java
+++ b/statefun-flink/statefun-flink-core/src/test/java/org/apache/flink/statefun/flink/core/logger/MemorySegmentPoolTest.java
@@ -20,11 +20,11 @@ package org.apache.flink.statefun.flink.core.logger;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.nullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import org.apache.flink.core.memory.MemorySegment;
 import org.hamcrest.CoreMatchers;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class MemorySegmentPoolTest {
 

--- a/statefun-flink/statefun-flink-core/src/test/java/org/apache/flink/statefun/flink/core/logger/UnboundedFeedbackLoggerTest.java
+++ b/statefun-flink/statefun-flink-core/src/test/java/org/apache/flink/statefun/flink/core/logger/UnboundedFeedbackLoggerTest.java
@@ -18,7 +18,8 @@
 package org.apache.flink.statefun.flink.core.logger;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.*;
 import java.util.ArrayList;
@@ -31,21 +32,21 @@ import org.apache.flink.runtime.io.disk.iomanager.IOManagerAsync;
 import org.apache.flink.statefun.flink.core.di.ObjectContainer;
 import org.apache.flink.statefun.flink.core.logger.UnboundedFeedbackLogger.Header;
 import org.hamcrest.Matchers;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 @SuppressWarnings("SameParameterValue")
 public class UnboundedFeedbackLoggerTest {
   private static IOManagerAsync IO_MANAGER;
 
-  @BeforeClass
+  @BeforeAll
   public static void beforeClass() {
     IO_MANAGER = new IOManagerAsync();
   }
 
-  @AfterClass
+  @AfterAll
   public static void afterClass() throws Exception {
     if (IO_MANAGER != null) {
       IO_MANAGER.close();
@@ -64,11 +65,15 @@ public class UnboundedFeedbackLoggerTest {
     assertThat(output.size(), Matchers.greaterThan(0));
   }
 
-  @Test(expected = IllegalStateException.class)
+  @Test
   public void commitWithoutStartLoggingShouldBeIllegal() {
-    UnboundedFeedbackLogger<Integer> logger = instanceUnderTest(128, 1);
+    assertThrows(
+        IllegalStateException.class,
+        () -> {
+          UnboundedFeedbackLogger<Integer> logger = instanceUnderTest(128, 1);
 
-    logger.commit();
+          logger.commit();
+        });
   }
 
   @Test
@@ -81,7 +86,7 @@ public class UnboundedFeedbackLoggerTest {
     roundTrip(0, 1024);
   }
 
-  @Ignore
+  @Disabled
   @Test
   public void roundTripWithSpill() throws Exception {
     roundTrip(1_000_000, 0);

--- a/statefun-flink/statefun-flink-core/src/test/java/org/apache/flink/statefun/flink/core/message/MessageTest.java
+++ b/statefun-flink/statefun-flink-core/src/test/java/org/apache/flink/statefun/flink/core/message/MessageTest.java
@@ -19,45 +19,33 @@ package org.apache.flink.statefun.flink.core.message;
 
 import static org.apache.flink.statefun.flink.core.TestUtils.*;
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.io.IOException;
-import java.util.Arrays;
+import java.util.stream.Stream;
 import org.apache.flink.core.memory.DataInputDeserializer;
 import org.apache.flink.core.memory.DataOutputSerializer;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameters;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
-@RunWith(Parameterized.class)
 public class MessageTest {
-  private final MessageFactoryType type;
-  private final String customPayloadSerializerClassName;
-  private final Object payload;
 
-  public MessageTest(
-      MessageFactoryType type, String customPayloadSerializerClassName, Object payload) {
-    this.type = type;
-    this.customPayloadSerializerClassName = customPayloadSerializerClassName;
-    this.payload = payload;
+  static Stream<Arguments> data() {
+    return Stream.of(
+        Arguments.of(MessageFactoryType.WITH_KRYO_PAYLOADS, null, DUMMY_PAYLOAD),
+        Arguments.of(MessageFactoryType.WITH_PROTOBUF_PAYLOADS, null, DUMMY_PAYLOAD),
+        Arguments.of(MessageFactoryType.WITH_RAW_PAYLOADS, null, DUMMY_PAYLOAD.toByteArray()),
+        Arguments.of(
+            MessageFactoryType.WITH_CUSTOM_PAYLOADS,
+            "org.apache.flink.statefun.flink.core.message.JavaPayloadSerializer",
+            DUMMY_PAYLOAD));
   }
 
-  @Parameters(name = "{0}")
-  public static Iterable<? extends Object[]> data() {
-    return Arrays.asList(
-        new Object[] {MessageFactoryType.WITH_KRYO_PAYLOADS, null, DUMMY_PAYLOAD},
-        new Object[] {MessageFactoryType.WITH_PROTOBUF_PAYLOADS, null, DUMMY_PAYLOAD},
-        new Object[] {MessageFactoryType.WITH_RAW_PAYLOADS, null, DUMMY_PAYLOAD.toByteArray()},
-        new Object[] {
-          MessageFactoryType.WITH_CUSTOM_PAYLOADS,
-          "org.apache.flink.statefun.flink.core.message.JavaPayloadSerializer",
-          DUMMY_PAYLOAD
-        });
-  }
-
-  @Test
-  public void roundTrip() throws IOException {
+  @ParameterizedTest
+  @MethodSource("data")
+  void roundTrip(MessageFactoryType type, String customPayloadSerializerClassName, Object payload)
+      throws IOException {
     MessageFactory factory =
         MessageFactory.forKey(MessageFactoryKey.forType(type, customPayloadSerializerClassName));
 
@@ -71,8 +59,8 @@ public class MessageTest {
     assertThat(fromEnvelope.target(), is(FUNCTION_2_ADDR));
 
     ClassLoader targetClassLoader = payload.getClass().getClassLoader();
-    Object payload = fromEnvelope.payload(factory, targetClassLoader);
+    Object actualPayload = fromEnvelope.payload(factory, targetClassLoader);
 
-    assertThat(payload, is(this.payload));
+    assertThat(actualPayload, is(payload));
   }
 }

--- a/statefun-flink/statefun-flink-core/src/test/java/org/apache/flink/statefun/flink/core/message/MessageTypeSerializerSnapshotTest.java
+++ b/statefun-flink/statefun-flink-core/src/test/java/org/apache/flink/statefun/flink/core/message/MessageTypeSerializerSnapshotTest.java
@@ -20,16 +20,15 @@ package org.apache.flink.statefun.flink.core.message;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.util.Arrays;
+import java.util.stream.Stream;
 import org.apache.flink.core.memory.DataInputView;
 import org.apache.flink.core.memory.DataInputViewStreamWrapper;
 import org.apache.flink.core.memory.DataOutputView;
 import org.apache.flink.core.memory.DataOutputViewStreamWrapper;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
-@RunWith(Parameterized.class)
 public class MessageTypeSerializerSnapshotTest {
 
   private static final String serializerClassName = "com.domain.Serializer";
@@ -39,21 +38,11 @@ public class MessageTypeSerializerSnapshotTest {
     public byte[] bytes;
   }
 
-  private static interface SnapshotDataProvider {
+  private interface SnapshotDataProvider {
     SnapshotData provide(MessageFactoryKey messageFactoryKey) throws IOException;
   }
 
-  private final MessageFactoryKey messageFactoryKey;
-  private final SnapshotDataProvider snapshotDataProvider;
-
-  public MessageTypeSerializerSnapshotTest(
-      MessageFactoryKey messageFactoryKey, SnapshotDataProvider snapshotDataProvider) {
-    this.messageFactoryKey = messageFactoryKey;
-    this.snapshotDataProvider = snapshotDataProvider;
-  }
-
-  @Parameterized.Parameters(name = "{0}")
-  public static Iterable<? extends Object[]> data() throws IOException {
+  static Stream<Arguments> data() {
 
     MessageFactoryKey kryoFactoryKey =
         MessageFactoryKey.forType(MessageFactoryType.WITH_KRYO_PAYLOADS, null);
@@ -92,18 +81,19 @@ public class MessageTypeSerializerSnapshotTest {
           }
         };
 
-    return Arrays.asList(
-        new Object[] {kryoFactoryKey, snapshotDataProviderV1},
-        new Object[] {kryoFactoryKey, snapshotDataProviderV2},
-        new Object[] {customFactoryKey, snapshotDataProviderV2});
+    return Stream.of(
+        Arguments.of(kryoFactoryKey, snapshotDataProviderV1),
+        Arguments.of(kryoFactoryKey, snapshotDataProviderV2),
+        Arguments.of(customFactoryKey, snapshotDataProviderV2));
   }
 
-  @Test
-  public void roundTrip() throws IOException {
+  @ParameterizedTest
+  @MethodSource("data")
+  void roundTrip(MessageFactoryKey messageFactoryKey, SnapshotDataProvider snapshotDataProvider)
+      throws IOException {
 
-    SnapshotData snapshotData = this.snapshotDataProvider.provide(this.messageFactoryKey);
-    MessageTypeSerializer.Snapshot snapshot =
-        new MessageTypeSerializer.Snapshot(this.messageFactoryKey);
+    SnapshotData snapshotData = snapshotDataProvider.provide(messageFactoryKey);
+    MessageTypeSerializer.Snapshot snapshot = new MessageTypeSerializer.Snapshot(messageFactoryKey);
     ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
 
     try (ByteArrayInputStream bis = new ByteArrayInputStream(snapshotData.bytes)) {
@@ -112,6 +102,6 @@ public class MessageTypeSerializerSnapshotTest {
     }
 
     // make sure the deserialized state matches what was used to serialize
-    assert (snapshot.getMessageFactoryKey().equals(this.messageFactoryKey));
+    assert (snapshot.getMessageFactoryKey().equals(messageFactoryKey));
   }
 }

--- a/statefun-flink/statefun-flink-core/src/test/java/org/apache/flink/statefun/flink/core/message/MessageTypeSerializerTest.java
+++ b/statefun-flink/statefun-flink-core/src/test/java/org/apache/flink/statefun/flink/core/message/MessageTypeSerializerTest.java
@@ -26,7 +26,7 @@ import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.core.memory.DataOutputSerializer;
 import org.apache.flink.statefun.flink.core.TestUtils;
 import org.apache.flink.testutils.DeeplyEqualsChecker;
-import org.junit.Ignore;
+import org.junit.jupiter.api.Disabled;
 
 public class MessageTypeSerializerTest extends SerializerTestBase<Message> {
 
@@ -81,7 +81,7 @@ public class MessageTypeSerializerTest extends SerializerTestBase<Message> {
         .toArray(Message[]::new);
   }
 
-  @Ignore
+  @Disabled
   @Override
   public void testInstantiate() {}
 }

--- a/statefun-flink/statefun-flink-core/src/test/java/org/apache/flink/statefun/flink/core/metrics/NonNegativeCounterTest.java
+++ b/statefun-flink/statefun-flink-core/src/test/java/org/apache/flink/statefun/flink/core/metrics/NonNegativeCounterTest.java
@@ -18,10 +18,10 @@
 package org.apache.flink.statefun.flink.core.metrics;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import org.apache.flink.metrics.Counter;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class NonNegativeCounterTest {
 

--- a/statefun-flink/statefun-flink-core/src/test/java/org/apache/flink/statefun/flink/core/nettyclient/EndpointTest.java
+++ b/statefun-flink/statefun-flink-core/src/test/java/org/apache/flink/statefun/flink/core/nettyclient/EndpointTest.java
@@ -18,11 +18,11 @@
 package org.apache.flink.statefun.flink.core.nettyclient;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.net.InetSocketAddress;
 import java.net.URI;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class EndpointTest {
 

--- a/statefun-flink/statefun-flink-core/src/test/java/org/apache/flink/statefun/flink/core/nettyclient/NettyClientTest.java
+++ b/statefun-flink/statefun-flink-core/src/test/java/org/apache/flink/statefun/flink/core/nettyclient/NettyClientTest.java
@@ -20,7 +20,7 @@ package org.apache.flink.statefun.flink.core.nettyclient;
 
 import static org.apache.flink.statefun.flink.core.httpfn.TransportClientTest.FromFunctionNettyTestServer.*;
 import static org.apache.flink.statefun.flink.core.nettyclient.NettyProtobuf.serializeProtobuf;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.net.URI;
 import java.net.URL;
@@ -35,21 +35,21 @@ import org.apache.flink.shaded.netty4.io.netty.channel.ChannelHandlerContext;
 import org.apache.flink.shaded.netty4.io.netty.channel.ChannelPromise;
 import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.*;
 import org.apache.flink.statefun.flink.core.httpfn.TransportClientTest;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 public class NettyClientTest extends TransportClientTest {
   private static FromFunctionNettyTestServer testServer;
   private static FromFunctionNettyTestServer.PortInfo portInfo;
 
-  @BeforeClass
+  @BeforeAll
   public static void beforeClass() {
     testServer = new FromFunctionNettyTestServer();
     portInfo = testServer.runAndGetPortInfo();
   }
 
-  @AfterClass
+  @AfterAll
   public static void afterClass() throws Exception {
     testServer.close();
   }
@@ -57,9 +57,9 @@ public class NettyClientTest extends TransportClientTest {
   @Test
   public void callingTestHttpServiceShouldSucceed() throws Throwable {
     assertTrue(
-        TLS_FAILURE_MESSAGE,
         callUsingStubsAndCheckSuccess(
-            createNettyClient(createHttpSpec(), "http", portInfo.getHttpPort())));
+            createNettyClient(createHttpSpec(), "http", portInfo.getHttpPort())),
+        TLS_FAILURE_MESSAGE);
   }
 
   @Test
@@ -75,7 +75,6 @@ public class NettyClientTest extends TransportClientTest {
     assertNotNull(clientKeyPasswordUrl);
 
     assertTrue(
-        TLS_FAILURE_MESSAGE,
         callUsingStubsAndCheckSuccess(
             createNettyClient(
                 createSpec(
@@ -84,13 +83,13 @@ public class NettyClientTest extends TransportClientTest {
                     clientKeyUrl.getPath(),
                     clientKeyPasswordUrl.getPath()),
                 "https",
-                portInfo.getHttpsMutualTlsRequiredPort())));
+                portInfo.getHttpsMutualTlsRequiredPort())),
+        TLS_FAILURE_MESSAGE);
   }
 
   @Test
   public void callingTestHttpServiceWithTlsFromClasspathShouldSucceed() throws Throwable {
     assertTrue(
-        TLS_FAILURE_MESSAGE,
         callUsingStubsAndCheckSuccess(
             createNettyClient(
                 createSpec(
@@ -99,13 +98,13 @@ public class NettyClientTest extends TransportClientTest {
                     "classpath:" + A_SIGNED_CLIENT_KEY_LOCATION,
                     "classpath:" + A_SIGNED_CLIENT_KEY_PASSWORD_LOCATION),
                 "https",
-                portInfo.getHttpsMutualTlsRequiredPort())));
+                portInfo.getHttpsMutualTlsRequiredPort())),
+        TLS_FAILURE_MESSAGE);
   }
 
   @Test
   public void callingTestHttpServiceWithTlsUsingKeyWithoutPasswordShouldSucceed() throws Throwable {
     assertTrue(
-        TLS_FAILURE_MESSAGE,
         callUsingStubsAndCheckSuccess(
             createNettyClient(
                 createSpec(
@@ -114,70 +113,83 @@ public class NettyClientTest extends TransportClientTest {
                     "classpath:" + C_SIGNED_CLIENT_KEY_LOCATION,
                     null),
                 "https",
-                portInfo.getHttpsMutualTlsRequiredPort())));
+                portInfo.getHttpsMutualTlsRequiredPort())),
+        TLS_FAILURE_MESSAGE);
   }
 
   @Test
   public void callingTestHttpServiceWithJustServerSideTlsShouldSucceed() throws Throwable {
     assertTrue(
-        TLS_FAILURE_MESSAGE,
         callUsingStubsAndCheckSuccess(
             createNettyClient(
                 createSpec("classpath:" + A_CA_CERTS_LOCATION, null, null, null),
                 "https",
-                portInfo.getHttpsServerTlsOnlyPort())));
+                portInfo.getHttpsServerTlsOnlyPort())),
+        TLS_FAILURE_MESSAGE);
   }
 
-  @Test(expected = SSLException.class)
-  public void callingTestHttpServiceWithUntrustedTlsClientShouldFail() throws Throwable {
-    assertFalse(
-        TLS_FAILURE_MESSAGE,
-        callUsingStubsAndCheckSuccess(
-            createNettyClient(
-                createSpec(
-                    "classpath:" + A_CA_CERTS_LOCATION,
-                    "classpath:" + B_SIGNED_CLIENT_CERT_LOCATION,
-                    "classpath:" + B_SIGNED_CLIENT_KEY_LOCATION,
-                    "classpath:" + B_SIGNED_CLIENT_KEY_PASSWORD_LOCATION),
-                "https",
-                portInfo.getHttpsMutualTlsRequiredPort())));
+  @Test
+  public void callingTestHttpServiceWithUntrustedTlsClientShouldFail() {
+    assertThrows(
+        SSLException.class,
+        () ->
+            assertFalse(
+                callUsingStubsAndCheckSuccess(
+                    createNettyClient(
+                        createSpec(
+                            "classpath:" + A_CA_CERTS_LOCATION,
+                            "classpath:" + B_SIGNED_CLIENT_CERT_LOCATION,
+                            "classpath:" + B_SIGNED_CLIENT_KEY_LOCATION,
+                            "classpath:" + B_SIGNED_CLIENT_KEY_PASSWORD_LOCATION),
+                        "https",
+                        portInfo.getHttpsMutualTlsRequiredPort())),
+                TLS_FAILURE_MESSAGE));
   }
 
-  @Test(expected = SSLException.class)
-  public void callingAnUntrustedTestHttpServiceWithTlsClientShouldFail() throws Throwable {
-    assertFalse(
-        TLS_FAILURE_MESSAGE,
-        callUsingStubsAndCheckSuccess(
-            createNettyClient(
-                createSpec(
-                    "classpath:" + B_CA_CERTS_LOCATION,
-                    "classpath:" + A_SIGNED_CLIENT_CERT_LOCATION,
-                    "classpath:" + A_SIGNED_CLIENT_KEY_LOCATION,
-                    "classpath:" + A_SIGNED_CLIENT_KEY_PASSWORD_LOCATION),
-                "https",
-                portInfo.getHttpsMutualTlsRequiredPort())));
+  @Test
+  public void callingAnUntrustedTestHttpServiceWithTlsClientShouldFail() {
+    assertThrows(
+        SSLException.class,
+        () ->
+            assertFalse(
+                callUsingStubsAndCheckSuccess(
+                    createNettyClient(
+                        createSpec(
+                            "classpath:" + B_CA_CERTS_LOCATION,
+                            "classpath:" + A_SIGNED_CLIENT_CERT_LOCATION,
+                            "classpath:" + A_SIGNED_CLIENT_KEY_LOCATION,
+                            "classpath:" + A_SIGNED_CLIENT_KEY_PASSWORD_LOCATION),
+                        "https",
+                        portInfo.getHttpsMutualTlsRequiredPort())),
+                TLS_FAILURE_MESSAGE));
   }
 
-  @Test(expected = SSLException.class)
-  public void callingTestHttpServiceWhereTlsRequiredButNoCertGivenShouldFail() throws Throwable {
-    assertFalse(
-        TLS_FAILURE_MESSAGE,
-        callUsingStubsAndCheckSuccess(
-            createNettyClient(
-                createSpec("classpath:" + A_CA_CERTS_LOCATION, null, null, null),
-                "https",
-                portInfo.getHttpsMutualTlsRequiredPort())));
+  @Test
+  public void callingTestHttpServiceWhereTlsRequiredButNoCertGivenShouldFail() {
+    assertThrows(
+        SSLException.class,
+        () ->
+            assertFalse(
+                callUsingStubsAndCheckSuccess(
+                    createNettyClient(
+                        createSpec("classpath:" + A_CA_CERTS_LOCATION, null, null, null),
+                        "https",
+                        portInfo.getHttpsMutualTlsRequiredPort())),
+                TLS_FAILURE_MESSAGE));
   }
 
-  @Test(expected = IllegalStateException.class)
-  public void callingTestHttpServerWithNonExistentCertsShouldFail() throws Throwable {
-    assertFalse(
-        TLS_FAILURE_MESSAGE,
-        callUsingStubsAndCheckSuccess(
-            createNettyClient(
-                createSpec("classpath:" + "DEFINITELY_NON_EXISTENT", null, null, null),
-                "https",
-                portInfo.getHttpsServerTlsOnlyPort())));
+  @Test
+  public void callingTestHttpServerWithNonExistentCertsShouldFail() {
+    assertThrows(
+        IllegalStateException.class,
+        () ->
+            assertFalse(
+                callUsingStubsAndCheckSuccess(
+                    createNettyClient(
+                        createSpec("classpath:" + "DEFINITELY_NON_EXISTENT", null, null, null),
+                        "https",
+                        portInfo.getHttpsServerTlsOnlyPort())),
+                TLS_FAILURE_MESSAGE));
   }
 
   private NettyClientWithResultStatusCodeFuture createNettyClient(

--- a/statefun-flink/statefun-flink-core/src/test/java/org/apache/flink/statefun/flink/core/nettyclient/NettyProtobufTest.java
+++ b/statefun-flink/statefun-flink-core/src/test/java/org/apache/flink/statefun/flink/core/nettyclient/NettyProtobufTest.java
@@ -18,7 +18,7 @@
 package org.apache.flink.statefun.flink.core.nettyclient;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.util.ArrayDeque;
 import java.util.Arrays;
@@ -27,12 +27,12 @@ import java.util.function.IntFunction;
 import org.apache.flink.shaded.netty4.io.netty.buffer.ByteBuf;
 import org.apache.flink.shaded.netty4.io.netty.buffer.ByteBufAllocator;
 import org.apache.flink.statefun.sdk.reqreply.generated.Address;
-import org.junit.After;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 
 public class NettyProtobufTest {
 
-  @After
+  @AfterEach
   public void tearDown() {
     ALLOCATOR.close();
   }

--- a/statefun-flink/statefun-flink-core/src/test/java/org/apache/flink/statefun/flink/core/nettyclient/NettyRequestTest.java
+++ b/statefun-flink/statefun-flink-core/src/test/java/org/apache/flink/statefun/flink/core/nettyclient/NettyRequestTest.java
@@ -18,8 +18,10 @@
 package org.apache.flink.statefun.flink.core.nettyclient;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.Closeable;
 import java.net.SocketAddress;
@@ -43,8 +45,7 @@ import org.apache.flink.statefun.sdk.Address;
 import org.apache.flink.statefun.sdk.FunctionType;
 import org.apache.flink.statefun.sdk.reqreply.generated.FromFunction;
 import org.apache.flink.statefun.sdk.reqreply.generated.ToFunction;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class NettyRequestTest {
 
@@ -125,7 +126,7 @@ public class NettyRequestTest {
 
     request.start();
 
-    Assert.assertTrue(request.result().isCompletedExceptionally());
+    assertTrue(request.result().isCompletedExceptionally());
   }
 
   @Test
@@ -142,7 +143,7 @@ public class NettyRequestTest {
     // fail the request
     request.completeAttemptExceptionally(DisconnectedException.INSTANCE);
 
-    Assert.assertFalse(request.result().isDone());
+    assertFalse(request.result().isDone());
     assertEquals(Duration.ofMillis(15).toNanos(), request.remainingRequestBudgetNanos());
   }
 
@@ -165,7 +166,7 @@ public class NettyRequestTest {
       fakeClient.TIMEOUTS.pop().run();
     }
 
-    throw new AssertionError();
+    throw new AssertionError("Expected request to eventually fail");
   }
 
   // ---------------------------------------------------------------------------------------------------------

--- a/statefun-flink/statefun-flink-core/src/test/java/org/apache/flink/statefun/flink/core/reqreply/PersistedRemoteFunctionValuesTest.java
+++ b/statefun-flink/statefun-flink-core/src/test/java/org/apache/flink/statefun/flink/core/reqreply/PersistedRemoteFunctionValuesTest.java
@@ -22,6 +22,7 @@ import static org.apache.flink.statefun.flink.core.reqreply.PersistedRemoteFunct
 import static org.hamcrest.CoreMatchers.hasItems;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.google.protobuf.ByteString;
 import java.util.Arrays;
@@ -32,7 +33,7 @@ import org.apache.flink.statefun.sdk.reqreply.generated.FromFunction.PersistedVa
 import org.apache.flink.statefun.sdk.reqreply.generated.ToFunction.InvocationBatchRequest;
 import org.apache.flink.statefun.sdk.reqreply.generated.ToFunction.PersistedValue;
 import org.apache.flink.statefun.sdk.reqreply.generated.TypedValue;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class PersistedRemoteFunctionValuesTest {
 
@@ -82,15 +83,19 @@ public class PersistedRemoteFunctionValuesTest {
     assertThat(builder.getStateList().size(), is(0));
   }
 
-  @Test(expected = IllegalStateException.class)
+  @Test
   public void updatingNonRegisteredStateShouldThrow() {
-    final PersistedRemoteFunctionValues values = new PersistedRemoteFunctionValues();
+    assertThrows(
+        IllegalStateException.class,
+        () -> {
+          final PersistedRemoteFunctionValues values = new PersistedRemoteFunctionValues();
 
-    values.updateStateValues(
-        Collections.singletonList(
-            protocolPersistedValueModifyMutation(
-                "non-registered-state",
-                protocolTypedValue(TEST_STATE_TYPE, ByteString.copyFromUtf8("data")))));
+          values.updateStateValues(
+              Collections.singletonList(
+                  protocolPersistedValueModifyMutation(
+                      "non-registered-state",
+                      protocolTypedValue(TEST_STATE_TYPE, ByteString.copyFromUtf8("data")))));
+        });
   }
 
   @Test
@@ -155,31 +160,40 @@ public class PersistedRemoteFunctionValuesTest {
                 "state", protocolTypedValue(TEST_STATE_TYPE, ByteString.copyFromUtf8("data")))));
   }
 
-  @Test(expected = RemoteFunctionStateException.class)
+  @Test
   public void mismatchingStateTypeAcrossRegistrations() {
-    final PersistedRemoteFunctionValues values = new PersistedRemoteFunctionValues();
+    assertThrows(
+        RemoteFunctionStateException.class,
+        () -> {
+          final PersistedRemoteFunctionValues values = new PersistedRemoteFunctionValues();
 
-    values.registerStates(
-        Collections.singletonList(
-            protocolPersistedValueSpec("state", TypeName.parseFrom("com.foo.bar/type-1"))));
-    values.registerStates(
-        Collections.singletonList(
-            protocolPersistedValueSpec("state", TypeName.parseFrom("com.foo.bar/type-2"))));
+          values.registerStates(
+              Collections.singletonList(
+                  protocolPersistedValueSpec("state", TypeName.parseFrom("com.foo.bar/type-1"))));
+          values.registerStates(
+              Collections.singletonList(
+                  protocolPersistedValueSpec("state", TypeName.parseFrom("com.foo.bar/type-2"))));
+        });
   }
 
-  @Test(expected = RemoteFunctionStateException.class)
+  @Test
   public void mutatingStateValueWithMismatchingType() {
-    final PersistedRemoteFunctionValues values = new PersistedRemoteFunctionValues();
+    assertThrows(
+        RemoteFunctionStateException.class,
+        () -> {
+          final PersistedRemoteFunctionValues values = new PersistedRemoteFunctionValues();
 
-    values.registerStates(
-        Collections.singletonList(
-            protocolPersistedValueSpec("state", TypeName.parseFrom("com.foo.bar/type-1"))));
-    values.updateStateValues(
-        Collections.singletonList(
-            protocolPersistedValueModifyMutation(
-                "state",
-                protocolTypedValue(
-                    TypeName.parseFrom("com.foo.bar/type-2"), ByteString.copyFromUtf8("data")))));
+          values.registerStates(
+              Collections.singletonList(
+                  protocolPersistedValueSpec("state", TypeName.parseFrom("com.foo.bar/type-1"))));
+          values.updateStateValues(
+              Collections.singletonList(
+                  protocolPersistedValueModifyMutation(
+                      "state",
+                      protocolTypedValue(
+                          TypeName.parseFrom("com.foo.bar/type-2"),
+                          ByteString.copyFromUtf8("data")))));
+        });
   }
 
   private static TypedValue protocolTypedValue(TypeName typename, ByteString value) {

--- a/statefun-flink/statefun-flink-core/src/test/java/org/apache/flink/statefun/flink/core/reqreply/RequestReplyFunctionTest.java
+++ b/statefun-flink/statefun-flink-core/src/test/java/org/apache/flink/statefun/flink/core/reqreply/RequestReplyFunctionTest.java
@@ -21,10 +21,10 @@ import static org.apache.flink.statefun.flink.core.TestUtils.FUNCTION_1_ADDR;
 import static org.apache.flink.statefun.flink.core.common.PolyglotUtil.polyglotAddressToSdkAddress;
 import static org.hamcrest.CoreMatchers.hasItems;
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.google.protobuf.ByteString;
 import java.time.Duration;
@@ -60,7 +60,7 @@ import org.apache.flink.statefun.sdk.reqreply.generated.FromFunction.PersistedVa
 import org.apache.flink.statefun.sdk.reqreply.generated.ToFunction;
 import org.apache.flink.statefun.sdk.reqreply.generated.ToFunction.Invocation;
 import org.apache.flink.statefun.sdk.reqreply.generated.TypedValue;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class RequestReplyFunctionTest {
   private static final FunctionType FN_TYPE = new FunctionType("foo", "bar");

--- a/statefun-flink/statefun-flink-core/src/test/java/org/apache/flink/statefun/flink/core/state/PersistedStatesTest.java
+++ b/statefun-flink/statefun-flink-core/src/test/java/org/apache/flink/statefun/flink/core/state/PersistedStatesTest.java
@@ -19,7 +19,8 @@ package org.apache.flink.statefun.flink.core.state;
 
 import static org.hamcrest.CoreMatchers.hasItems;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -41,7 +42,7 @@ import org.apache.flink.statefun.sdk.state.PersistedTable;
 import org.apache.flink.statefun.sdk.state.PersistedValue;
 import org.apache.flink.statefun.sdk.state.RemotePersistedValue;
 import org.apache.flink.statefun.sdk.state.TableAccessor;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class PersistedStatesTest {
 
@@ -59,9 +60,11 @@ public class PersistedStatesTest {
     assertThat(state.boundNames, hasItems("name", "last"));
   }
 
-  @Test(expected = IllegalStateException.class)
+  @Test
   public void nullValueField() {
-    PersistedStates.findReflectivelyAndBind(new NullValueClass(), binderUnderTest);
+    assertThrows(
+        IllegalStateException.class,
+        () -> PersistedStates.findReflectivelyAndBind(new NullValueClass(), binderUnderTest));
   }
 
   @Test
@@ -78,9 +81,11 @@ public class PersistedStatesTest {
     assertThat(state.boundNames, hasItems("parent", "child"));
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void staticPersistedFieldsAreNotAllowed() {
-    PersistedStates.findReflectivelyAndBind(new StaticPersistedValue(), binderUnderTest);
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> PersistedStates.findReflectivelyAndBind(new StaticPersistedValue(), binderUnderTest));
   }
 
   @Test

--- a/statefun-flink/statefun-flink-datastream/pom.xml
+++ b/statefun-flink/statefun-flink-datastream/pom.xml
@@ -75,8 +75,8 @@ under the License.
 
         <!-- Tests -->
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
         </dependency>
         <dependency>
             <groupId>org.hamcrest</groupId>

--- a/statefun-flink/statefun-flink-datastream/src/test/java/org/apache/flink/statefun/flink/datastream/AsyncRequestReplyFunctionBuilderTest.java
+++ b/statefun-flink/statefun-flink-datastream/src/test/java/org/apache/flink/statefun/flink/datastream/AsyncRequestReplyFunctionBuilderTest.java
@@ -20,7 +20,7 @@ package org.apache.flink.statefun.flink.datastream;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.notNullValue;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -31,7 +31,7 @@ import org.apache.flink.statefun.flink.core.httpfn.HttpFunctionEndpointSpec;
 import org.apache.flink.statefun.flink.core.httpfn.TransportClientConstants;
 import org.apache.flink.statefun.flink.core.nettyclient.NettyRequestReplySpec;
 import org.apache.flink.statefun.sdk.FunctionType;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class AsyncRequestReplyFunctionBuilderTest {
 

--- a/statefun-flink/statefun-flink-datastream/src/test/java/org/apache/flink/statefun/flink/datastream/RequestReplyFunctionBuilderTest.java
+++ b/statefun-flink/statefun-flink-datastream/src/test/java/org/apache/flink/statefun/flink/datastream/RequestReplyFunctionBuilderTest.java
@@ -20,7 +20,7 @@ package org.apache.flink.statefun.flink.datastream;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.notNullValue;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -31,7 +31,7 @@ import org.apache.flink.statefun.flink.core.httpfn.DefaultHttpRequestReplyClient
 import org.apache.flink.statefun.flink.core.httpfn.HttpFunctionEndpointSpec;
 import org.apache.flink.statefun.flink.core.httpfn.TransportClientConstants;
 import org.apache.flink.statefun.sdk.FunctionType;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class RequestReplyFunctionBuilderTest {
 

--- a/statefun-flink/statefun-flink-datastream/src/test/java/org/apache/flink/statefun/flink/datastream/SerializableHttpFunctionProviderTest.java
+++ b/statefun-flink/statefun-flink-datastream/src/test/java/org/apache/flink/statefun/flink/datastream/SerializableHttpFunctionProviderTest.java
@@ -18,12 +18,12 @@ package org.apache.flink.statefun.flink.datastream;
  * limitations under the License.
  */
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.apache.flink.statefun.flink.core.httpfn.DefaultHttpRequestReplyClientFactory;
 import org.apache.flink.statefun.flink.core.httpfn.TransportClientConstants;
 import org.apache.flink.statefun.flink.core.nettyclient.NettyRequestReplyClientFactory;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class SerializableHttpFunctionProviderTest {
 

--- a/statefun-flink/statefun-flink-io-bundle/pom.xml
+++ b/statefun-flink/statefun-flink-io-bundle/pom.xml
@@ -94,8 +94,8 @@ under the License.
 
         <!-- test -->
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
         </dependency>
         <dependency>
             <groupId>org.hamcrest</groupId>

--- a/statefun-flink/statefun-flink-io-bundle/src/test/java/org/apache/flink/statefun/flink/io/common/ReflectionUtilTest.java
+++ b/statefun-flink/statefun-flink-io-bundle/src/test/java/org/apache/flink/statefun/flink/io/common/ReflectionUtilTest.java
@@ -22,7 +22,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import org.apache.flink.statefun.sdk.kafka.KafkaIngressDeserializer;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.hamcrest.CoreMatchers;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class ReflectionUtilTest {
 

--- a/statefun-flink/statefun-flink-io-bundle/src/test/java/org/apache/flink/statefun/flink/io/kafka/binders/egress/v1/GenericKafkaEgressBinderV1Test.java
+++ b/statefun-flink/statefun-flink-io-bundle/src/test/java/org/apache/flink/statefun/flink/io/kafka/binders/egress/v1/GenericKafkaEgressBinderV1Test.java
@@ -18,8 +18,8 @@
 
 package org.apache.flink.statefun.flink.io.kafka.binders.egress.v1;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.instanceOf;
-import static org.junit.Assert.assertThat;
 
 import java.net.URL;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.ObjectMapper;
@@ -30,7 +30,7 @@ import org.apache.flink.statefun.flink.io.testutils.TestModuleBinder;
 import org.apache.flink.statefun.sdk.io.EgressIdentifier;
 import org.apache.flink.statefun.sdk.kafka.KafkaEgressSpec;
 import org.apache.flink.statefun.sdk.reqreply.generated.TypedValue;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class GenericKafkaEgressBinderV1Test {
 

--- a/statefun-flink/statefun-flink-io-bundle/src/test/java/org/apache/flink/statefun/flink/io/kafka/binders/ingress/v1/RoutableKafkaIngressBinderV1Test.java
+++ b/statefun-flink/statefun-flink-io-bundle/src/test/java/org/apache/flink/statefun/flink/io/kafka/binders/ingress/v1/RoutableKafkaIngressBinderV1Test.java
@@ -18,9 +18,9 @@
 
 package org.apache.flink.statefun.flink.io.kafka.binders.ingress.v1;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.instanceOf;
-import static org.junit.Assert.assertThat;
 
 import com.google.protobuf.Message;
 import java.net.URL;
@@ -32,7 +32,7 @@ import org.apache.flink.statefun.flink.io.common.AutoRoutableProtobufRouter;
 import org.apache.flink.statefun.flink.io.testutils.TestModuleBinder;
 import org.apache.flink.statefun.sdk.io.IngressIdentifier;
 import org.apache.flink.statefun.sdk.kafka.KafkaIngressSpec;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class RoutableKafkaIngressBinderV1Test {
 

--- a/statefun-flink/statefun-flink-state-processor/pom.xml
+++ b/statefun-flink/statefun-flink-state-processor/pom.xml
@@ -56,8 +56,8 @@ under the License.
 
         <!-- tests -->
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
         </dependency>
 
         <dependency>

--- a/statefun-flink/statefun-flink-state-processor/src/test/java/org/apache/flink/statefun/flink/state/processor/StatefulFunctionsSavepointCreatorTest.java
+++ b/statefun-flink/statefun-flink-state-processor/src/test/java/org/apache/flink/statefun/flink/state/processor/StatefulFunctionsSavepointCreatorTest.java
@@ -18,44 +18,62 @@
 
 package org.apache.flink.statefun.flink.state.processor;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 import org.apache.flink.statefun.sdk.FunctionType;
 import org.apache.flink.statefun.sdk.io.Router;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class StatefulFunctionsSavepointCreatorTest {
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void invalidMaxParallelism() {
-    new StatefulFunctionsSavepointCreator(-1);
+    assertThrows(IllegalArgumentException.class, () -> new StatefulFunctionsSavepointCreator(-1));
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void duplicateStateBootstrapFunctionProvider() {
-    final StatefulFunctionsSavepointCreator testCreator = new StatefulFunctionsSavepointCreator(1);
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> {
+          final StatefulFunctionsSavepointCreator testCreator =
+              new StatefulFunctionsSavepointCreator(1);
 
-    testCreator.withStateBootstrapFunctionProvider(
-        new FunctionType("ns", "test"), ignored -> new NoOpStateBootstrapFunction());
-    testCreator.withStateBootstrapFunctionProvider(
-        new FunctionType("ns", "test"), ignored -> new NoOpStateBootstrapFunction());
+          testCreator.withStateBootstrapFunctionProvider(
+              new FunctionType("ns", "test"), ignored -> new NoOpStateBootstrapFunction());
+          testCreator.withStateBootstrapFunctionProvider(
+              new FunctionType("ns", "test"), ignored -> new NoOpStateBootstrapFunction());
+        });
   }
 
-  @Test(expected = IllegalStateException.class)
+  @Test
   public void noBootstrapDataOnWrite() {
-    final StatefulFunctionsSavepointCreator testCreator = new StatefulFunctionsSavepointCreator(1);
+    assertThrows(
+        IllegalStateException.class,
+        () -> {
+          final StatefulFunctionsSavepointCreator testCreator =
+              new StatefulFunctionsSavepointCreator(1);
 
-    testCreator.withStateBootstrapFunctionProvider(
-        new FunctionType("ns", "test"), ignored -> new NoOpStateBootstrapFunction());
-    testCreator.write("ignored");
+          testCreator.withStateBootstrapFunctionProvider(
+              new FunctionType("ns", "test"), ignored -> new NoOpStateBootstrapFunction());
+          testCreator.write("ignored");
+        });
   }
 
-  @Test(expected = IllegalStateException.class)
+  @Test
   public void noStateBootstrapFunctionProvidersOnWrite() {
-    final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
-    final StatefulFunctionsSavepointCreator testCreator = new StatefulFunctionsSavepointCreator(1);
+    assertThrows(
+        IllegalStateException.class,
+        () -> {
+          final StreamExecutionEnvironment env =
+              StreamExecutionEnvironment.getExecutionEnvironment();
+          final StatefulFunctionsSavepointCreator testCreator =
+              new StatefulFunctionsSavepointCreator(1);
 
-    testCreator.withBootstrapData(env.fromElements("foobar"), NoOpBootstrapDataRouter::new);
-    testCreator.write("ignored");
+          testCreator.withBootstrapData(env.fromElements("foobar"), NoOpBootstrapDataRouter::new);
+          testCreator.write("ignored");
+        });
   }
 
   private static class NoOpStateBootstrapFunction implements StateBootstrapFunction {

--- a/statefun-flink/statefun-flink-state-processor/src/test/java/org/apache/flink/statefun/flink/state/processor/operator/StateBootstrapperTest.java
+++ b/statefun-flink/statefun-flink-state-processor/src/test/java/org/apache/flink/statefun/flink/state/processor/operator/StateBootstrapperTest.java
@@ -18,9 +18,9 @@
 package org.apache.flink.statefun.flink.state.processor.operator;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -39,7 +39,7 @@ import org.apache.flink.statefun.sdk.state.PersistedTable;
 import org.apache.flink.statefun.sdk.state.PersistedValue;
 import org.apache.flink.statefun.sdk.state.RemotePersistedValue;
 import org.apache.flink.statefun.sdk.state.TableAccessor;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class StateBootstrapperTest {
 
@@ -211,7 +211,7 @@ public class StateBootstrapperTest {
     }
 
     private void assertKeySet() {
-      assertNotNull("Key should have been set before accessing state.", currentKey);
+      assertNotNull(currentKey, "Key should have been set before accessing state.");
     }
 
     Object getState(FunctionType functionType, String stateName, String functionId) {

--- a/statefun-flink/statefun-flink-state-processor/src/test/java/org/apache/flink/statefun/flink/state/processor/union/BootstrapDatasetUnionTest.java
+++ b/statefun-flink/statefun-flink-state-processor/src/test/java/org/apache/flink/statefun/flink/state/processor/union/BootstrapDatasetUnionTest.java
@@ -18,7 +18,7 @@
 package org.apache.flink.statefun.flink.state.processor.union;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -37,7 +37,7 @@ import org.hamcrest.Description;
 import org.hamcrest.Matcher;
 import org.hamcrest.Matchers;
 import org.hamcrest.TypeSafeMatcher;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class BootstrapDatasetUnionTest {
 

--- a/statefun-flink/statefun-flink-state-processor/src/test/java/org/apache/flink/statefun/flink/state/processor/union/TaggedBootstrapDataSerializerTest.java
+++ b/statefun-flink/statefun-flink-state-processor/src/test/java/org/apache/flink/statefun/flink/state/processor/union/TaggedBootstrapDataSerializerTest.java
@@ -29,7 +29,7 @@ import org.apache.flink.api.common.typeutils.base.IntSerializer;
 import org.apache.flink.statefun.sdk.Address;
 import org.apache.flink.statefun.sdk.FunctionType;
 import org.apache.flink.testutils.DeeplyEqualsChecker;
-import org.junit.Ignore;
+import org.junit.jupiter.api.Disabled;
 
 public class TaggedBootstrapDataSerializerTest extends SerializerTestBase<TaggedBootstrapData> {
 
@@ -104,14 +104,14 @@ public class TaggedBootstrapDataSerializerTest extends SerializerTestBase<Tagged
   // -----------------------------------------------------------------------------
 
   @Override
-  @Ignore
+  @Disabled
   public void testConfigSnapshotInstantiation() {
     // test ignored; this is a test that is only relevant for serializers that are used for
     // persistent data
   }
 
   @Override
-  @Ignore
+  @Disabled
   public void testSnapshotConfigurationAndReconfigure() {
     // test ignored; this is a test that is only relevant for serializers that are used for
     // persistent data

--- a/statefun-k8s-native-e2e/pom.xml
+++ b/statefun-k8s-native-e2e/pom.xml
@@ -34,7 +34,7 @@ under the License.
         <kafka-clients.version>3.9.0</kafka-clients.version>
         <awaitility.version>4.2.2</awaitility.version>
         <assertj.version>3.27.3</assertj.version>
-        <junit-jupiter.version>5.11.4</junit-jupiter.version>
+        
         <minio.version>8.5.14</minio.version>
         <slf4j.version>2.0.9</slf4j.version>
     </properties>
@@ -76,7 +76,7 @@ under the License.
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
-            <version>${junit-jupiter.version}</version>
+            
             <scope>test</scope>
         </dependency>
 

--- a/statefun-kafka-io/pom.xml
+++ b/statefun-kafka-io/pom.xml
@@ -56,8 +56,8 @@ under the License.
 
         <!-- test -->
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
         </dependency>
         <dependency>
             <groupId>org.hamcrest</groupId>

--- a/statefun-kafka-io/src/test/java/org/apache/flink/statefun/sdk/kafka/KafkaIngressBuilderTest.java
+++ b/statefun-kafka-io/src/test/java/org/apache/flink/statefun/sdk/kafka/KafkaIngressBuilderTest.java
@@ -22,14 +22,14 @@ import static org.apache.flink.statefun.sdk.kafka.testutils.Matchers.isMapOfSize
 import static org.hamcrest.CoreMatchers.allOf;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
-import static org.junit.Assert.assertThat;
 
 import java.util.Properties;
 import org.apache.flink.statefun.sdk.io.IngressIdentifier;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class KafkaIngressBuilderTest {
 

--- a/statefun-kinesis-io/pom.xml
+++ b/statefun-kinesis-io/pom.xml
@@ -38,8 +38,13 @@ under the License.
         </dependency>
 
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest</artifactId>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 </project>

--- a/statefun-kinesis-io/src/test/java/org/apache/flink/statefun/sdk/kinesis/KinesisEgressBuilderTest.java
+++ b/statefun-kinesis-io/src/test/java/org/apache/flink/statefun/sdk/kinesis/KinesisEgressBuilderTest.java
@@ -18,16 +18,16 @@
 package org.apache.flink.statefun.sdk.kinesis;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.apache.flink.statefun.sdk.io.EgressIdentifier;
 import org.apache.flink.statefun.sdk.kinesis.egress.EgressRecord;
 import org.apache.flink.statefun.sdk.kinesis.egress.KinesisEgressBuilder;
 import org.apache.flink.statefun.sdk.kinesis.egress.KinesisEgressSerializer;
 import org.apache.flink.statefun.sdk.kinesis.egress.KinesisEgressSpec;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class KinesisEgressBuilderTest {
 

--- a/statefun-kinesis-io/src/test/java/org/apache/flink/statefun/sdk/kinesis/KinesisIngressBuilderTest.java
+++ b/statefun-kinesis-io/src/test/java/org/apache/flink/statefun/sdk/kinesis/KinesisIngressBuilderTest.java
@@ -19,8 +19,8 @@ package org.apache.flink.statefun.sdk.kinesis;
 
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Collections;
 import org.apache.flink.statefun.sdk.io.IngressIdentifier;
@@ -28,7 +28,7 @@ import org.apache.flink.statefun.sdk.kinesis.ingress.IngressRecord;
 import org.apache.flink.statefun.sdk.kinesis.ingress.KinesisIngressBuilder;
 import org.apache.flink.statefun.sdk.kinesis.ingress.KinesisIngressDeserializer;
 import org.apache.flink.statefun.sdk.kinesis.ingress.KinesisIngressSpec;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class KinesisIngressBuilderTest {
 

--- a/statefun-sdk-embedded/pom.xml
+++ b/statefun-sdk-embedded/pom.xml
@@ -41,8 +41,8 @@ under the License.
 
         <!-- Tests -->
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
         </dependency>
         <dependency>
             <groupId>org.hamcrest</groupId>

--- a/statefun-sdk-embedded/src/test/java/org/apache/flink/statefun/sdk/state/PersistedAppendingBufferTest.java
+++ b/statefun-sdk-embedded/src/test/java/org/apache/flink/statefun/sdk/state/PersistedAppendingBufferTest.java
@@ -19,15 +19,16 @@
 package org.apache.flink.statefun.sdk.state;
 
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.collection.IsIterableContainingInOrder.contains;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Iterator;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class PersistedAppendingBufferTest {
 
@@ -89,12 +90,17 @@ public class PersistedAppendingBufferTest {
     assertFalse(buffer.view().iterator().hasNext());
   }
 
-  @Test(expected = UnsupportedOperationException.class)
+  @Test
   public void viewUnmodifiable() {
-    PersistedAppendingBuffer<String> buffer = PersistedAppendingBuffer.of("test", String.class);
-    buffer.append("element");
+    assertThrows(
+        UnsupportedOperationException.class,
+        () -> {
+          PersistedAppendingBuffer<String> buffer =
+              PersistedAppendingBuffer.of("test", String.class);
+          buffer.append("element");
 
-    Iterator<String> view = buffer.view().iterator();
-    view.remove();
+          Iterator<String> view = buffer.view().iterator();
+          view.remove();
+        });
   }
 }

--- a/statefun-sdk-embedded/src/test/java/org/apache/flink/statefun/sdk/state/PersistedStateRegistryTest.java
+++ b/statefun-sdk-embedded/src/test/java/org/apache/flink/statefun/sdk/state/PersistedStateRegistryTest.java
@@ -18,8 +18,10 @@
 
 package org.apache.flink.statefun.sdk.state;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 import org.apache.flink.statefun.sdk.TypeName;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class PersistedStateRegistryTest {
 
@@ -34,11 +36,15 @@ public class PersistedStateRegistryTest {
         RemotePersistedValue.of("remote", TypeName.parseFrom("io.statefun.types/raw")));
   }
 
-  @Test(expected = IllegalStateException.class)
+  @Test
   public void duplicateRegistration() {
-    final PersistedStateRegistry registry = new PersistedStateRegistry();
+    assertThrows(
+        IllegalStateException.class,
+        () -> {
+          final PersistedStateRegistry registry = new PersistedStateRegistry();
 
-    registry.registerValue(PersistedValue.of("my-state", String.class));
-    registry.registerTable(PersistedTable.of("my-state", String.class, Integer.class));
+          registry.registerValue(PersistedValue.of("my-state", String.class));
+          registry.registerTable(PersistedTable.of("my-state", String.class, Integer.class));
+        });
   }
 }

--- a/statefun-sdk-java/pom.xml
+++ b/statefun-sdk-java/pom.xml
@@ -38,8 +38,8 @@ under the License.
 
         <!-- test dependencies -->
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
         </dependency>
         <dependency>
             <groupId>org.hamcrest</groupId>

--- a/statefun-sdk-java/src/test/java/ValueSpecTest.java
+++ b/statefun-sdk-java/src/test/java/ValueSpecTest.java
@@ -16,12 +16,13 @@
  * limitations under the License.
  */
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.apache.flink.statefun.sdk.java.ValueSpec;
 import org.apache.flink.statefun.sdk.java.types.Types;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class ValueSpecTest {
 
@@ -33,18 +34,21 @@ public class ValueSpecTest {
     assertThat(spec.type(), is(Types.integerType()));
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void stateNameWithSpaces() {
-    ValueSpec.named("bad state name").withIntType();
+    assertThrows(
+        IllegalArgumentException.class, () -> ValueSpec.named("bad state name").withIntType());
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void stateNameWithInvalidStartChar() {
-    ValueSpec.named("123bad_state_name").withIntType();
+    assertThrows(
+        IllegalArgumentException.class, () -> ValueSpec.named("123bad_state_name").withIntType());
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void stateNameWithInvalidPartChar() {
-    ValueSpec.named("bad!_state_name").withIntType();
+    assertThrows(
+        IllegalArgumentException.class, () -> ValueSpec.named("bad!_state_name").withIntType());
   }
 }

--- a/statefun-sdk-java/src/test/java/org/apache/flink/statefun/sdk/java/StatefulFunctionSpecTest.java
+++ b/statefun-sdk-java/src/test/java/org/apache/flink/statefun/sdk/java/StatefulFunctionSpecTest.java
@@ -17,14 +17,15 @@
  */
 package org.apache.flink.statefun.sdk.java;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.concurrent.CompletableFuture;
 import org.apache.flink.statefun.sdk.java.message.Message;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class StatefulFunctionSpecTest {
 
@@ -45,11 +46,15 @@ public class StatefulFunctionSpecTest {
     assertThat(spec.knownValues(), hasKey("state_b"));
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void duplicateRegistration() {
-    StatefulFunctionSpec.builder(TypeName.typeNameOf("test.namespace", "test.name"))
-        .withValueSpecs(
-            ValueSpec.named("foobar").withIntType(), ValueSpec.named("foobar").withBooleanType());
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            StatefulFunctionSpec.builder(TypeName.typeNameOf("test.namespace", "test.name"))
+                .withValueSpecs(
+                    ValueSpec.named("foobar").withIntType(),
+                    ValueSpec.named("foobar").withBooleanType()));
   }
 
   private static class TestFunction implements StatefulFunction {

--- a/statefun-sdk-java/src/test/java/org/apache/flink/statefun/sdk/java/handler/ConcurrentRequestReplyHandlerTest.java
+++ b/statefun-sdk-java/src/test/java/org/apache/flink/statefun/sdk/java/handler/ConcurrentRequestReplyHandlerTest.java
@@ -20,9 +20,9 @@ package org.apache.flink.statefun.sdk.java.handler;
 import static java.util.Collections.singletonMap;
 import static org.apache.flink.statefun.sdk.java.handler.TestUtils.modifiedValue;
 import static org.apache.flink.statefun.sdk.java.handler.TestUtils.protoFromValueSpec;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.notNullValue;
-import static org.junit.Assert.assertThat;
 
 import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
@@ -36,7 +36,7 @@ import org.apache.flink.statefun.sdk.java.message.Message;
 import org.apache.flink.statefun.sdk.java.types.Types;
 import org.apache.flink.statefun.sdk.reqreply.generated.FromFunction;
 import org.apache.flink.statefun.sdk.reqreply.generated.ToFunction;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class ConcurrentRequestReplyHandlerTest {
 

--- a/statefun-sdk-java/src/test/java/org/apache/flink/statefun/sdk/java/handler/MoreFuturesTest.java
+++ b/statefun-sdk-java/src/test/java/org/apache/flink/statefun/sdk/java/handler/MoreFuturesTest.java
@@ -27,7 +27,7 @@ import java.util.Iterator;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentLinkedDeque;
 import java.util.stream.IntStream;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class MoreFuturesTest {
 

--- a/statefun-sdk-java/src/test/java/org/apache/flink/statefun/sdk/java/slice/SliceOutputTest.java
+++ b/statefun-sdk-java/src/test/java/org/apache/flink/statefun/sdk/java/slice/SliceOutputTest.java
@@ -17,7 +17,7 @@
  */
 package org.apache.flink.statefun.sdk.java.slice;
 
-import static org.junit.Assert.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -25,7 +25,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.ThreadLocalRandom;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class SliceOutputTest {
 

--- a/statefun-sdk-java/src/test/java/org/apache/flink/statefun/sdk/java/slice/SliceProtobufUtilTest.java
+++ b/statefun-sdk-java/src/test/java/org/apache/flink/statefun/sdk/java/slice/SliceProtobufUtilTest.java
@@ -17,10 +17,10 @@
  */
 package org.apache.flink.statefun.sdk.java.slice;
 
-import static org.junit.Assert.assertSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 import org.apache.flink.statefun.sdk.shaded.com.google.protobuf.ByteString;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class SliceProtobufUtilTest {
 
@@ -31,6 +31,6 @@ public class SliceProtobufUtilTest {
     Slice slice = SliceProtobufUtil.asSlice(expected);
     ByteString got = SliceProtobufUtil.asByteString(slice);
 
-    assertSame("Expecting the same reference.", expected, got);
+    assertSame(expected, got, "Expecting the same reference.");
   }
 }

--- a/statefun-sdk-java/src/test/java/org/apache/flink/statefun/sdk/java/storage/ConcurrentAddressScopedStorageTest.java
+++ b/statefun-sdk-java/src/test/java/org/apache/flink/statefun/sdk/java/storage/ConcurrentAddressScopedStorageTest.java
@@ -21,6 +21,7 @@ package org.apache.flink.statefun.sdk.java.storage;
 import static org.apache.flink.statefun.sdk.java.storage.StateValueContexts.StateValueContext;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -32,7 +33,7 @@ import org.apache.flink.statefun.sdk.java.types.Type;
 import org.apache.flink.statefun.sdk.reqreply.generated.ToFunction;
 import org.apache.flink.statefun.sdk.reqreply.generated.TypedValue;
 import org.apache.flink.statefun.sdk.shaded.com.google.protobuf.ByteString;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class ConcurrentAddressScopedStorageTest {
 
@@ -115,68 +116,99 @@ public class ConcurrentAddressScopedStorageTest {
     assertThat(storage.get(stateSpec), is(Optional.empty()));
   }
 
-  @Test(expected = IllegalStorageAccessException.class)
+  @Test
   public void getNonExistingCell() {
-    final AddressScopedStorage storage =
-        new ConcurrentAddressScopedStorage(Collections.emptyList());
+    assertThrows(
+        IllegalStorageAccessException.class,
+        () -> {
+          final AddressScopedStorage storage =
+              new ConcurrentAddressScopedStorage(Collections.emptyList());
 
-    storage.get(ValueSpec.named("does_not_exist").withIntType());
+          storage.get(ValueSpec.named("does_not_exist").withIntType());
+        });
   }
 
-  @Test(expected = IllegalStorageAccessException.class)
+  @Test
   public void setNonExistingCell() {
-    final AddressScopedStorage storage =
-        new ConcurrentAddressScopedStorage(Collections.emptyList());
+    assertThrows(
+        IllegalStorageAccessException.class,
+        () -> {
+          final AddressScopedStorage storage =
+              new ConcurrentAddressScopedStorage(Collections.emptyList());
 
-    storage.set(ValueSpec.named("does_not_exist").withIntType(), 999);
+          storage.set(ValueSpec.named("does_not_exist").withIntType(), 999);
+        });
   }
 
-  @Test(expected = IllegalStorageAccessException.class)
+  @Test
   public void clearNonExistingCell() {
-    final AddressScopedStorage storage =
-        new ConcurrentAddressScopedStorage(Collections.emptyList());
+    assertThrows(
+        IllegalStorageAccessException.class,
+        () -> {
+          final AddressScopedStorage storage =
+              new ConcurrentAddressScopedStorage(Collections.emptyList());
 
-    storage.remove(ValueSpec.named("does_not_exist").withIntType());
+          storage.remove(ValueSpec.named("does_not_exist").withIntType());
+        });
   }
 
-  @Test(expected = IllegalStorageAccessException.class)
+  @Test
   public void setToNull() {
-    final ValueSpec<Integer> stateSpec = ValueSpec.named("state").withIntType();
+    assertThrows(
+        IllegalStorageAccessException.class,
+        () -> {
+          final ValueSpec<Integer> stateSpec = ValueSpec.named("state").withIntType();
 
-    List<StateValueContext<?>> testStateValues = testStateValues(stateValue(stateSpec, 91));
-    final AddressScopedStorage storage = new ConcurrentAddressScopedStorage(testStateValues);
+          List<StateValueContext<?>> testStateValues = testStateValues(stateValue(stateSpec, 91));
+          final AddressScopedStorage storage = new ConcurrentAddressScopedStorage(testStateValues);
 
-    storage.set(stateSpec, null);
+          storage.set(stateSpec, null);
+        });
   }
 
-  @Test(expected = IllegalStorageAccessException.class)
+  @Test
   public void getWithWrongType() {
-    final ValueSpec<Integer> stateSpec = ValueSpec.named("state").withIntType();
+    assertThrows(
+        IllegalStorageAccessException.class,
+        () -> {
+          final ValueSpec<Integer> stateSpec = ValueSpec.named("state").withIntType();
 
-    final List<StateValueContext<?>> testStateValues = testStateValues(stateValue(stateSpec, 91));
-    final AddressScopedStorage storage = new ConcurrentAddressScopedStorage(testStateValues);
+          final List<StateValueContext<?>> testStateValues =
+              testStateValues(stateValue(stateSpec, 91));
+          final AddressScopedStorage storage = new ConcurrentAddressScopedStorage(testStateValues);
 
-    storage.get(ValueSpec.named("state").withBooleanType());
+          storage.get(ValueSpec.named("state").withBooleanType());
+        });
   }
 
-  @Test(expected = IllegalStorageAccessException.class)
+  @Test
   public void setWithWrongType() {
-    final ValueSpec<Integer> stateSpec = ValueSpec.named("state").withIntType();
+    assertThrows(
+        IllegalStorageAccessException.class,
+        () -> {
+          final ValueSpec<Integer> stateSpec = ValueSpec.named("state").withIntType();
 
-    final List<StateValueContext<?>> testStateValues = testStateValues(stateValue(stateSpec, 91));
-    final AddressScopedStorage storage = new ConcurrentAddressScopedStorage(testStateValues);
+          final List<StateValueContext<?>> testStateValues =
+              testStateValues(stateValue(stateSpec, 91));
+          final AddressScopedStorage storage = new ConcurrentAddressScopedStorage(testStateValues);
 
-    storage.set(ValueSpec.named("state").withBooleanType(), true);
+          storage.set(ValueSpec.named("state").withBooleanType(), true);
+        });
   }
 
-  @Test(expected = IllegalStorageAccessException.class)
+  @Test
   public void clearWithWrongType() {
-    final ValueSpec<Integer> stateSpec = ValueSpec.named("state").withIntType();
+    assertThrows(
+        IllegalStorageAccessException.class,
+        () -> {
+          final ValueSpec<Integer> stateSpec = ValueSpec.named("state").withIntType();
 
-    final List<StateValueContext<?>> testStateValues = testStateValues(stateValue(stateSpec, 91));
-    final AddressScopedStorage storage = new ConcurrentAddressScopedStorage(testStateValues);
+          final List<StateValueContext<?>> testStateValues =
+              testStateValues(stateValue(stateSpec, 91));
+          final AddressScopedStorage storage = new ConcurrentAddressScopedStorage(testStateValues);
 
-    storage.remove(ValueSpec.named("state").withBooleanType());
+          storage.remove(ValueSpec.named("state").withBooleanType());
+        });
   }
 
   private static List<StateValueContext<?>> testStateValues(StateValueContext<?>... testValues) {

--- a/statefun-sdk-java/src/test/java/org/apache/flink/statefun/sdk/java/storage/StateValueContextsTest.java
+++ b/statefun-sdk-java/src/test/java/org/apache/flink/statefun/sdk/java/storage/StateValueContextsTest.java
@@ -39,7 +39,7 @@ import org.hamcrest.Matcher;
 import org.hamcrest.Matchers;
 import org.hamcrest.TypeSafeDiagnosingMatcher;
 import org.hamcrest.TypeSafeMatcher;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public final class StateValueContextsTest {
 

--- a/statefun-sdk-java/src/test/java/org/apache/flink/statefun/sdk/java/testing/TestContextIntegrationTest.java
+++ b/statefun-sdk-java/src/test/java/org/apache/flink/statefun/sdk/java/testing/TestContextIntegrationTest.java
@@ -36,7 +36,7 @@ import org.apache.flink.statefun.sdk.java.message.EgressMessage;
 import org.apache.flink.statefun.sdk.java.message.EgressMessageBuilder;
 import org.apache.flink.statefun.sdk.java.message.Message;
 import org.apache.flink.statefun.sdk.java.message.MessageBuilder;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TestContextIntegrationTest {
 

--- a/statefun-sdk-java/src/test/java/org/apache/flink/statefun/sdk/java/testing/TestContextTest.java
+++ b/statefun-sdk-java/src/test/java/org/apache/flink/statefun/sdk/java/testing/TestContextTest.java
@@ -31,8 +31,8 @@ import org.apache.flink.statefun.sdk.java.message.Message;
 import org.apache.flink.statefun.sdk.java.message.MessageBuilder;
 import org.apache.flink.statefun.sdk.java.types.SimpleType;
 import org.apache.flink.statefun.sdk.java.types.Type;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class TestContextTest {
 
@@ -40,7 +40,7 @@ public class TestContextTest {
   private Address someone;
   private Address me;
 
-  @Before
+  @BeforeEach
   public void resetContext() {
     me = new Address(TypeName.typeNameOf("com.example", "function"), "me");
     someone = new Address(TypeName.typeNameOf("com.example", "function"), "someone");

--- a/statefun-sdk-java/src/test/java/org/apache/flink/statefun/sdk/java/types/SanityPrimitiveTypeTest.java
+++ b/statefun-sdk-java/src/test/java/org/apache/flink/statefun/sdk/java/types/SanityPrimitiveTypeTest.java
@@ -17,7 +17,7 @@
  */
 package org.apache.flink.statefun.sdk.java.types;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
@@ -30,8 +30,8 @@ import org.apache.flink.statefun.sdk.types.generated.BooleanWrapper;
 import org.apache.flink.statefun.sdk.types.generated.IntWrapper;
 import org.apache.flink.statefun.sdk.types.generated.LongWrapper;
 import org.apache.flink.statefun.sdk.types.generated.StringWrapper;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 public class SanityPrimitiveTypeTest {
 
@@ -124,7 +124,7 @@ public class SanityPrimitiveTypeTest {
     }
   }
 
-  @Ignore
+  @Disabled
   @Test
   public void testCompatibilityWithAnIntegerWrapper() throws InvalidProtocolBufferException {
     TypeSerializer<Integer> serializer = Types.integerType().typeSerializer();

--- a/statefun-sdk-java/src/test/java/org/apache/flink/statefun/sdk/java/types/SimpleTypeTest.java
+++ b/statefun-sdk-java/src/test/java/org/apache/flink/statefun/sdk/java/types/SimpleTypeTest.java
@@ -18,14 +18,14 @@
 
 package org.apache.flink.statefun.sdk.java.types;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.nio.charset.StandardCharsets;
 import org.apache.flink.statefun.sdk.java.TypeName;
 import org.apache.flink.statefun.sdk.java.slice.Slice;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class SimpleTypeTest {
 

--- a/statefun-testutil/pom.xml
+++ b/statefun-testutil/pom.xml
@@ -40,8 +40,8 @@ under the License.
             <scope>compile</scope>
         </dependency>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
         </dependency>
     </dependencies>
 

--- a/statefun-testutil/src/test/java/org/apache/flink/statefun/testutils/function/FunctionTestHarnessTest.java
+++ b/statefun-testutil/src/test/java/org/apache/flink/statefun/testutils/function/FunctionTestHarnessTest.java
@@ -18,6 +18,7 @@
 package org.apache.flink.statefun.testutils.function;
 
 import static org.apache.flink.statefun.testutils.matchers.StatefulFunctionMatchers.*;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.equalTo;
 
@@ -29,8 +30,7 @@ import org.apache.flink.statefun.sdk.Context;
 import org.apache.flink.statefun.sdk.FunctionType;
 import org.apache.flink.statefun.sdk.StatefulFunction;
 import org.apache.flink.statefun.sdk.io.EgressIdentifier;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /** Simple validation tests of the test harness. */
 public class FunctionTestHarnessTest {
@@ -53,7 +53,7 @@ public class FunctionTestHarnessTest {
     FunctionTestHarness harness =
         FunctionTestHarness.test(ignore -> new BasicFunction(), UNDER_TEST, "id");
 
-    Assert.assertThat(harness.invoke(CALLER, "ping"), sent(messagesTo(CALLER, equalTo("pong"))));
+    assertThat(harness.invoke(CALLER, "ping"), sent(messagesTo(CALLER, equalTo("pong"))));
   }
 
   @Test
@@ -61,7 +61,7 @@ public class FunctionTestHarnessTest {
     FunctionTestHarness harness =
         FunctionTestHarness.test(ignore -> new MultiResponseFunction(), UNDER_TEST, "id");
 
-    Assert.assertThat(
+    assertThat(
         harness.invoke("hello"),
         sent(
             messagesTo(CALLER, equalTo("a"), equalTo("b")),
@@ -73,7 +73,7 @@ public class FunctionTestHarnessTest {
     FunctionTestHarness harness =
         FunctionTestHarness.test(ignore -> new SelfResponseFunction(), UNDER_TEST, "id");
 
-    Assert.assertThat(harness.invoke("hello"), sent(messagesTo(SELF_ADDRESS, equalTo("world"))));
+    assertThat(harness.invoke("hello"), sent(messagesTo(SELF_ADDRESS, equalTo("world"))));
   }
 
   @Test
@@ -81,8 +81,8 @@ public class FunctionTestHarnessTest {
     FunctionTestHarness harness =
         FunctionTestHarness.test(ignore -> new EgressFunction(), UNDER_TEST, "id");
 
-    Assert.assertThat(harness.invoke(CALLER, "ping"), sentNothing());
-    Assert.assertThat(harness.getEgress(EGRESS), contains(equalTo("pong")));
+    assertThat(harness.invoke(CALLER, "ping"), sentNothing());
+    assertThat(harness.getEgress(EGRESS), contains(equalTo("pong")));
   }
 
   @Test
@@ -90,9 +90,8 @@ public class FunctionTestHarnessTest {
     FunctionTestHarness harness =
         FunctionTestHarness.test(ignore -> new DelayedResponse(), UNDER_TEST, "id");
 
-    Assert.assertThat(harness.invoke(CALLER, "ping"), sentNothing());
-    Assert.assertThat(
-        harness.tick(Duration.ofMinutes(1)), sent(messagesTo(CALLER, equalTo("pong"))));
+    assertThat(harness.invoke(CALLER, "ping"), sentNothing());
+    assertThat(harness.tick(Duration.ofMinutes(1)), sent(messagesTo(CALLER, equalTo("pong"))));
   }
 
   @Test
@@ -100,7 +99,7 @@ public class FunctionTestHarnessTest {
     FunctionTestHarness harness =
         FunctionTestHarness.test(ignore -> new AsyncOperation(), UNDER_TEST, "id");
 
-    Assert.assertThat(harness.invoke(CALLER, "ping"), sent(messagesTo(CALLER, equalTo("pong"))));
+    assertThat(harness.invoke(CALLER, "ping"), sent(messagesTo(CALLER, equalTo("pong"))));
   }
 
   private static class BasicFunction implements StatefulFunction {


### PR DESCRIPTION
## Summary
- Replace `junit:junit:4.13.2` with `org.junit.jupiter:junit-jupiter:5.11.4` across all modules
- Convert all JUnit 4 test annotations, assertions, and patterns to JUnit 5 equivalents
- Add explicit `hamcrest` dependency where needed (no longer transitive from JUnit 5)
- Convert `ExternalResource` to `BeforeAllCallback`/`AfterAllCallback`
- Convert parameterized tests from `@RunWith(Parameterized)` to `@ParameterizedTest`/`@MethodSource`

## Test plan
- [x] Full local build with all tests passes (`mvn clean install -B`)
- [x] K8s E2E tests pass locally
- [ ] CI pipeline passes