### PR TITLE
chore(ci): add OpenSSF Scorecard workflow

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,45 @@
+# SPDX-License-Identifier: Apache-2.0
+name: OpenSSF Scorecard
+
+on:
+  branch_protection_rule:
+  schedule:
+    - cron: "30 5 * * 1"  # weekly Monday 05:30 UTC
+  push:
+    branches: [release]
+
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      security-events: write
+      id-token: write
+      contents: read
+      actions: read
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - uses: ossf/scorecard-action@v2.4.0
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true
+
+      - name: Upload SARIF to code-scanning dashboard
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: results.sarif
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: scorecard-results
+          path: results.sarif
+          retention-days: 30


### PR DESCRIPTION
## Summary

Adds \`.github/workflows/scorecard.yml\` running OpenSSF Scorecard analysis weekly + on push to \`release\`. Publishes results to:

- GitHub's code-scanning dashboard (Security tab)
- Public OpenSSF Scorecard API (auto-generates badge URL)
- Workflow artifact (30-day retention)

## Why

Trust signal #3 from the project audit. Auto-grades supply-chain hygiene across 18 dimensions: branch protection, signed releases, SBOM, code review enforcement, token permissions, dependency pinning, fuzzing, license compliance, etc. Public score gives consumers a quick "how healthy is this project's security posture" answer.

After landing, can add a badge to README.md once the score generates (1-2 hours after first run).

## Test plan

- [ ] CI \`Build & Test\`
- [ ] CI \`K8s End-to-End Test\`
- After merge: scorecard runs on next push, score visible at https://api.securityscorecards.dev/projects/github.com/kzmlabs/flink-statefun