### PR TITLE
docs: discoverability + community health files

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,59 @@
+name: Bug Report
+description: Report a problem with Kzmlabs Flink StateFun
+labels: ["bug", "triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to file a bug report. Please fill out as much of the form as you can.
+  - type: input
+    id: version
+    attributes:
+      label: StateFun version
+      description: Which version of `io.github.kzmlabs.flinkstatefun` are you using?
+      placeholder: "3.4.0-KZM-2.0"
+    validations:
+      required: true
+  - type: input
+    id: flink
+    attributes:
+      label: Flink version
+      placeholder: "2.2.0"
+    validations:
+      required: true
+  - type: input
+    id: java
+    attributes:
+      label: Java version
+      placeholder: "21"
+    validations:
+      required: true
+  - type: input
+    id: os
+    attributes:
+      label: OS / architecture
+      placeholder: "Linux x86_64, Kubernetes 1.29"
+    validations:
+      required: false
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: Describe the actual behavior and what you expected instead.
+    validations:
+      required: true
+  - type: textarea
+    id: reproducer
+    attributes:
+      label: Minimal reproducer
+      description: Code, configuration, or steps needed to reproduce.
+      render: text
+    validations:
+      required: false
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs / stack trace
+      render: shell
+    validations:
+      required: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,18 @@
+## Summary
+
+<!-- What does this PR do and why? 1–3 bullets. -->
+
+## Changes
+
+<!-- Brief list of user-visible changes. -->
+
+## Test plan
+
+- [ ] `mvn spotless:apply` clean
+- [ ] `mvn install -Dskip.k8s.e2e -B` passes
+- [ ] New or updated tests cover the change
+- [ ] K8s E2E run (if touching runtime/runner): `mvn verify -pl statefun-k8s-native-e2e`
+
+## Related issues
+
+<!-- Fixes #123, Refs #456 -->

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,24 @@
+cff-version: 1.2.0
+message: "If you use Kzmlabs Flink StateFun in your research or production work, please cite it."
+title: "Kzmlabs Flink StateFun"
+abstract: "Actively maintained continuation of the Stateful Functions framework for building distributed stateful applications and event-driven microservices on Apache Flink 2.2.0 with Java 21. Function-as-actor programming model with durable state, exactly-once messaging, Kafka and Kinesis ingress/egress, and Kubernetes-native deployment via the Flink Kubernetes Operator."
+type: software
+authors:
+  - name: "Kzmlabs"
+    website: "https://github.com/kzmlabs"
+repository-code: "https://github.com/kzmlabs/flink-statefun"
+url: "https://github.com/kzmlabs/flink-statefun"
+license: Apache-2.0
+version: "3.4.0-KZM-2.0"
+date-released: "2026-04-23"
+keywords:
+  - apache-flink
+  - stateful-functions
+  - statefun
+  - stream-processing
+  - event-driven-architecture
+  - distributed-systems
+  - actor-model
+  - kubernetes
+  - kafka
+  - java

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,73 @@
+# Contributing to Kzmlabs Flink StateFun
+
+Thanks for your interest in contributing! This project is an actively maintained continuation of the Stateful Functions framework, updated for Flink 2.2.0 and Java 21.
+
+## Ways to Contribute
+
+- **Report bugs** — Open an issue with a minimal reproducer, Flink/Java versions, and stack trace
+- **Request features** — Open an issue describing the use case and desired behavior
+- **Submit pull requests** — Bug fixes, new ingress/egress connectors, documentation, tests
+- **Improve documentation** — README, inline Javadoc, examples
+- **Answer questions** — Help others in issues and discussions
+
+## Development Setup
+
+### Prerequisites
+
+- Java 21 (`JAVA_HOME` set)
+- Maven 3.5+
+- Docker (for K8s E2E tests)
+
+### Build
+
+```bash
+# Full build with all tests (including K8s E2E)
+mvn install -B
+
+# Skip K8s E2E for faster iteration
+mvn install -Dskip.k8s.e2e -B
+
+# Skip all tests
+mvn install -DskipTests -B
+```
+
+### Code Style
+
+Google Java Format (2-space indent) is enforced by `spotless-maven-plugin`. Before committing:
+
+```bash
+mvn spotless:apply
+```
+
+CI will fail builds that do not conform.
+
+## Pull Request Process
+
+1. Fork the repository and create a feature branch from `release`
+2. Make focused, well-scoped commits with clear messages
+3. Add or update tests for behavior changes (JUnit Jupiter 5.11)
+4. Run `mvn spotless:apply` before committing
+5. Ensure `mvn install -Dskip.k8s.e2e -B` passes locally
+6. Open a PR against the `release` branch
+7. A maintainer will review; CI must pass before merge
+
+### Commit Messages
+
+- Use imperative mood ("Add Kafka headers support", not "Added")
+- First line ≤ 72 characters
+- Reference issue numbers where relevant (`Fixes #123`)
+
+## Reporting Bugs
+
+Include:
+
+- Kzmlabs StateFun version
+- Flink version (should be 2.2.x)
+- Java version (should be 21)
+- OS and architecture
+- Minimal reproducer (code + config)
+- Full stack trace and relevant logs
+
+## License
+
+By contributing, you agree your contributions will be licensed under the [Apache License 2.0](LICENSE).

--- a/README.md
+++ b/README.md
@@ -4,19 +4,22 @@
 [![Maven Central](https://img.shields.io/maven-central/v/io.github.kzmlabs.flinkstatefun/statefun-sdk-java.svg)](https://search.maven.org/search?q=g:io.github.kzmlabs.flinkstatefun)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
 
-An actively maintained continuation of Stateful Functions updated for **Flink 2.2.0** and **Java 21**, published to Maven Central under the `io.github.kzmlabs.flinkstatefun` group ID.
+A continuation of **Stateful Functions** — a framework for building **distributed stateful applications** and **event-driven microservices** on Apache Flink — updated for **Flink 2.2.0** and **Java 21**, published to Maven Central under the `io.github.kzmlabs.flinkstatefun` group ID.
 
-> Originally based on [Apache Flink Stateful Functions](https://github.com/apache/flink-statefun), which has been archived upstream. This project is now independently maintained by Kzmlabs.
+> Based on [Apache Flink Stateful Functions](https://github.com/apache/flink-statefun), whose upstream development has slowed significantly. Kzmlabs StateFun is an independent continuation with active releases, Flink 2.x compatibility, and a Kubernetes-native release gate.
+
+**Use cases:** event-driven microservices, real-time fraud detection, IoT digital twins, payment orchestration, actor-style stateful compute, serverless stream processing.
 
 ## Why This Project?
 
-The upstream Apache Flink StateFun project has been archived and is no longer actively maintained. Kzmlabs Flink StateFun picks up where it left off:
+Kzmlabs Flink StateFun advances the original StateFun codebase with:
 
-- **Updates to Flink 2.2.0** — The latest stable Flink release
-- **Requires Java 21** — Modern Java runtime with improved performance
-- **Published to Maven Central** — Easy dependency management via `io.github.kzmlabs.flinkstatefun` coordinates
-- **Maintains compatibility** — Same API as Apache StateFun 3.3.x
-- **Kubernetes-native** — Release-gated K8s E2E test suite running on the Flink Kubernetes Operator
+- **Flink 2.2.0** — Built and tested against the current Flink major release
+- **Java 21** — Modern LTS runtime with improved performance and virtual threads
+- **Maven Central** — Drop-in dependency via `io.github.kzmlabs.flinkstatefun` coordinates; BOM available (`statefun-bom`)
+- **API compatible** — Same SDK surface as Apache StateFun 3.3.x — minimal migration cost
+- **Kubernetes-native** — Release-gated K8s E2E test suite exercising the Flink Kubernetes Operator, Kafka ingress/egress, and RocksDB checkpoints on S3-compatible storage
+- **Active releases** — Versioned tags, SemVer-aligned, published to Maven Central and GHCR
 
 ## Quick Start
 
@@ -222,6 +225,8 @@ docker logs statefun-remote-function
 | `statefun-kafka-io` | Kafka ingress/egress connectors |
 | `statefun-flink-harness` | Local testing harness |
 | `statefun-flink-runner` | Uber JAR for K8s deployment via Flink Operator |
+| `statefun-kinesis-io` | AWS Kinesis ingress/egress connectors |
+| `statefun-bom` | Bill of Materials for dependency version alignment |
 | `statefun-k8s-native-e2e` | Kubernetes end-to-end tests |
 
 ## Differences from Apache StateFun
@@ -231,8 +236,9 @@ docker logs statefun-remote-function
 | Flink Version | 1.16.x | 2.2.0 |
 | Java Version | 8/11 | 21 |
 | Maven Group ID | `org.apache.flink` | `io.github.kzmlabs.flinkstatefun` |
-| Kinesis Connector | Included | Removed (separate repo in Flink 2.x) |
-| Status | Archived | Actively maintained |
+| Test framework | JUnit 4 | JUnit Jupiter 5.11 |
+| K8s E2E gate | None | Release-blocking (kind + Flink Operator) |
+| Release cadence | Dormant | Active (Maven Central + GHCR) |
 
 ### Configuration Changes for Flink 2.x
 
@@ -271,6 +277,16 @@ This project is licensed under the [Apache License 2.0](LICENSE).
 
 ---
 
-**Upstream (archived):** [Apache Flink Stateful Functions](https://github.com/apache/flink-statefun)
+## Links
+
+- **Maven Central:** [io.github.kzmlabs.flinkstatefun](https://central.sonatype.com/namespace/io.github.kzmlabs.flinkstatefun)
+- **Container images:** [ghcr.io/kzmlabs/flink-statefun](https://github.com/kzmlabs/flink-statefun/pkgs/container/flink-statefun)
+- **Upstream project:** [Apache Flink Stateful Functions](https://github.com/apache/flink-statefun)
+- **Apache Flink:** [flink.apache.org](https://flink.apache.org/)
+- **StateFun Playground examples:** [flink-statefun-playground](https://github.com/apache/flink-statefun-playground)
+
+## Keywords
+
+Apache Flink, Stateful Functions, StateFun, stream processing, event-driven architecture, event-driven microservices, distributed systems, actor model, stateful serverless, Kubernetes, Flink Kubernetes Operator, Kafka, RocksDB, Java 21, JVM stream processing, real-time analytics.
 
 **Maintained by:** [Kzmlabs](https://github.com/kzmlabs)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,39 @@
+# Security Policy
+
+## Supported Versions
+
+The latest `3.4.x-KZM-2.x` release line receives security fixes. Older versions are not maintained.
+
+| Version        | Supported |
+| -------------- | --------- |
+| 3.4.0-KZM-2.x  | Yes       |
+| earlier        | No        |
+
+## Reporting a Vulnerability
+
+**Please do not open public GitHub issues for security vulnerabilities.**
+
+Report suspected vulnerabilities privately via GitHub's [security advisory form](https://github.com/kzmlabs/flink-statefun/security/advisories/new).
+
+Include:
+
+- A description of the vulnerability and its impact
+- Affected versions
+- Steps to reproduce (proof of concept if possible)
+- Any mitigations you have identified
+
+You can expect an acknowledgement within 7 days. A fix target date will be shared after the initial triage.
+
+## Disclosure Policy
+
+We follow coordinated disclosure:
+
+1. Reporter submits a private advisory
+2. We triage, confirm, and develop a fix
+3. A CVE is requested if warranted
+4. Fix is released on Maven Central and GHCR
+5. Public advisory is published alongside the release notes
+
+## Dependency Vulnerabilities
+
+We track transitive dependency CVEs via Dependabot. Reports of vulnerable dependencies (that are actually reachable in StateFun's code paths) are welcome through the same private channel.

--- a/pom.xml
+++ b/pom.xml
@@ -374,6 +374,9 @@ under the License.
                         <exclude>**/README.md</exclude>
                         <exclude>**/README.zh.md</exclude>
                         <exclude>**/CODE_OF_CONDUCT.md</exclude>
+                        <exclude>**/CONTRIBUTING.md</exclude>
+                        <exclude>**/SECURITY.md</exclude>
+                        <exclude>**/CITATION.cff</exclude>
                         <exclude>**/KZMLABS-GUIDE.md</exclude>
                         <exclude>**/CHANGELOG.md</exclude>
                         <exclude>**/RELEASE-GUIDE.md</exclude>

--- a/pom.xml
+++ b/pom.xml
@@ -25,10 +25,15 @@ under the License.
     <name>Kzmlabs StateFun Parent</name>
     <version>3.4.0-KZM-2.0</version>
     <packaging>pom</packaging>
-    <description>Kzmlabs fork of Apache Flink Stateful Functions</description>
+    <description>Kzmlabs Flink StateFun — actively maintained continuation of the Stateful Functions framework for building distributed stateful applications and event-driven microservices on Apache Flink 2.2.0 with Java 21. Provides a function-as-actor programming model with durable state, exactly-once messaging, Kafka and Kinesis ingress/egress, and Kubernetes-native deployment via the Flink Kubernetes Operator.</description>
 
     <url>https://github.com/kzmlabs/flink-statefun</url>
     <inceptionYear>2024</inceptionYear>
+
+    <organization>
+        <name>Kzmlabs</name>
+        <url>https://github.com/kzmlabs</url>
+    </organization>
 
     <licenses>
         <license>
@@ -40,9 +45,14 @@ under the License.
 
     <developers>
         <developer>
+            <id>kzmlabs</id>
             <name>Kzmlabs Team</name>
             <organization>Kzmlabs</organization>
             <organizationUrl>https://github.com/kzmlabs</organizationUrl>
+            <url>https://github.com/kzmlabs</url>
+            <roles>
+                <role>maintainer</role>
+            </roles>
         </developer>
     </developers>
 
@@ -50,7 +60,18 @@ under the License.
         <url>https://github.com/kzmlabs/flink-statefun</url>
         <connection>scm:git:git://github.com/kzmlabs/flink-statefun.git</connection>
         <developerConnection>scm:git:git@github.com:kzmlabs/flink-statefun.git</developerConnection>
+        <tag>HEAD</tag>
     </scm>
+
+    <issueManagement>
+        <system>GitHub Issues</system>
+        <url>https://github.com/kzmlabs/flink-statefun/issues</url>
+    </issueManagement>
+
+    <ciManagement>
+        <system>GitHub Actions</system>
+        <url>https://github.com/kzmlabs/flink-statefun/actions</url>
+    </ciManagement>
 
     <distributionManagement>
         <snapshotRepository>


### PR DESCRIPTION
## Summary

Improve public discoverability and on-repo contributor experience.

## Changes

- **CONTRIBUTING.md** — dev setup, build commands, spotless, PR process, commit style
- **SECURITY.md** — supported versions, private reporting via GitHub Security Advisories, disclosure policy
- **CITATION.cff** — enables GitHub "Cite this repository" button and academic indexing
- **.github/ISSUE_TEMPLATE/bug_report.yml** — structured bug report form (version, Flink, Java, reproducer)
- **.github/PULL_REQUEST_TEMPLATE.md** — summary + checklist
- **pom.xml** — richer `<description>`, added `<organization>`, `<issueManagement>`, `<ciManagement>`; dropped personal developer identity in favor of generic "Kzmlabs Team"
- **README.md** — reframe as "continuation" instead of "fork"; correct module table (add `statefun-kinesis-io`, `statefun-bom`); replace inaccurate "Kinesis removed / upstream archived" claims; add Links and Keywords sections

## Notes

- GitHub repo metadata already updated out-of-band: description, homepage (Maven Central), 18 topics, Issues + Discussions enabled
- Community Standards score was 50/100; should reach 100 after this merges into `release`

## Test plan

- [ ] `mvn help:evaluate -Dexpression=project.description -N` resolves the new description
- [ ] POM parses (verified locally)
- [ ] README renders on GitHub