### PR TITLE
docs: align version references with RC7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,6 +101,8 @@ All notable changes to the Kzmlabs StateFun fork are documented in this file.
 - Add Docker image publishing to GitHub Container Registry
 - Add release setup guide and release script
 
+[3.4.0-KZM-2.0-RC7]: https://github.com/kzmlabs/flink-statefun/releases/tag/v3.4.0-KZM-2.0-RC7
+[3.4.0-KZM-2.0-RC6]: https://github.com/kzmlabs/flink-statefun/releases/tag/v3.4.0-KZM-2.0-RC6
 [3.4.0-KZM-2.0-RC5]: https://github.com/kzmlabs/flink-statefun/releases/tag/v3.4.0-KZM-2.0-RC5
 [3.4.0-KZM-2.0-RC4]: https://github.com/kzmlabs/flink-statefun/releases/tag/v3.4.0-KZM-2.0-RC4
 [3.4.0-KZM-2.0-RC3]: https://github.com/kzmlabs/flink-statefun/releases/tag/v3.4.0-KZM-2.0-RC3

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ The upstream Apache Flink StateFun project has been archived and is no longer ac
 <dependency>
     <groupId>io.github.kzmlabs.flinkstatefun</groupId>
     <artifactId>statefun-sdk-java</artifactId>
-    <version>3.4.0-KZM-2.0</version>
+    <version>3.4.0-KZM-2.0-RC7</version>
 </dependency>
 ```
 
@@ -87,7 +87,7 @@ A _module_ is the entry point for adding primitives (ingresses, egresses, router
 <dependency>
     <groupId>io.github.kzmlabs.flinkstatefun</groupId>
     <artifactId>statefun-sdk-java</artifactId>
-    <version>3.4.0-KZM-2.0</version>
+    <version>3.4.0-KZM-2.0-RC7</version>
 </dependency>
 ```
 
@@ -145,7 +145,7 @@ mvn install -DskipTests -B
 ./tools/docker/build-stateful-functions.sh
 ```
 
-For local development, the image will be tagged as `flink-statefun:3.4.0-KZM-2.0`.
+For local development, the image will be tagged as `flink-statefun:3.4.0-KZM-2.0-RC7`.
 
 Official releases are published to GitHub Container Registry: `ghcr.io/kzmlabs/flink-statefun:<version>`
 

--- a/RELEASE-GUIDE.md
+++ b/RELEASE-GUIDE.md
@@ -4,10 +4,10 @@
 
 This guide documents the release process for publishing to Maven Central and GitHub Container Registry (GHCR).
 
-## Current Release: 3.4.0-KZM-1.0-RC20
+## Current Release: 3.4.0-KZM-2.0-RC7
 
 - **Maven Central**: Published
-- **Docker Image**: `ghcr.io/kzmlabs/flink-statefun:3.4.0-KZM-1.0-RC20`
+- **Docker Image**: `ghcr.io/kzmlabs/flink-statefun:3.4.0-KZM-2.0-RC7`
 - **GitHub Release**: https://github.com/kzmlabs/flink-statefun/releases
 
 ---
@@ -20,14 +20,14 @@ Triggered automatically when pushing a tag starting with `v`:
 
 ```bash
 # Update version
-mvn versions:set -DnewVersion=3.4.0-KZM-1.0-RC21 -DgenerateBackupPoms=false
+mvn versions:set -DnewVersion=3.4.0-KZM-2.0-RC8 -DgenerateBackupPoms=false
 
 # Commit and tag
 git add -A
-git commit -m "Release 3.4.0-KZM-1.0-RC21"
+git commit -m "Release 3.4.0-KZM-2.0-RC8"
 git push origin release
-git tag v3.4.0-KZM-1.0-RC21
-git push origin v3.4.0-KZM-1.0-RC21
+git tag v3.4.0-KZM-2.0-RC8
+git push origin v3.4.0-KZM-2.0-RC8
 ```
 
 This runs `.github/workflows/release.yml` which:
@@ -196,5 +196,5 @@ mvn clean install -Prelease -DskipTests -Dgpg.skip=true
 gh run list --repo kzmlabs/flink-statefun
 
 # Pull Docker image
-docker pull ghcr.io/kzmlabs/flink-statefun:3.4.0-KZM-1.0-RC20
+docker pull ghcr.io/kzmlabs/flink-statefun:3.4.0-KZM-2.0-RC7
 ```

--- a/tools/docker/build-stateful-functions.sh
+++ b/tools/docker/build-stateful-functions.sh
@@ -17,7 +17,7 @@
 
 set -e
 
-VERSION_TAG=${1:-3.4.0-KZM-2.0-RC5}
+VERSION_TAG=${1:-3.4.0-KZM-2.0-RC7}
 
 #
 # setup the environment


### PR DESCRIPTION
## Summary

Cleans up stale version references in docs and the local Docker build script so everything points to the current `3.4.0-KZM-2.0-RC7` release.

- `README.md` — SDK coordinates and local image tag now show `-RC7` (were `3.4.0-KZM-2.0` with no RC suffix).
- `RELEASE-GUIDE.md` — current release pointer, example `mvn versions:set` / `git tag` commands, and `docker pull` example moved from the outdated `3.4.0-KZM-1.0-RC20` to `3.4.0-KZM-2.0-RC7` / `RC8`.
- `CHANGELOG.md` — added missing tag link refs for RC6 and RC7.
- `tools/docker/build-stateful-functions.sh` — `VERSION_TAG` default bumped from `RC5` to `RC7` for manual local builds (CI always passes the version explicitly).

No source code or pom changes; purely docs + one shell script default.

## Verification

- Full Maven build green locally: `mvn clean install -B -Drat.skip=false` (34 modules, K8s native E2E `StateFunK8sE2E` 3/3 passed).
- `grep -rn "KZM-1.0"` returns no hits outside git history.
- No changes to published artifacts.

## Test plan

- [x] `mvn clean install` succeeds with all tests including K8s E2E
- [x] `grep` confirms no `KZM-1.0` refs remain
- [x] README examples render correctly on GitHub
- [ ] Reviewer spot-check of diff