### PR TITLE
chore(ci): add CodeQL static analysis workflow

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,53 @@
+# SPDX-License-Identifier: Apache-2.0
+name: CodeQL
+
+on:
+  push:
+    branches: [release, master]
+  pull_request:
+    branches: [release, master]
+  schedule:
+    - cron: "0 6 * * 1"  # weekly Monday 06:00 UTC
+
+permissions:
+  contents: read
+  security-events: write
+  actions: read
+
+concurrency:
+  group: codeql-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [java]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-java@v4
+        with:
+          java-version: "21"
+          distribution: temurin
+          cache: maven
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          queries: security-and-quality
+
+      - name: Build (skip tests)
+        run: mvn install -DskipTests -B -Drat.skip=true -Dskip.k8s.e2e
+
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: /language:${{ matrix.language }}


### PR DESCRIPTION
## Summary

Adds \`.github/workflows/codeql.yml\` running GitHub-native SAST on every push/PR to \`release\`/\`master\` plus weekly schedule.

- Languages: Java
- Queries: \`security-and-quality\` (extended ruleset beyond default)
- Builds via \`mvn install -DskipTests -Drat.skip=true -Dskip.k8s.e2e\` for compiler-driven dataflow analysis
- Concurrency-limited per ref to prevent stale runs

## Why

Trust signal #2 from the project audit. Surfaces SAST findings in GitHub's Security tab without requiring third-party tools. Catches a class of bugs (taint tracking, deserialization gadgets, SQL injection patterns) that compiler + tests don't.

## Test plan

- [ ] CI \`Build & Test\`
- [ ] CI \`K8s End-to-End Test\`
- After merge: CodeQL workflow self-validates by running on its first scheduled trigger.