### PR TITLE
chore(ci): modernize GitHub Actions — checkout v5 + permissions + timeouts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ release, master ]
 
+permissions:
+  contents: read
+
 concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: true
@@ -18,7 +21,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up JDK 21
         uses: actions/setup-java@v4

--- a/.github/workflows/doc-check.yml
+++ b/.github/workflows/doc-check.yml
@@ -2,11 +2,15 @@ name: Doc Check
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Build and Check Documentation
         run: ./tools/ci/docs.sh

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -33,7 +33,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up JDK 21
         uses: actions/setup-java@v4

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up JDK 21
         uses: actions/setup-java@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,7 +47,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Determine release type
         id: release_type

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -5,14 +5,18 @@ on:
     tags:
       - 'snapshot-*'  # e.g., snapshot-2024-02-01, snapshot-1
 
+permissions:
+  contents: read
+
 jobs:
   snapshot:
     runs-on: ubuntu-latest
     name: Deploy Snapshot to OSSRH
+    timeout-minutes: 60
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up JDK 21
         uses: actions/setup-java@v4


### PR DESCRIPTION
Bundle of three workflow-hygiene improvements:

1. `actions/checkout@v4` → `@v5` in all 6 workflows (Node 24, dodges Sept 2026 sunset)
2. `permissions: contents: read` (least-privilege baseline) on ci.yml, doc-check.yml, snapshot.yml. Workflows that need elevated perms keep their explicit job-level grants.
3. Add `timeout-minutes` to jobs missing it: doc-check 10, snapshot 60.

Test plan: CI Build & Test, K8s E2E gate.