### PR TITLE
docs: add feature request template + MAINTAINERS.md

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,56 @@
+# SPDX-License-Identifier: Apache-2.0
+name: Feature request
+description: Suggest a new feature or enhancement
+title: "[FEATURE] "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for proposing an improvement to Kzmlabs Flink StateFun!
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem statement
+      description: What problem does this feature solve? Who's affected?
+      placeholder: "When I try to ..., I can't because ..."
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: How would you like this to work? Concrete API/behavior preferred.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Other approaches you've thought about and why they fall short.
+
+  - type: dropdown
+    id: scope
+    attributes:
+      label: Scope
+      description: Where does this change live?
+      options:
+        - SDK (statefun-sdk-java / statefun-sdk-embedded)
+        - Runtime (statefun-flink-core / statefun-flink-distribution)
+        - I/O (statefun-kafka-io / statefun-kinesis-io)
+        - Build / packaging (statefun-docker / Maven / Dockerfile)
+        - K8s deployment (statefun-k8s-native-e2e / Flink Operator)
+        - Documentation
+        - CI / release process
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Links to related issues, upstream Flink/StateFun discussions, prior art.

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,27 @@
+# Maintainers
+
+This project is actively maintained by Kzmlabs.
+
+| Maintainer | GitHub | Role |
+|------------|--------|------|
+| Oleksandr Kazimirov | [@oleksandr-kazimirov](https://github.com/oleksandr-kazimirov) | Lead maintainer, releases |
+
+## Releases
+
+- All releases are signed (GPG via Maven Central, Sigstore keyless via GHCR)
+- Release tags follow the pattern `v3.4.0-KZM-X.Y[-RCN]` (full release) or `docker-3.4.0-KZM-X.Y` (Docker-only)
+- Maven Central namespace: `io.github.kzmlabs.flinkstatefun`
+- Container registry: `ghcr.io/kzmlabs/flink-statefun`
+
+## Reporting issues
+
+- **Security vulnerabilities**: see [SECURITY.md](SECURITY.md) — private disclosure via GitHub Security Advisories
+- **Bugs / features**: open an issue using the templates in `.github/ISSUE_TEMPLATE/`
+
+## Contribution
+
+Pull requests welcome. See [CONTRIBUTING.md](CONTRIBUTING.md).
+
+## Project heritage
+
+Kzmlabs Flink StateFun is a downstream continuation of [Apache Flink Stateful Functions](https://github.com/apache/flink-statefun). Apache 2.0 licensed; copyright attribution to the Apache Software Foundation is preserved at the file level (SPDX) and in the project [`NOTICE`](NOTICE) at root.


### PR DESCRIPTION
Two standard OSS hygiene files flagged in the project audit:

- `.github/ISSUE_TEMPLATE/feature_request.yml`: structured form-based feature request template (project previously had only `bug_report.yml`).
- `MAINTAINERS.md`: lists Kzmlabs ownership, release pointers, project heritage.

Test plan: CI Build & Test, K8s E2E gate.