### PR TITLE
chore: P0 hygiene fixes — always-on E2E + version refs + plugin pins

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -3,11 +3,7 @@ name: K8s E2E Test
 on:
   workflow_call:    # reusable by release workflows
   workflow_dispatch:
-  pull_request:
-    paths:
-      - 'statefun-k8s-native-e2e/**'
-      - 'statefun-flink-runner/**'
-      - 'tools/docker/**'
+  pull_request:    # gate every PR — no path filter, full E2E coverage
 
 jobs:
   k8s-e2e:

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -9,8 +9,8 @@ authors:
 repository-code: "https://github.com/kzmlabs/flink-statefun"
 url: "https://github.com/kzmlabs/flink-statefun"
 license: Apache-2.0
-version: "3.4.0-KZM-2.0"
-date-released: "2026-04-23"
+version: "3.4.0-KZM-3.0-RC1"
+date-released: "2026-04-24"
 keywords:
   - apache-flink
   - stateful-functions

--- a/docs/config.toml
+++ b/docs/config.toml
@@ -21,11 +21,11 @@ pygmentsUseClasses = true
   # we change the version for the complete docs when forking of a release branch
   # etc.
   # The full version string as referenced in Maven (e.g. 1.2.1)
-  Version = "3.4.0-KZM-2.0"
+  Version = "3.4.0-KZM-3.0-RC1"
 
   # For stable releases, leave the bugfix version out (e.g. 1.2). For snapshot
   # release this should be the same as the regular version
-  VersionTitle = "3.4.0-KZM-2.0"
+  VersionTitle = "3.4.0-KZM-3.0-RC1"
 
   # The branch for this version of Kzmlabs Flink Stateful Functions
   Branch = "release"

--- a/pom.xml
+++ b/pom.xml
@@ -109,6 +109,25 @@
         <flink-shaded-jackson.version>2.18.2-20.0</flink-shaded-jackson.version>
         <slf4j-log4j12.version>1.7.36</slf4j-log4j12.version>
         <test.unit.pattern>**/*Test.*</test.unit.pattern>
+
+        <maven-compiler-plugin.version>3.13.0</maven-compiler-plugin.version>
+        <maven-enforcer-plugin.version>3.6.2</maven-enforcer-plugin.version>
+        <maven-surefire-plugin.version>3.5.5</maven-surefire-plugin.version>
+        <maven-failsafe-plugin.version>3.5.5</maven-failsafe-plugin.version>
+        <maven-shade-plugin.version>3.6.1</maven-shade-plugin.version>
+        <maven-source-plugin.version>3.4.0</maven-source-plugin.version>
+        <maven-javadoc-plugin.version>3.12.0</maven-javadoc-plugin.version>
+        <maven-gpg-plugin.version>3.2.8</maven-gpg-plugin.version>
+        <maven-deploy-plugin.version>3.1.4</maven-deploy-plugin.version>
+        <maven-install-plugin.version>3.1.4</maven-install-plugin.version>
+        <maven-jar-plugin.version>3.4.2</maven-jar-plugin.version>
+        <maven-clean-plugin.version>3.4.0</maven-clean-plugin.version>
+        <maven-site-plugin.version>3.21.0</maven-site-plugin.version>
+        <maven-resources-plugin.version>3.3.1</maven-resources-plugin.version>
+        <maven-dependency-plugin.version>3.8.1</maven-dependency-plugin.version>
+        <maven-assembly-plugin.version>3.7.1</maven-assembly-plugin.version>
+        <exec-maven-plugin.version>3.6.3</exec-maven-plugin.version>
+        <central-publishing-maven-plugin.version>0.10.0</central-publishing-maven-plugin.version>
     </properties>
 
     <dependencies>
@@ -181,7 +200,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-source-plugin</artifactId>
-                        <version>3.4.0</version>
+                        <version>${maven-source-plugin.version}</version>
                         <executions>
                             <execution>
                                 <id>attach-sources</id>
@@ -194,7 +213,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-javadoc-plugin</artifactId>
-                        <version>3.12.0</version>
+                        <version>${maven-javadoc-plugin.version}</version>
                         <configuration>
                             <doclint>none</doclint>
                             <failOnError>false</failOnError>
@@ -211,7 +230,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-gpg-plugin</artifactId>
-                        <version>3.2.8</version>
+                        <version>${maven-gpg-plugin.version}</version>
                         <executions>
                             <execution>
                                 <id>sign-artifacts</id>
@@ -231,7 +250,7 @@
                     <plugin>
                         <groupId>org.sonatype.central</groupId>
                         <artifactId>central-publishing-maven-plugin</artifactId>
-                        <version>0.10.0</version>
+                        <version>${central-publishing-maven-plugin.version}</version>
                         <extensions>true</extensions>
                         <configuration>
                             <publishingServerId>central</publishingServerId>
@@ -321,6 +340,32 @@
                         </execution>
                     </executions>
                 </plugin>
+
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-deploy-plugin</artifactId>
+                    <version>${maven-deploy-plugin.version}</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-jar-plugin</artifactId>
+                    <version>${maven-jar-plugin.version}</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-install-plugin</artifactId>
+                    <version>${maven-install-plugin.version}</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-clean-plugin</artifactId>
+                    <version>${maven-clean-plugin.version}</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-site-plugin</artifactId>
+                    <version>${maven-site-plugin.version}</version>
+                </plugin>
             </plugins>
         </pluginManagement>
 
@@ -329,7 +374,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.13.0</version>
+                <version>${maven-compiler-plugin.version}</version>
                 <configuration>
                     <source>21</source>
                     <target>21</target>
@@ -347,7 +392,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-enforcer-plugin</artifactId>
-                <version>3.6.2</version>
+                <version>${maven-enforcer-plugin.version}</version>
                 <executions>
                     <execution>
                         <id>enforce</id>
@@ -367,7 +412,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.5.5</version>
+                <version>${maven-surefire-plugin.version}</version>
                 <configuration>
                     <trimStackTrace>false</trimStackTrace>
                     <systemPropertyVariables>


### PR DESCRIPTION
## Summary

Four small fixes consolidated into one PR. Per the project-wide audit, these are P0 (bug fixes / staleness).

## Changes

### 1. \`.github/workflows/e2e-test.yml\`: drop \`pull_request\` path filter

Previously triggered K8s E2E only on changes to:
- \`statefun-k8s-native-e2e/**\`
- \`statefun-flink-runner/**\`
- \`tools/docker/**\`  ← **stale: directory deleted in PR #45**

After PR #45 the path filter became broken — any change to \`statefun-docker/\` (the new module) wouldn't trigger E2E. **Fix: remove the path filter entirely.** Trade-off: ~6 min CI per PR; benefit: 100%% E2E coverage. Subsequent PRs in this audit-driven cleanup all need E2E gating, so this enables that.

### 2. \`CITATION.cff\`: \`3.4.0-KZM-2.0\` → \`3.4.0-KZM-3.0-RC1\`

Was lagging one release behind. Updated date-released too.

### 3. \`docs/config.toml\`: \`Version\` and \`VersionTitle\` → \`3.4.0-KZM-3.0-RC1\`

Hugo docs site Version params still pointed at KZM-2.0.

### 4. \`pom.xml\` \`<pluginManagement>\`: pin missing plugin versions

Added explicit versions for plugins that previously fell back to Maven super-pom defaults (non-deterministic across Maven releases):
- \`maven-deploy-plugin:3.1.4\`
- \`maven-jar-plugin:3.4.2\`
- \`maven-install-plugin:3.1.4\`
- \`maven-clean-plugin:3.4.0\`
- \`maven-site-plugin:3.21.0\`

## Test plan

- [ ] \`Build & Test\`
- [ ] \`K8s End-to-End Test\` (now triggers on every PR)