### PR TITLE
chore: centralize plugin versions via parent pluginManagement (Maven best practice)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -366,6 +366,37 @@
                     <artifactId>maven-site-plugin</artifactId>
                     <version>${maven-site-plugin.version}</version>
                 </plugin>
+
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-shade-plugin</artifactId>
+                    <version>${maven-shade-plugin.version}</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-failsafe-plugin</artifactId>
+                    <version>${maven-failsafe-plugin.version}</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-dependency-plugin</artifactId>
+                    <version>${maven-dependency-plugin.version}</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-resources-plugin</artifactId>
+                    <version>${maven-resources-plugin.version}</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-assembly-plugin</artifactId>
+                    <version>${maven-assembly-plugin.version}</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>exec-maven-plugin</artifactId>
+                    <version>${exec-maven-plugin.version}</version>
+                </plugin>
             </plugins>
         </pluginManagement>
 

--- a/statefun-docker/pom.xml
+++ b/statefun-docker/pom.xml
@@ -72,7 +72,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>
-                <version>3.10.0</version>
                 <executions>
                     <execution>
                         <id>stage-statefun-jars</id>
@@ -113,7 +112,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-resources-plugin</artifactId>
-                <version>3.5.0</version>
                 <executions>
                     <execution>
                         <id>stage-dockerfile</id>

--- a/statefun-e2e-tests/pom.xml
+++ b/statefun-e2e-tests/pom.xml
@@ -85,7 +85,6 @@
                     <plugin>
                         <groupId>org.codehaus.mojo</groupId>
                         <artifactId>exec-maven-plugin</artifactId>
-                        <version>3.6.3</version>
                         <executions>
                             <execution>
                                 <id>build-statefun-base-image</id>
@@ -120,7 +119,6 @@
                     </plugin>
                     <plugin>
                         <artifactId>maven-failsafe-plugin</artifactId>
-                        <version>3.5.5</version>
                         <executions>
                             <execution>
                                 <goals>

--- a/statefun-e2e-tests/statefun-smoke-e2e-driver/pom.xml
+++ b/statefun-e2e-tests/statefun-smoke-e2e-driver/pom.xml
@@ -171,7 +171,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>3.6.2</version>
                 <executions>
                     <!-- Run shade goal on package phase -->
                     <execution>

--- a/statefun-e2e-tests/statefun-smoke-e2e-embedded/pom.xml
+++ b/statefun-e2e-tests/statefun-smoke-e2e-embedded/pom.xml
@@ -57,7 +57,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>3.6.2</version>
                 <executions>
                     <!-- Run shade goal on package phase -->
                     <execution>

--- a/statefun-e2e-tests/statefun-smoke-e2e-java/pom.xml
+++ b/statefun-e2e-tests/statefun-smoke-e2e-java/pom.xml
@@ -70,7 +70,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
-                <version>3.8.0</version>
                 <configuration>
                     <descriptorRefs>
                         <descriptorRef>jar-with-dependencies</descriptorRef>

--- a/statefun-flink-runner/pom.xml
+++ b/statefun-flink-runner/pom.xml
@@ -107,7 +107,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>3.6.2</version>
                 <executions>
                     <execution>
                         <phase>package</phase>

--- a/statefun-flink/statefun-flink-datastream/pom.xml
+++ b/statefun-flink/statefun-flink-datastream/pom.xml
@@ -77,7 +77,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>3.6.2</version>
                 <executions>
                     <!-- Run shade goal on package phase -->
                     <execution>

--- a/statefun-flink/statefun-flink-distribution/pom.xml
+++ b/statefun-flink/statefun-flink-distribution/pom.xml
@@ -120,7 +120,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>3.6.2</version>
                 <executions>
                     <!-- Run shade goal on package phase -->
                     <execution>

--- a/statefun-k8s-native-e2e/pom.xml
+++ b/statefun-k8s-native-e2e/pom.xml
@@ -149,7 +149,6 @@
                     <plugin>
                         <groupId>org.codehaus.mojo</groupId>
                         <artifactId>exec-maven-plugin</artifactId>
-                        <version>3.6.3</version>
                         <configuration>
                             <skip>${skipTests}</skip>
                         </configuration>
@@ -248,7 +247,6 @@
                     <!-- Failsafe for E2E tests -->
                     <plugin>
                         <artifactId>maven-failsafe-plugin</artifactId>
-                        <version>3.5.5</version>
                         <executions>
                             <execution>
                                 <goals>

--- a/statefun-shaded/statefun-protobuf-shaded/pom.xml
+++ b/statefun-shaded/statefun-protobuf-shaded/pom.xml
@@ -41,7 +41,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>3.6.2</version>
                 <executions>
                     <execution>
                         <phase>package</phase>


### PR DESCRIPTION
## Summary

Moves all shared plugin versions into the parent pom's \`<pluginManagement>\`. Sub-pom \`<plugin>\` blocks now declare GAV only — version inherits from parent. **Idiomatic Maven multi-module pattern** (the same shape Apache Flink, Spring, Spark use).

## Changes

### Parent \`pom.xml\` — 6 new \`<pluginManagement>\` entries
- \`maven-shade-plugin\` → \`\${maven-shade-plugin.version}\`
- \`maven-failsafe-plugin\` → \`\${maven-failsafe-plugin.version}\`
- \`maven-dependency-plugin\` → \`\${maven-dependency-plugin.version}\`
- \`maven-resources-plugin\` → \`\${maven-resources-plugin.version}\`
- \`maven-assembly-plugin\` → \`\${maven-assembly-plugin.version}\`
- \`exec-maven-plugin\` → \`\${exec-maven-plugin.version}\`

### Sub-poms — drop inline \`<version>\` (10 modules)
- \`statefun-flink-runner\` (shade)
- \`statefun-flink/statefun-flink-distribution\` (shade)
- \`statefun-flink/statefun-flink-datastream\` (shade)
- \`statefun-shaded/statefun-protobuf-shaded\` (shade)
- \`statefun-e2e-tests/statefun-smoke-e2e-driver\` (shade)
- \`statefun-e2e-tests/statefun-smoke-e2e-embedded\` (shade)
- \`statefun-e2e-tests/statefun-smoke-e2e-java\` (assembly)
- \`statefun-e2e-tests\` (exec, failsafe)
- \`statefun-k8s-native-e2e\` (exec, failsafe)
- \`statefun-docker\` (dependency, resources)

\`<configuration>\` and \`<executions>\` stay in each sub-pom (module-specific). Only the version declaration moves.

### NOT touched

\`statefun-k8s-native-e2e/remote-function/pom.xml\` — standalone pom with no \`<parent>\`, runs independent Maven build, can't access parent properties.

## Why

- **Single source of truth** for plugin versions — Dependabot bumps the parent property in one place instead of fanning out across 10 modules.
- **Eliminates version drift** — modules can't diverge from the canonical version anymore.
- **Less boilerplate** — sub-poms shrink. \`<plugin>\` blocks become declarative ("I use shade") rather than configurative ("I use shade 3.6.2").
- **Industry-standard Maven multi-module shape** — what every mature Apache project does.

## Net delta

12 files, +31 / −13 lines. Modest but high-leverage.

## Test plan

- [ ] CI \`Build & Test\`
- [ ] CI \`K8s End-to-End Test\` (gates real shading + failsafe discovery)

If shading/failsafe/exec inheritance silently broke for any module, the K8s E2E would fail (image build, JAR shading, test discovery, cluster setup all exercise these plugins).