### PR TITLE
chore(deps): low-risk version bumps (okhttp, snappy-java, jna, kafka)

### DIFF
--- a/statefun-e2e-tests/statefun-e2e-tests-common/pom.xml
+++ b/statefun-e2e-tests/statefun-e2e-tests-common/pom.xml
@@ -14,7 +14,7 @@
     <artifactId>statefun-e2e-tests-common</artifactId>
 
     <properties>
-        <kafka.version>2.4.1</kafka.version>
+        <kafka.version>3.9.1</kafka.version>
         <central.skip>true</central.skip>
     </properties>
 
@@ -67,7 +67,7 @@
         <dependency>
             <groupId>net.java.dev.jna</groupId>
             <artifactId>jna</artifactId>
-            <version>5.5.0</version>
+            <version>5.14.0</version>
         </dependency>
 
         <dependency>

--- a/statefun-flink/pom.xml
+++ b/statefun-flink/pom.xml
@@ -217,7 +217,7 @@
             <dependency>
                 <groupId>org.xerial.snappy</groupId>
                 <artifactId>snappy-java</artifactId>
-                <version>1.1.10.1</version>
+                <version>1.1.10.5</version>
             </dependency>
             <!--
             Pin the scala library version in order to resolve the dependency conversion problem between two


### PR DESCRIPTION
Four dependency version bumps with low blast radius:

- `com.squareup.okhttp3:okhttp` 4.12.0 → 4.13.0 (statefun-flink-core)
- `org.xerial.snappy:snappy-java` 1.1.10.1 → 1.1.10.5 (statefun-flink parent dependencyManagement)
- `net.java.dev.jna:jna` 5.5.0 → 5.14.0 (statefun-e2e-tests-common, dormant profile; 9 minors current)
- `org.apache.kafka:kafka-clients` 2.4.1 → 3.9.1 (statefun-e2e-tests-common, dormant profile; aligns with active modules)

Active runtime/build deps (Flink, Scala, Jackson, Netty, Protobuf) intentionally not bumped — coupled to Flink 2.2.0.

Test plan: CI Build & Test, K8s E2E gate.