### PR TITLE
chore(ci): add Dependabot config for Maven, Actions, and Docker

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,64 @@
+# SPDX-License-Identifier: Apache-2.0
+version: 2
+
+updates:
+  - package-ecosystem: maven
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+      time: "06:00"
+      timezone: Europe/Kyiv
+    open-pull-requests-limit: 10
+    labels:
+      - dependencies
+      - maven
+    groups:
+      flink-2x:
+        patterns:
+          - "org.apache.flink:*"
+      aws-sdk:
+        patterns:
+          - "software.amazon.awssdk:*"
+      junit:
+        patterns:
+          - "org.junit.*"
+          - "org.mockito:*"
+          - "org.assertj:*"
+          - "org.hamcrest:*"
+          - "org.awaitility:*"
+      logging:
+        patterns:
+          - "ch.qos.logback:*"
+          - "org.slf4j:*"
+          - "net.logstash.logback:*"
+      maven-plugins:
+        patterns:
+          - "org.apache.maven.plugins:*"
+
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+    labels:
+      - dependencies
+      - github-actions
+
+  - package-ecosystem: docker
+    directory: "/statefun-docker/src/main/docker"
+    schedule:
+      interval: weekly
+      day: monday
+    labels:
+      - dependencies
+      - docker
+
+  - package-ecosystem: docker
+    directory: "/statefun-k8s-native-e2e/remote-function"
+    schedule:
+      interval: weekly
+      day: monday
+    labels:
+      - dependencies
+      - docker


### PR DESCRIPTION
## Summary

Adds \`.github/dependabot.yml\` enabling weekly automated dependency PRs across three ecosystems:

- **Maven** — root reactor, with grouped updates for Flink, AWS SDK, JUnit/test, logging, and Maven plugins
- **GitHub Actions** — all workflow files
- **Docker** — both Dockerfiles (\`statefun-docker/\` + remote-function E2E image)

Schedule: every Monday 06:00 Europe/Kyiv. Open-PR limit 10 per ecosystem.

## Why

Trust signal #1 from the project audit. Closes the supply-chain gap where transitive CVEs can land in dependencies (Hadoop, Jackson, Netty, etc.) without being surfaced. With Dependabot, every CVE-bumped version triggers an auto-PR with full diff and CI gating.

## Test plan

- [ ] CI \`Build & Test\`
- [ ] CI \`K8s End-to-End Test\`