### PR TITLE
chore: deeper pom centralization (BOMs + ${revision} + Flink + enforcer + wrapper)

### DIFF
--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -1,0 +1,3 @@
+# SPDX-License-Identifier: Apache-2.0
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.9/apache-maven-3.9.9-bin.zip
+wrapperUrl=https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/3.3.2/maven-wrapper-3.3.2.jar

--- a/mvnw
+++ b/mvnw
@@ -1,0 +1,15 @@
+#!/bin/sh
+# SPDX-License-Identifier: Apache-2.0
+# Maven Wrapper bootstrap. Resolves and runs Maven version specified in
+# .mvn/wrapper/maven-wrapper.properties. Standard upstream maven-wrapper layout.
+set -e
+WRAPPER_JAR=".mvn/wrapper/maven-wrapper.jar"
+PROPS=".mvn/wrapper/maven-wrapper.properties"
+if [ ! -f "$WRAPPER_JAR" ]; then
+    WRAPPER_URL=$(grep '^wrapperUrl=' "$PROPS" | cut -d'=' -f2-)
+    echo "Downloading Maven wrapper from $WRAPPER_URL"
+    curl -fsSL -o "$WRAPPER_JAR" "$WRAPPER_URL"
+fi
+exec "${JAVA_HOME:-}/bin/java" -classpath "$WRAPPER_JAR" \
+    "-Dmaven.multiModuleProjectDirectory=$(pwd)" \
+    org.apache.maven.wrapper.MavenWrapperMain "$@"

--- a/mvnw.cmd
+++ b/mvnw.cmd
@@ -1,0 +1,15 @@
+@REM SPDX-License-Identifier: Apache-2.0
+@REM Maven Wrapper bootstrap (Windows). Resolves and runs Maven version specified
+@REM in .mvn\wrapper\maven-wrapper.properties.
+@echo off
+setlocal
+set WRAPPER_JAR=.mvn\wrapper\maven-wrapper.jar
+set PROPS=.mvn\wrapper\maven-wrapper.properties
+if not exist "%WRAPPER_JAR%" (
+    for /f "tokens=2 delims==" %%A in ('findstr /B "wrapperUrl=" "%PROPS%"') do set WRAPPER_URL=%%A
+    echo Downloading Maven wrapper from %WRAPPER_URL%
+    powershell -Command "Invoke-WebRequest -Uri '%WRAPPER_URL%' -OutFile '%WRAPPER_JAR%'"
+)
+"%JAVA_HOME%\bin\java" -classpath "%WRAPPER_JAR%" ^
+    "-Dmaven.multiModuleProjectDirectory=%CD%" ^
+    org.apache.maven.wrapper.MavenWrapperMain %*

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     <groupId>io.github.kzmlabs.flinkstatefun</groupId>
     <artifactId>statefun-parent</artifactId>
     <name>Kzmlabs StateFun Parent</name>
-    <version>3.4.0-KZM-3.0-RC1</version>
+    <version>${revision}</version>
     <packaging>pom</packaging>
     <description>Kzmlabs Flink StateFun — actively maintained continuation of the Stateful Functions framework for building distributed stateful applications and event-driven microservices on Apache Flink 2.2.0 with Java 21. Provides a function-as-actor programming model with durable state, exactly-once messaging, Kafka and Kinesis ingress/egress, and Kubernetes-native deployment via the Flink Kubernetes Operator.</description>
 
@@ -91,11 +91,15 @@
     </modules>
 
     <properties>
+        <revision>3.4.0-KZM-3.0-RC1</revision>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <java.version>21</java.version>
+        <maven.minimum.version>3.9.0</maven.minimum.version>
         <!-- Central publishing skip flag - modules can override to true -->
         <central.skip>false</central.skip>
+        <awssdk.version>2.43.0</awssdk.version>
+        <flatten-maven-plugin.version>1.6.0</flatten-maven-plugin.version>
         <auto-service.version>1.1.1</auto-service.version>
         <protobuf.version>3.25.5</protobuf.version>
         <unixsocket.version>2.10.1</unixsocket.version>
@@ -140,12 +144,23 @@
 
     <dependencyManagement>
         <dependencies>
+            <!-- BOM: JUnit Jupiter — manages all junit-* artifact versions -->
             <dependency>
-                <groupId>org.junit.jupiter</groupId>
-                <artifactId>junit-jupiter</artifactId>
+                <groupId>org.junit</groupId>
+                <artifactId>junit-bom</artifactId>
                 <version>5.11.4</version>
-                <scope>test</scope>
+                <type>pom</type>
+                <scope>import</scope>
             </dependency>
+            <!-- BOM: AWS SDK v2 — manages 200+ awssdk artifact versions -->
+            <dependency>
+                <groupId>software.amazon.awssdk</groupId>
+                <artifactId>bom</artifactId>
+                <version>${awssdk.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+
             <dependency>
                 <groupId>org.hamcrest</groupId>
                 <artifactId>hamcrest</artifactId>
@@ -157,6 +172,33 @@
                 <artifactId>assertj-core</artifactId>
                 <version>3.27.3</version>
                 <scope>test</scope>
+            </dependency>
+
+            <!-- Flink runtime — kept as <scope>provided</scope> by consumers -->
+            <dependency>
+                <groupId>org.apache.flink</groupId>
+                <artifactId>flink-core</artifactId>
+                <version>${flink.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.flink</groupId>
+                <artifactId>flink-streaming-java</artifactId>
+                <version>${flink.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.flink</groupId>
+                <artifactId>flink-runtime</artifactId>
+                <version>${flink.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.flink</groupId>
+                <artifactId>flink-clients</artifactId>
+                <version>${flink.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.flink</groupId>
+                <artifactId>flink-metrics-dropwizard</artifactId>
+                <version>${flink.version}</version>
             </dependency>
 
             <!-- Resolve dependency convergence issue -->
@@ -398,11 +440,44 @@
                         <id>enforce</id>
                         <configuration>
                             <rules>
+                                <requireMavenVersion>
+                                    <version>${maven.minimum.version}</version>
+                                </requireMavenVersion>
+                                <requireJavaVersion>
+                                    <version>${java.version}</version>
+                                </requireJavaVersion>
                                 <dependencyConvergence/>
                             </rules>
                         </configuration>
                         <goals>
                             <goal>enforce</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <!-- flatten-maven-plugin resolves ${revision} for deployed POMs (CI-friendly versioning) -->
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>flatten-maven-plugin</artifactId>
+                <version>${flatten-maven-plugin.version}</version>
+                <configuration>
+                    <flattenMode>resolveCiFriendliesOnly</flattenMode>
+                    <updatePomFile>true</updatePomFile>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>flatten</id>
+                        <phase>process-resources</phase>
+                        <goals>
+                            <goal>flatten</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>flatten.clean</id>
+                        <phase>clean</phase>
+                        <goals>
+                            <goal>clean</goal>
                         </goals>
                     </execution>
                 </executions>

--- a/statefun-bom/pom.xml
+++ b/statefun-bom/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>io.github.kzmlabs.flinkstatefun</groupId>
         <artifactId>statefun-parent</artifactId>
-        <version>3.4.0-KZM-3.0-RC1</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>statefun-bom</artifactId>

--- a/statefun-docker/pom.xml
+++ b/statefun-docker/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <artifactId>statefun-parent</artifactId>
         <groupId>io.github.kzmlabs.flinkstatefun</groupId>
-        <version>3.4.0-KZM-3.0-RC1</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/statefun-e2e-tests/pom.xml
+++ b/statefun-e2e-tests/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <artifactId>statefun-parent</artifactId>
         <groupId>io.github.kzmlabs.flinkstatefun</groupId>
-        <version>3.4.0-KZM-3.0-RC1</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/statefun-e2e-tests/statefun-e2e-tests-common/pom.xml
+++ b/statefun-e2e-tests/statefun-e2e-tests-common/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <artifactId>statefun-e2e-tests</artifactId>
         <groupId>io.github.kzmlabs.flinkstatefun</groupId>
-        <version>3.4.0-KZM-3.0-RC1</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/statefun-e2e-tests/statefun-smoke-e2e-common/pom.xml
+++ b/statefun-e2e-tests/statefun-smoke-e2e-common/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <artifactId>statefun-e2e-tests</artifactId>
         <groupId>io.github.kzmlabs.flinkstatefun</groupId>
-        <version>3.4.0-KZM-3.0-RC1</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/statefun-e2e-tests/statefun-smoke-e2e-driver/pom.xml
+++ b/statefun-e2e-tests/statefun-smoke-e2e-driver/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <artifactId>statefun-e2e-tests</artifactId>
         <groupId>io.github.kzmlabs.flinkstatefun</groupId>
-        <version>3.4.0-KZM-3.0-RC1</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/statefun-e2e-tests/statefun-smoke-e2e-embedded/pom.xml
+++ b/statefun-e2e-tests/statefun-smoke-e2e-embedded/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <artifactId>statefun-e2e-tests</artifactId>
         <groupId>io.github.kzmlabs.flinkstatefun</groupId>
-        <version>3.4.0-KZM-3.0-RC1</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -47,7 +47,7 @@
         <dependency>
             <groupId>io.github.kzmlabs.flinkstatefun</groupId>
             <artifactId>statefun-smoke-e2e-driver</artifactId>
-            <version>3.4.0-KZM-3.0-RC1</version>
+            <version>${revision}</version>
         </dependency>
     </dependencies>
 

--- a/statefun-e2e-tests/statefun-smoke-e2e-golang/pom.xml
+++ b/statefun-e2e-tests/statefun-smoke-e2e-golang/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.github.kzmlabs.flinkstatefun</groupId>
         <artifactId>statefun-smoke-e2e-multilang-base</artifactId>
-        <version>3.4.0-KZM-3.0-RC1</version>
+        <version>${revision}</version>
         <relativePath>../statefun-smoke-e2e-multilang-base/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/statefun-e2e-tests/statefun-smoke-e2e-java/pom.xml
+++ b/statefun-e2e-tests/statefun-smoke-e2e-java/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.github.kzmlabs.flinkstatefun</groupId>
         <artifactId>statefun-smoke-e2e-multilang-base</artifactId>
-        <version>3.4.0-KZM-3.0-RC1</version>
+        <version>${revision}</version>
         <relativePath>../statefun-smoke-e2e-multilang-base/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/statefun-e2e-tests/statefun-smoke-e2e-js/pom.xml
+++ b/statefun-e2e-tests/statefun-smoke-e2e-js/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.github.kzmlabs.flinkstatefun</groupId>
         <artifactId>statefun-smoke-e2e-multilang-base</artifactId>
-        <version>3.4.0-KZM-3.0-RC1</version>
+        <version>${revision}</version>
         <relativePath>../statefun-smoke-e2e-multilang-base/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/statefun-e2e-tests/statefun-smoke-e2e-multilang-base/pom.xml
+++ b/statefun-e2e-tests/statefun-smoke-e2e-multilang-base/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <artifactId>statefun-e2e-tests</artifactId>
         <groupId>io.github.kzmlabs.flinkstatefun</groupId>
-        <version>3.4.0-KZM-3.0-RC1</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/statefun-e2e-tests/statefun-smoke-e2e-multilang-harness/pom.xml
+++ b/statefun-e2e-tests/statefun-smoke-e2e-multilang-harness/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <artifactId>statefun-e2e-tests</artifactId>
         <groupId>io.github.kzmlabs.flinkstatefun</groupId>
-        <version>3.4.0-KZM-3.0-RC1</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -36,7 +36,7 @@
         <dependency>
             <groupId>io.github.kzmlabs.flinkstatefun</groupId>
             <artifactId>statefun-smoke-e2e-driver</artifactId>
-            <version>3.4.0-KZM-3.0-RC1</version>
+            <version>${revision}</version>
         </dependency>
 
         <!-- Test scope dependencies -->

--- a/statefun-flink-runner/pom.xml
+++ b/statefun-flink-runner/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>io.github.kzmlabs.flinkstatefun</groupId>
         <artifactId>statefun-parent</artifactId>
-        <version>3.4.0-KZM-3.0-RC1</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>statefun-flink-runner</artifactId>

--- a/statefun-flink/pom.xml
+++ b/statefun-flink/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <artifactId>statefun-parent</artifactId>
         <groupId>io.github.kzmlabs.flinkstatefun</groupId>
-        <version>3.4.0-KZM-3.0-RC1</version>
+        <version>${revision}</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/statefun-flink/statefun-flink-common/pom.xml
+++ b/statefun-flink/statefun-flink-common/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>io.github.kzmlabs.flinkstatefun</groupId>
         <artifactId>statefun-flink</artifactId>
-        <version>3.4.0-KZM-3.0-RC1</version>
+        <version>${revision}</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/statefun-flink/statefun-flink-core/pom.xml
+++ b/statefun-flink/statefun-flink-core/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>io.github.kzmlabs.flinkstatefun</groupId>
         <artifactId>statefun-flink</artifactId>
-        <version>3.4.0-KZM-3.0-RC1</version>
+        <version>${revision}</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/statefun-flink/statefun-flink-datastream/pom.xml
+++ b/statefun-flink/statefun-flink-datastream/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>io.github.kzmlabs.flinkstatefun</groupId>
         <artifactId>statefun-flink</artifactId>
-        <version>3.4.0-KZM-3.0-RC1</version>
+        <version>${revision}</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/statefun-flink/statefun-flink-distribution/pom.xml
+++ b/statefun-flink/statefun-flink-distribution/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>io.github.kzmlabs.flinkstatefun</groupId>
         <artifactId>statefun-flink</artifactId>
-        <version>3.4.0-KZM-3.0-RC1</version>
+        <version>${revision}</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/statefun-flink/statefun-flink-extensions/pom.xml
+++ b/statefun-flink/statefun-flink-extensions/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>io.github.kzmlabs.flinkstatefun</groupId>
         <artifactId>statefun-flink</artifactId>
-        <version>3.4.0-KZM-3.0-RC1</version>
+        <version>${revision}</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/statefun-flink/statefun-flink-harness/pom.xml
+++ b/statefun-flink/statefun-flink-harness/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>io.github.kzmlabs.flinkstatefun</groupId>
         <artifactId>statefun-flink</artifactId>
-        <version>3.4.0-KZM-3.0-RC1</version>
+        <version>${revision}</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/statefun-flink/statefun-flink-io-bundle/pom.xml
+++ b/statefun-flink/statefun-flink-io-bundle/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>io.github.kzmlabs.flinkstatefun</groupId>
         <artifactId>statefun-flink</artifactId>
-        <version>3.4.0-KZM-3.0-RC1</version>
+        <version>${revision}</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/statefun-flink/statefun-flink-io/pom.xml
+++ b/statefun-flink/statefun-flink-io/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>io.github.kzmlabs.flinkstatefun</groupId>
         <artifactId>statefun-flink</artifactId>
-        <version>3.4.0-KZM-3.0-RC1</version>
+        <version>${revision}</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/statefun-flink/statefun-flink-launcher/pom.xml
+++ b/statefun-flink/statefun-flink-launcher/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>io.github.kzmlabs.flinkstatefun</groupId>
         <artifactId>statefun-flink</artifactId>
-        <version>3.4.0-KZM-3.0-RC1</version>
+        <version>${revision}</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/statefun-flink/statefun-flink-state-processor/pom.xml
+++ b/statefun-flink/statefun-flink-state-processor/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <artifactId>statefun-flink</artifactId>
         <groupId>io.github.kzmlabs.flinkstatefun</groupId>
-        <version>3.4.0-KZM-3.0-RC1</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/statefun-k8s-native-e2e/pom.xml
+++ b/statefun-k8s-native-e2e/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <artifactId>statefun-parent</artifactId>
         <groupId>io.github.kzmlabs.flinkstatefun</groupId>
-        <version>3.4.0-KZM-3.0-RC1</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -17,7 +17,6 @@
         <central.skip>true</central.skip>
         <skipTests>false</skipTests>
         <kafka-clients.version>3.9.0</kafka-clients.version>
-        <awssdk.version>2.43.0</awssdk.version>
         <awaitility.version>4.2.2</awaitility.version>
         <assertj.version>3.27.3</assertj.version>
         
@@ -53,17 +52,16 @@
             <scope>test</scope>
         </dependency>
 
-        <!-- AWS SDK v2 clients (drive Kinesis streams + S3 checkpoint bucket via LocalStack) -->
+        <!-- AWS SDK v2 clients (drive Kinesis streams + S3 checkpoint bucket via LocalStack);
+             versions managed by software.amazon.awssdk:bom in parent dependencyManagement. -->
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>kinesis</artifactId>
-            <version>${awssdk.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>s3</artifactId>
-            <version>${awssdk.version}</version>
             <scope>test</scope>
         </dependency>
 

--- a/statefun-kafka-io/pom.xml
+++ b/statefun-kafka-io/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <artifactId>statefun-parent</artifactId>
         <groupId>io.github.kzmlabs.flinkstatefun</groupId>
-        <version>3.4.0-KZM-3.0-RC1</version>
+        <version>${revision}</version>
         <relativePath>..</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/statefun-kinesis-io/pom.xml
+++ b/statefun-kinesis-io/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <artifactId>statefun-parent</artifactId>
         <groupId>io.github.kzmlabs.flinkstatefun</groupId>
-        <version>3.4.0-KZM-3.0-RC1</version>
+        <version>${revision}</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/statefun-sdk-embedded/pom.xml
+++ b/statefun-sdk-embedded/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <artifactId>statefun-parent</artifactId>
         <groupId>io.github.kzmlabs.flinkstatefun</groupId>
-        <version>3.4.0-KZM-3.0-RC1</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/statefun-sdk-java/pom.xml
+++ b/statefun-sdk-java/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <artifactId>statefun-parent</artifactId>
         <groupId>io.github.kzmlabs.flinkstatefun</groupId>
-        <version>3.4.0-KZM-3.0-RC1</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>statefun-sdk-java</artifactId>

--- a/statefun-sdk-protos/pom.xml
+++ b/statefun-sdk-protos/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <artifactId>statefun-parent</artifactId>
         <groupId>io.github.kzmlabs.flinkstatefun</groupId>
-        <version>3.4.0-KZM-3.0-RC1</version>
+        <version>${revision}</version>
         <relativePath>..</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/statefun-shaded/pom.xml
+++ b/statefun-shaded/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <artifactId>statefun-parent</artifactId>
         <groupId>io.github.kzmlabs.flinkstatefun</groupId>
-        <version>3.4.0-KZM-3.0-RC1</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>statefun-shaded</artifactId>

--- a/statefun-shaded/statefun-protobuf-shaded/pom.xml
+++ b/statefun-shaded/statefun-protobuf-shaded/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <artifactId>statefun-shaded</artifactId>
         <groupId>io.github.kzmlabs.flinkstatefun</groupId>
-        <version>3.4.0-KZM-3.0-RC1</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>statefun-protobuf-shaded</artifactId>

--- a/statefun-shaded/statefun-protocol-shaded/pom.xml
+++ b/statefun-shaded/statefun-protocol-shaded/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <artifactId>statefun-shaded</artifactId>
         <groupId>io.github.kzmlabs.flinkstatefun</groupId>
-        <version>3.4.0-KZM-3.0-RC1</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>statefun-protocol-shaded</artifactId>

--- a/statefun-testutil/pom.xml
+++ b/statefun-testutil/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <artifactId>statefun-parent</artifactId>
         <groupId>io.github.kzmlabs.flinkstatefun</groupId>
-        <version>3.4.0-KZM-3.0-RC1</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 


### PR DESCRIPTION
## Summary

Five Maven best-practice improvements in one bundle. **Builds on PR #74** (which centralized plugin versions via parent \`<pluginManagement>\`).

## Changes

### 1. BOMs in parent \`<dependencyManagement>\`

Replaces individual artifact pins with **Bill of Materials** imports — the modern Maven idiom.

\`\`\`xml
<dependency>
  <groupId>org.junit</groupId>
  <artifactId>junit-bom</artifactId>
  <version>5.11.4</version>
  <type>pom</type>
  <scope>import</scope>
</dependency>
<dependency>
  <groupId>software.amazon.awssdk</groupId>
  <artifactId>bom</artifactId>
  <version>\${awssdk.version}</version>
  <type>pom</type>
  <scope>import</scope>
</dependency>
\`\`\`

junit-bom manages all junit-jupiter-* artifact versions in one go. AWS SDK bom manages 200+ awssdk artifacts.

### 2. \`\${revision}\` CI-friendly versioning

Parent's \`<version>\` is now \`\${revision}\`. The literal version string \`3.4.0-KZM-3.0-RC1\` lives in **one place** — the \`<revision>\` property.

\`\`\`xml
<version>\${revision}</version>
<properties>
  <revision>3.4.0-KZM-3.0-RC1</revision>
</properties>
\`\`\`

All 34 child poms have their \`<parent><version>\` updated to \`\${revision}\` via a Python script.

\`flatten-maven-plugin\` resolves \`\${revision}\` to a literal value in the deployed POM (Maven Central requires concrete versions; the property syntax can't be published).

Future version bumps: \`mvn versions:set -Drevision=X.Y.Z\` or edit one line in parent \`pom.xml\`. CI can override per-build: \`mvn -Drevision=3.4.0-KZM-3.0-RC2 deploy\`.

### 3. Flink runtime deps in parent \`<dependencyManagement>\`

Adds \`flink-core\`, \`flink-streaming-java\`, \`flink-runtime\`, \`flink-clients\`, \`flink-metrics-dropwizard\` to parent. Sub-poms can drop \`<version>\${flink.version}</version>\` on these deps. (Removal of inline versions is incremental — sub-poms still work as-is, but new modules / cleanups can drop versions.)

### 4. Tightened Maven enforcer rules

\`\`\`xml
<rules>
  <requireMavenVersion><version>\${maven.minimum.version}</version></requireMavenVersion>
  <requireJavaVersion><version>\${java.version}</version></requireJavaVersion>
  <dependencyConvergence/>
</rules>
\`\`\`

Catches Maven < 3.9 and Java < 21 environments early with a clean error.

Skipped \`bannedDependencies(log4j 1.x)\` — project currently uses log4j 1.2.17 directly in statefun-flink-distribution. Will revisit after log4j removal.

### 5. Maven Wrapper (\`mvnw\`, \`mvnw.cmd\`, \`.mvn/wrapper/maven-wrapper.properties\`)

Pins Maven 3.9.9 per-project. CI runners don't need to install Maven; new contributors don't need to match versions.

\`\`\`bash
./mvnw clean install
\`\`\`

### 6. AWS SDK cleanup

\`statefun-k8s-native-e2e/pom.xml\`: drops \`<awssdk.version>\` property + version refs on \`awssdk:kinesis\`/\`s3\` deps (now BOM-managed).

## Out of scope (skipped per request)

- Empty-javadoc-jar dedup
- \`failOnWarning\` compiler config

## Files

38 files changed, +150 / −44 lines.

## Test plan

- [ ] CI \`Build & Test\`
- [ ] CI \`K8s End-to-End Test\`
- The K8s E2E gate is the strongest validation: any wrong dep resolution from BOM imports, broken \${revision} in deployed pom, or enforcer-rule failure breaks the build.