### PR TITLE
Release 3.4.0-KZM-2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to the Kzmlabs StateFun fork are documented in this file.
 
+## [3.4.0-KZM-2.0] - 2026-04-23
+
+First stable release of the KZM-2.0 line, promoting RC7 after successful Maven Central and GHCR validation, Kubernetes native E2E testing, and dependency/plugin modernization completed across RC1–RC7.
+
+### Highlights (cumulative since 3.4.0-KZM-1.0)
+
+- **Flink 2.2.0 + Java 21** baseline with `io.github.kzmlabs.flinkstatefun` groupId
+- **Kubernetes native E2E test suite** with Flink K8s Operator 1.11 (Kafka, MinIO, RocksDB checkpointing) — mandatory release gate
+- **JUnit Jupiter 5.11.4** migration across all modules
+- **Maven Central** publishing with Sonatype central-publishing-maven-plugin 0.10.0
+- **GHCR Docker image** (`ghcr.io/kzmlabs/flink-statefun`) — `latest` tag now published for stable releases
+- **Dependency modernization**: Kafka clients 3.9.1, OkHttp 4.12.0, Testcontainers 2.0.3, Hamcrest 3.0, Protobuf 3.25.5, commons-lang3 3.20.0, commons-compress 1.28.0
+- **Plugin modernization**: maven-compiler 3.13.0, maven-shade 3.6.1, surefire/failsafe 3.5.5, enforcer 3.6.2, rat 0.17, javadoc 3.12.0, gpg 3.2.8
+- **statefun-bom** module for centralized dependency management
+- **statefun-flink-runner** uber-JAR module with K8s-ready Docker image
+
 ## [3.4.0-KZM-2.0-RC7] - 2025-02-25
 
 ### Testing
@@ -101,6 +117,7 @@ All notable changes to the Kzmlabs StateFun fork are documented in this file.
 - Add Docker image publishing to GitHub Container Registry
 - Add release setup guide and release script
 
+[3.4.0-KZM-2.0]: https://github.com/kzmlabs/flink-statefun/releases/tag/v3.4.0-KZM-2.0
 [3.4.0-KZM-2.0-RC7]: https://github.com/kzmlabs/flink-statefun/releases/tag/v3.4.0-KZM-2.0-RC7
 [3.4.0-KZM-2.0-RC6]: https://github.com/kzmlabs/flink-statefun/releases/tag/v3.4.0-KZM-2.0-RC6
 [3.4.0-KZM-2.0-RC5]: https://github.com/kzmlabs/flink-statefun/releases/tag/v3.4.0-KZM-2.0-RC5

--- a/README.md
+++ b/README.md
@@ -4,16 +4,19 @@
 [![Maven Central](https://img.shields.io/maven-central/v/io.github.kzmlabs.flinkstatefun/statefun-sdk-java.svg)](https://search.maven.org/search?q=g:io.github.kzmlabs.flinkstatefun)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
 
-A fork of [Apache Flink Stateful Functions](https://github.com/apache/flink-statefun) updated for **Flink 2.2.0** and **Java 21**, published to Maven Central under the `io.github.kzmlabs.flinkstatefun` group ID.
+An actively maintained continuation of Stateful Functions updated for **Flink 2.2.0** and **Java 21**, published to Maven Central under the `io.github.kzmlabs.flinkstatefun` group ID.
 
-## Why This Fork?
+> Originally based on [Apache Flink Stateful Functions](https://github.com/apache/flink-statefun), which has been archived upstream. This project is now independently maintained by Kzmlabs.
 
-The upstream Apache Flink StateFun project has been archived and is no longer actively maintained. This fork:
+## Why This Project?
 
-- **Updates to Flink 2.2.0** - The latest stable Flink release
-- **Requires Java 21** - Modern Java runtime with improved performance
-- **Published to Maven Central** - Easy dependency management via `io.github.kzmlabs.flinkstatefun` coordinates
-- **Maintains compatibility** - Same API as Apache StateFun 3.3.x
+The upstream Apache Flink StateFun project has been archived and is no longer actively maintained. Kzmlabs Flink StateFun picks up where it left off:
+
+- **Updates to Flink 2.2.0** — The latest stable Flink release
+- **Requires Java 21** — Modern Java runtime with improved performance
+- **Published to Maven Central** — Easy dependency management via `io.github.kzmlabs.flinkstatefun` coordinates
+- **Maintains compatibility** — Same API as Apache StateFun 3.3.x
+- **Kubernetes-native** — Release-gated K8s E2E test suite running on the Flink Kubernetes Operator
 
 ## Quick Start
 
@@ -23,7 +26,7 @@ The upstream Apache Flink StateFun project has been archived and is no longer ac
 <dependency>
     <groupId>io.github.kzmlabs.flinkstatefun</groupId>
     <artifactId>statefun-sdk-java</artifactId>
-    <version>3.4.0-KZM-2.0-RC7</version>
+    <version>3.4.0-KZM-2.0</version>
 </dependency>
 ```
 
@@ -47,7 +50,7 @@ Stateful Functions is an API that simplifies building **distributed stateful app
 - [Getting Started](#getting-started)
 - [Building from Source](#building-from-source)
 - [Module Structure](#module-structure)
-- [Differences from Upstream](#differences-from-upstream)
+- [Differences from Apache StateFun](#differences-from-apache-statefun)
 - [Contributing](#contributing)
 - [License](#license)
 
@@ -87,7 +90,7 @@ A _module_ is the entry point for adding primitives (ingresses, egresses, router
 <dependency>
     <groupId>io.github.kzmlabs.flinkstatefun</groupId>
     <artifactId>statefun-sdk-java</artifactId>
-    <version>3.4.0-KZM-2.0-RC7</version>
+    <version>3.4.0-KZM-2.0</version>
 </dependency>
 ```
 
@@ -145,7 +148,7 @@ mvn install -DskipTests -B
 ./tools/docker/build-stateful-functions.sh
 ```
 
-For local development, the image will be tagged as `flink-statefun:3.4.0-KZM-2.0-RC7`.
+For local development, the image will be tagged as `flink-statefun:3.4.0-KZM-2.0`.
 
 Official releases are published to GitHub Container Registry: `ghcr.io/kzmlabs/flink-statefun:<version>`
 
@@ -221,10 +224,10 @@ docker logs statefun-remote-function
 | `statefun-flink-runner` | Uber JAR for K8s deployment via Flink Operator |
 | `statefun-k8s-native-e2e` | Kubernetes end-to-end tests |
 
-## Differences from Upstream
+## Differences from Apache StateFun
 
-| Feature | Apache StateFun | Kzmlabs Fork |
-|---------|-----------------|--------------|
+| Feature | Apache StateFun | Kzmlabs StateFun |
+|---------|-----------------|------------------|
 | Flink Version | 1.16.x | 2.2.0 |
 | Java Version | 8/11 | 21 |
 | Maven Group ID | `org.apache.flink` | `io.github.kzmlabs.flinkstatefun` |
@@ -251,8 +254,8 @@ classloader:
 
 ## Branch Strategy
 
-- **`master`** - Synced with upstream Apache (read-only)
-- **`release`** - Main development branch for this fork
+- **`master`** — Historical snapshot of the original Apache Flink StateFun source (read-only)
+- **`release`** — Main development branch
 
 ## Contributing
 
@@ -268,6 +271,6 @@ This project is licensed under the [Apache License 2.0](LICENSE).
 
 ---
 
-**Original Project:** [Apache Flink Stateful Functions](https://github.com/apache/flink-statefun)
+**Upstream (archived):** [Apache Flink Stateful Functions](https://github.com/apache/flink-statefun)
 
 **Maintained by:** [Kzmlabs](https://github.com/kzmlabs)

--- a/RELEASE-GUIDE.md
+++ b/RELEASE-GUIDE.md
@@ -4,10 +4,10 @@
 
 This guide documents the release process for publishing to Maven Central and GitHub Container Registry (GHCR).
 
-## Current Release: 3.4.0-KZM-2.0-RC7
+## Current Release: 3.4.0-KZM-2.0
 
 - **Maven Central**: Published
-- **Docker Image**: `ghcr.io/kzmlabs/flink-statefun:3.4.0-KZM-2.0-RC7`
+- **Docker Image**: `ghcr.io/kzmlabs/flink-statefun:3.4.0-KZM-2.0`
 - **GitHub Release**: https://github.com/kzmlabs/flink-statefun/releases
 
 ---
@@ -196,5 +196,5 @@ mvn clean install -Prelease -DskipTests -Dgpg.skip=true
 gh run list --repo kzmlabs/flink-statefun
 
 # Pull Docker image
-docker pull ghcr.io/kzmlabs/flink-statefun:3.4.0-KZM-2.0-RC7
+docker pull ghcr.io/kzmlabs/flink-statefun:3.4.0-KZM-2.0
 ```

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@ under the License.
     <groupId>io.github.kzmlabs.flinkstatefun</groupId>
     <artifactId>statefun-parent</artifactId>
     <name>Kzmlabs StateFun Parent</name>
-    <version>3.4.0-KZM-2.0-RC7</version>
+    <version>3.4.0-KZM-2.0</version>
     <packaging>pom</packaging>
     <description>Kzmlabs fork of Apache Flink Stateful Functions</description>
 

--- a/statefun-bom/pom.xml
+++ b/statefun-bom/pom.xml
@@ -23,7 +23,7 @@ under the License.
     <parent>
         <groupId>io.github.kzmlabs.flinkstatefun</groupId>
         <artifactId>statefun-parent</artifactId>
-        <version>3.4.0-KZM-2.0-RC7</version>
+        <version>3.4.0-KZM-2.0</version>
     </parent>
 
     <artifactId>statefun-bom</artifactId>

--- a/statefun-e2e-tests/pom.xml
+++ b/statefun-e2e-tests/pom.xml
@@ -21,7 +21,7 @@ under the License.
     <parent>
         <artifactId>statefun-parent</artifactId>
         <groupId>io.github.kzmlabs.flinkstatefun</groupId>
-        <version>3.4.0-KZM-2.0-RC7</version>
+        <version>3.4.0-KZM-2.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/statefun-e2e-tests/statefun-e2e-tests-common/pom.xml
+++ b/statefun-e2e-tests/statefun-e2e-tests-common/pom.xml
@@ -21,7 +21,7 @@ under the License.
     <parent>
         <artifactId>statefun-e2e-tests</artifactId>
         <groupId>io.github.kzmlabs.flinkstatefun</groupId>
-        <version>3.4.0-KZM-2.0-RC7</version>
+        <version>3.4.0-KZM-2.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/statefun-e2e-tests/statefun-smoke-e2e-common/pom.xml
+++ b/statefun-e2e-tests/statefun-smoke-e2e-common/pom.xml
@@ -21,7 +21,7 @@ under the License.
     <parent>
         <artifactId>statefun-e2e-tests</artifactId>
         <groupId>io.github.kzmlabs.flinkstatefun</groupId>
-        <version>3.4.0-KZM-2.0-RC7</version>
+        <version>3.4.0-KZM-2.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/statefun-e2e-tests/statefun-smoke-e2e-driver/pom.xml
+++ b/statefun-e2e-tests/statefun-smoke-e2e-driver/pom.xml
@@ -21,7 +21,7 @@ under the License.
     <parent>
         <artifactId>statefun-e2e-tests</artifactId>
         <groupId>io.github.kzmlabs.flinkstatefun</groupId>
-        <version>3.4.0-KZM-2.0-RC7</version>
+        <version>3.4.0-KZM-2.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/statefun-e2e-tests/statefun-smoke-e2e-embedded/pom.xml
+++ b/statefun-e2e-tests/statefun-smoke-e2e-embedded/pom.xml
@@ -21,7 +21,7 @@ under the License.
     <parent>
         <artifactId>statefun-e2e-tests</artifactId>
         <groupId>io.github.kzmlabs.flinkstatefun</groupId>
-        <version>3.4.0-KZM-2.0-RC7</version>
+        <version>3.4.0-KZM-2.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -61,7 +61,7 @@ under the License.
         <dependency>
             <groupId>io.github.kzmlabs.flinkstatefun</groupId>
             <artifactId>statefun-smoke-e2e-driver</artifactId>
-            <version>3.4.0-KZM-2.0-RC7</version>
+            <version>3.4.0-KZM-2.0</version>
         </dependency>
     </dependencies>
 

--- a/statefun-e2e-tests/statefun-smoke-e2e-golang/pom.xml
+++ b/statefun-e2e-tests/statefun-smoke-e2e-golang/pom.xml
@@ -21,7 +21,7 @@ under the License.
     <parent>
         <groupId>io.github.kzmlabs.flinkstatefun</groupId>
         <artifactId>statefun-smoke-e2e-multilang-base</artifactId>
-        <version>3.4.0-KZM-2.0-RC7</version>
+        <version>3.4.0-KZM-2.0</version>
         <relativePath>../statefun-smoke-e2e-multilang-base/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/statefun-e2e-tests/statefun-smoke-e2e-java/pom.xml
+++ b/statefun-e2e-tests/statefun-smoke-e2e-java/pom.xml
@@ -21,7 +21,7 @@ under the License.
     <parent>
         <groupId>io.github.kzmlabs.flinkstatefun</groupId>
         <artifactId>statefun-smoke-e2e-multilang-base</artifactId>
-        <version>3.4.0-KZM-2.0-RC7</version>
+        <version>3.4.0-KZM-2.0</version>
         <relativePath>../statefun-smoke-e2e-multilang-base/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/statefun-e2e-tests/statefun-smoke-e2e-js/pom.xml
+++ b/statefun-e2e-tests/statefun-smoke-e2e-js/pom.xml
@@ -21,7 +21,7 @@ under the License.
     <parent>
         <groupId>io.github.kzmlabs.flinkstatefun</groupId>
         <artifactId>statefun-smoke-e2e-multilang-base</artifactId>
-        <version>3.4.0-KZM-2.0-RC7</version>
+        <version>3.4.0-KZM-2.0</version>
         <relativePath>../statefun-smoke-e2e-multilang-base/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/statefun-e2e-tests/statefun-smoke-e2e-multilang-base/pom.xml
+++ b/statefun-e2e-tests/statefun-smoke-e2e-multilang-base/pom.xml
@@ -21,7 +21,7 @@ under the License.
     <parent>
         <artifactId>statefun-e2e-tests</artifactId>
         <groupId>io.github.kzmlabs.flinkstatefun</groupId>
-        <version>3.4.0-KZM-2.0-RC7</version>
+        <version>3.4.0-KZM-2.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/statefun-e2e-tests/statefun-smoke-e2e-multilang-harness/pom.xml
+++ b/statefun-e2e-tests/statefun-smoke-e2e-multilang-harness/pom.xml
@@ -21,7 +21,7 @@ under the License.
     <parent>
         <artifactId>statefun-e2e-tests</artifactId>
         <groupId>io.github.kzmlabs.flinkstatefun</groupId>
-        <version>3.4.0-KZM-2.0-RC7</version>
+        <version>3.4.0-KZM-2.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -50,7 +50,7 @@ under the License.
         <dependency>
             <groupId>io.github.kzmlabs.flinkstatefun</groupId>
             <artifactId>statefun-smoke-e2e-driver</artifactId>
-            <version>3.4.0-KZM-2.0-RC7</version>
+            <version>3.4.0-KZM-2.0</version>
         </dependency>
 
         <!-- Test scope dependencies -->

--- a/statefun-flink-runner/pom.xml
+++ b/statefun-flink-runner/pom.xml
@@ -23,7 +23,7 @@ under the License.
     <parent>
         <groupId>io.github.kzmlabs.flinkstatefun</groupId>
         <artifactId>statefun-parent</artifactId>
-        <version>3.4.0-KZM-2.0-RC7</version>
+        <version>3.4.0-KZM-2.0</version>
     </parent>
 
     <artifactId>statefun-flink-runner</artifactId>

--- a/statefun-flink/pom.xml
+++ b/statefun-flink/pom.xml
@@ -22,7 +22,7 @@ under the License.
     <parent>
         <artifactId>statefun-parent</artifactId>
         <groupId>io.github.kzmlabs.flinkstatefun</groupId>
-        <version>3.4.0-KZM-2.0-RC7</version>
+        <version>3.4.0-KZM-2.0</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/statefun-flink/statefun-flink-common/pom.xml
+++ b/statefun-flink/statefun-flink-common/pom.xml
@@ -23,7 +23,7 @@ under the License.
     <parent>
         <groupId>io.github.kzmlabs.flinkstatefun</groupId>
         <artifactId>statefun-flink</artifactId>
-        <version>3.4.0-KZM-2.0-RC7</version>
+        <version>3.4.0-KZM-2.0</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/statefun-flink/statefun-flink-core/pom.xml
+++ b/statefun-flink/statefun-flink-core/pom.xml
@@ -23,7 +23,7 @@ under the License.
     <parent>
         <groupId>io.github.kzmlabs.flinkstatefun</groupId>
         <artifactId>statefun-flink</artifactId>
-        <version>3.4.0-KZM-2.0-RC7</version>
+        <version>3.4.0-KZM-2.0</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/statefun-flink/statefun-flink-datastream/pom.xml
+++ b/statefun-flink/statefun-flink-datastream/pom.xml
@@ -23,7 +23,7 @@ under the License.
     <parent>
         <groupId>io.github.kzmlabs.flinkstatefun</groupId>
         <artifactId>statefun-flink</artifactId>
-        <version>3.4.0-KZM-2.0-RC7</version>
+        <version>3.4.0-KZM-2.0</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/statefun-flink/statefun-flink-distribution/pom.xml
+++ b/statefun-flink/statefun-flink-distribution/pom.xml
@@ -23,7 +23,7 @@ under the License.
     <parent>
         <groupId>io.github.kzmlabs.flinkstatefun</groupId>
         <artifactId>statefun-flink</artifactId>
-        <version>3.4.0-KZM-2.0-RC7</version>
+        <version>3.4.0-KZM-2.0</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/statefun-flink/statefun-flink-extensions/pom.xml
+++ b/statefun-flink/statefun-flink-extensions/pom.xml
@@ -23,7 +23,7 @@ under the License.
     <parent>
         <groupId>io.github.kzmlabs.flinkstatefun</groupId>
         <artifactId>statefun-flink</artifactId>
-        <version>3.4.0-KZM-2.0-RC7</version>
+        <version>3.4.0-KZM-2.0</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/statefun-flink/statefun-flink-harness/pom.xml
+++ b/statefun-flink/statefun-flink-harness/pom.xml
@@ -23,7 +23,7 @@ under the License.
     <parent>
         <groupId>io.github.kzmlabs.flinkstatefun</groupId>
         <artifactId>statefun-flink</artifactId>
-        <version>3.4.0-KZM-2.0-RC7</version>
+        <version>3.4.0-KZM-2.0</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/statefun-flink/statefun-flink-io-bundle/pom.xml
+++ b/statefun-flink/statefun-flink-io-bundle/pom.xml
@@ -23,7 +23,7 @@ under the License.
     <parent>
         <groupId>io.github.kzmlabs.flinkstatefun</groupId>
         <artifactId>statefun-flink</artifactId>
-        <version>3.4.0-KZM-2.0-RC7</version>
+        <version>3.4.0-KZM-2.0</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/statefun-flink/statefun-flink-io/pom.xml
+++ b/statefun-flink/statefun-flink-io/pom.xml
@@ -23,7 +23,7 @@ under the License.
     <parent>
         <groupId>io.github.kzmlabs.flinkstatefun</groupId>
         <artifactId>statefun-flink</artifactId>
-        <version>3.4.0-KZM-2.0-RC7</version>
+        <version>3.4.0-KZM-2.0</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/statefun-flink/statefun-flink-launcher/pom.xml
+++ b/statefun-flink/statefun-flink-launcher/pom.xml
@@ -23,7 +23,7 @@ under the License.
     <parent>
         <groupId>io.github.kzmlabs.flinkstatefun</groupId>
         <artifactId>statefun-flink</artifactId>
-        <version>3.4.0-KZM-2.0-RC7</version>
+        <version>3.4.0-KZM-2.0</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/statefun-flink/statefun-flink-state-processor/pom.xml
+++ b/statefun-flink/statefun-flink-state-processor/pom.xml
@@ -21,7 +21,7 @@ under the License.
     <parent>
         <artifactId>statefun-flink</artifactId>
         <groupId>io.github.kzmlabs.flinkstatefun</groupId>
-        <version>3.4.0-KZM-2.0-RC7</version>
+        <version>3.4.0-KZM-2.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/statefun-k8s-native-e2e/pom.xml
+++ b/statefun-k8s-native-e2e/pom.xml
@@ -21,7 +21,7 @@ under the License.
     <parent>
         <artifactId>statefun-parent</artifactId>
         <groupId>io.github.kzmlabs.flinkstatefun</groupId>
-        <version>3.4.0-KZM-2.0-RC7</version>
+        <version>3.4.0-KZM-2.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/statefun-kafka-io/pom.xml
+++ b/statefun-kafka-io/pom.xml
@@ -21,7 +21,7 @@ under the License.
     <parent>
         <artifactId>statefun-parent</artifactId>
         <groupId>io.github.kzmlabs.flinkstatefun</groupId>
-        <version>3.4.0-KZM-2.0-RC7</version>
+        <version>3.4.0-KZM-2.0</version>
         <relativePath>..</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/statefun-kinesis-io/pom.xml
+++ b/statefun-kinesis-io/pom.xml
@@ -21,7 +21,7 @@ under the License.
     <parent>
         <artifactId>statefun-parent</artifactId>
         <groupId>io.github.kzmlabs.flinkstatefun</groupId>
-        <version>3.4.0-KZM-2.0-RC7</version>
+        <version>3.4.0-KZM-2.0</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/statefun-sdk-embedded/pom.xml
+++ b/statefun-sdk-embedded/pom.xml
@@ -21,7 +21,7 @@ under the License.
     <parent>
         <artifactId>statefun-parent</artifactId>
         <groupId>io.github.kzmlabs.flinkstatefun</groupId>
-        <version>3.4.0-KZM-2.0-RC7</version>
+        <version>3.4.0-KZM-2.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/statefun-sdk-java/pom.xml
+++ b/statefun-sdk-java/pom.xml
@@ -21,7 +21,7 @@ under the License.
     <parent>
         <artifactId>statefun-parent</artifactId>
         <groupId>io.github.kzmlabs.flinkstatefun</groupId>
-        <version>3.4.0-KZM-2.0-RC7</version>
+        <version>3.4.0-KZM-2.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>statefun-sdk-java</artifactId>

--- a/statefun-sdk-protos/pom.xml
+++ b/statefun-sdk-protos/pom.xml
@@ -21,7 +21,7 @@ under the License.
     <parent>
         <artifactId>statefun-parent</artifactId>
         <groupId>io.github.kzmlabs.flinkstatefun</groupId>
-        <version>3.4.0-KZM-2.0-RC7</version>
+        <version>3.4.0-KZM-2.0</version>
         <relativePath>..</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/statefun-shaded/pom.xml
+++ b/statefun-shaded/pom.xml
@@ -23,7 +23,7 @@ under the License.
     <parent>
         <artifactId>statefun-parent</artifactId>
         <groupId>io.github.kzmlabs.flinkstatefun</groupId>
-        <version>3.4.0-KZM-2.0-RC7</version>
+        <version>3.4.0-KZM-2.0</version>
     </parent>
 
     <artifactId>statefun-shaded</artifactId>

--- a/statefun-shaded/statefun-protobuf-shaded/pom.xml
+++ b/statefun-shaded/statefun-protobuf-shaded/pom.xml
@@ -23,7 +23,7 @@ under the License.
     <parent>
         <artifactId>statefun-shaded</artifactId>
         <groupId>io.github.kzmlabs.flinkstatefun</groupId>
-        <version>3.4.0-KZM-2.0-RC7</version>
+        <version>3.4.0-KZM-2.0</version>
     </parent>
 
     <artifactId>statefun-protobuf-shaded</artifactId>

--- a/statefun-shaded/statefun-protocol-shaded/pom.xml
+++ b/statefun-shaded/statefun-protocol-shaded/pom.xml
@@ -23,7 +23,7 @@ under the License.
     <parent>
         <artifactId>statefun-shaded</artifactId>
         <groupId>io.github.kzmlabs.flinkstatefun</groupId>
-        <version>3.4.0-KZM-2.0-RC7</version>
+        <version>3.4.0-KZM-2.0</version>
     </parent>
 
     <artifactId>statefun-protocol-shaded</artifactId>

--- a/statefun-testutil/pom.xml
+++ b/statefun-testutil/pom.xml
@@ -21,7 +21,7 @@ under the License.
     <parent>
         <artifactId>statefun-parent</artifactId>
         <groupId>io.github.kzmlabs.flinkstatefun</groupId>
-        <version>3.4.0-KZM-2.0-RC7</version>
+        <version>3.4.0-KZM-2.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/tools/docker/build-stateful-functions.sh
+++ b/tools/docker/build-stateful-functions.sh
@@ -17,7 +17,7 @@
 
 set -e
 
-VERSION_TAG=${1:-3.4.0-KZM-2.0-RC7}
+VERSION_TAG=${1:-3.4.0-KZM-2.0}
 
 #
 # setup the environment


### PR DESCRIPTION
## Summary

First stable release of the **KZM-2.0** line, promoting RC7 after full validation.

- Bump pom version `3.4.0-KZM-2.0-RC7` → `3.4.0-KZM-2.0` across all 34 modules
- Reframe `README.md` as actively maintained continuation (repository detached from Apache fork network on GitHub)
- Update `RELEASE-GUIDE.md`, `CHANGELOG.md` to point to `3.4.0-KZM-2.0` as the current release; add cumulative highlights entry in CHANGELOG
- Bump `tools/docker/build-stateful-functions.sh` `VERSION_TAG` default

## Validation

- Full `mvn clean install -B -Drat.skip=false` on RC7 (last commit of RC7) — **BUILD SUCCESS**, 34 modules, K8s native E2E `StateFunK8sE2E` 3/3 passed in 64s.
- Compile-only verification on this branch post version bump — **BUILD SUCCESS**.

## Post-merge steps

Once merged, tag `v3.4.0-KZM-2.0` on `release` to trigger the release pipeline:

- Maven Central publish via Sonatype Central Publishing 0.10.0
- GHCR push (`ghcr.io/kzmlabs/flink-statefun:3.4.0-KZM-2.0` + `:latest` — stable release)
- GitHub Release creation

## Test plan

- [x] Pom version consistent across all 34 modules
- [x] No `-RC` suffix references remain in docs or scripts
- [x] CHANGELOG has stable entry with cumulative highlights
- [x] README no longer frames project as a fork
- [ ] CI green (Build & Test + K8s E2E)
- [ ] Post-merge: tag `v3.4.0-KZM-2.0` triggers release pipeline