### PR TITLE
chore(ci): add Trivy CVE scan to release pipelines

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -74,6 +74,15 @@ jobs:
           provenance: mode=max
           sbom: true
 
+      - name: Scan image for CVEs (Trivy)
+        uses: aquasecurity/trivy-action@0.28.0
+        with:
+          image-ref: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ steps.build.outputs.digest }}
+          format: table
+          exit-code: "1"
+          severity: HIGH,CRITICAL
+          ignore-unfixed: true
+
       - name: Attest image provenance (Sigstore keyless)
         uses: actions/attest-build-provenance@v2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -122,6 +122,15 @@ jobs:
           provenance: mode=max
           sbom: true
 
+      - name: Scan image for CVEs (Trivy)
+        uses: aquasecurity/trivy-action@0.28.0
+        with:
+          image-ref: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ steps.build.outputs.digest }}
+          format: table
+          exit-code: "1"
+          severity: HIGH,CRITICAL
+          ignore-unfixed: true
+
       - name: Attest image provenance (Sigstore keyless)
         uses: actions/attest-build-provenance@v2
         with:


### PR DESCRIPTION
## Summary

Adds \`aquasecurity/trivy-action@0.28.0\` as a step between \`docker/build-push-action\` and \`actions/attest-build-provenance\` in both \`release.yml\` and \`docker-release.yml\`.

Scan config:
- Target: just-published image by digest (\`@sha256:...\`)
- Severity threshold: \`HIGH,CRITICAL\`
- \`exit-code: 1\` — release fails if vulnerabilities found
- \`ignore-unfixed: true\` — don't fail on CVEs without an upstream patch (we can't fix those anyway)
- Output format: table (visible in workflow log)

## Why

Trust signal #4 from the project audit. The published image inherits CVEs from \`apache/flink:2.2.0-java21\` base, transitive Java deps, and OS packages. Without scanning, these ship to consumers undetected.

Concrete example: a Log4Shell-class CVE in a transitive dep would now block release until upgraded. Combined with Dependabot (PR #49), the loop is: Dependabot detects → PR with bump → tests pass → Trivy scans on next release → ship clean image.

## Test plan

- [ ] CI \`Build & Test\`
- [ ] CI \`K8s End-to-End Test\`
- Note: This change only takes effect on the NEXT release tag/workflow_dispatch — won't run on this PR's CI.