### PR TITLE
ci: run K8s E2E on push to release/master

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -4,6 +4,8 @@ on:
   workflow_call:    # reusable by release workflows
   workflow_dispatch:
   pull_request:    # gate every PR — no path filter, full E2E coverage
+  push:
+    branches: [release, master]    # post-merge validation on protected branches
 
 jobs:
   k8s-e2e:


### PR DESCRIPTION
Adds push trigger to e2e-test.yml. K8s E2E now runs on every merge, not just on PR.

Test plan: this PR's own CI exercises the change.