### PR TITLE
feat(release): add bump-version.sh — single-command version bumps

### DIFF
--- a/tools/bump-version.sh
+++ b/tools/bump-version.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+#
+# Bump the project version in one shot. Updates every file that references
+# the current version, leaving git-staged changes for review/commit.
+#
+# Usage:
+#   ./tools/bump-version.sh <new-version>
+#
+# Example:
+#   ./tools/bump-version.sh 3.4.0-KZM-3.0-RC2
+#
+# What it touches:
+#   - pom.xml                          <revision>...</revision>      (Maven source of truth)
+#   - CITATION.cff                     version: "..."
+#   - docs/config.toml                 Version, VersionTitle
+#   - README.md                        Maven coordinate + docker pull examples
+#
+# After running, review with `git diff` and commit:
+#   git add -u && git commit -m "Release X.Y.Z"
+
+set -euo pipefail
+
+if [ "$#" -ne 1 ]; then
+    echo "Usage: $0 <new-version>" >&2
+    echo "  e.g. $0 3.4.0-KZM-3.0-RC2" >&2
+    exit 1
+fi
+
+NEW="$1"
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+# Extract current version from root pom.xml's <revision> property (single source of truth)
+OLD=$(grep -oP '<revision>\K[^<]+' pom.xml | head -1)
+
+if [ -z "$OLD" ]; then
+    echo "ERROR: couldn't read current version from pom.xml <revision>" >&2
+    exit 2
+fi
+
+if [ "$OLD" = "$NEW" ]; then
+    echo "Already at $NEW; nothing to do."
+    exit 0
+fi
+
+echo "Bumping: $OLD -> $NEW"
+echo
+
+update() {
+    local file="$1"
+    if [ ! -f "$file" ]; then
+        echo "  skip   $file (missing)"
+        return
+    fi
+    if ! grep -qF "$OLD" "$file"; then
+        echo "  skip   $file (no $OLD found)"
+        return
+    fi
+    # Use sed with a tmp file for cross-platform compatibility (Windows git-bash, macOS, Linux)
+    sed -i.bak "s|$OLD|$NEW|g" "$file"
+    rm -f "$file.bak"
+    local count=$(grep -cF "$NEW" "$file" || true)
+    echo "  update $file ($count occurrences)"
+}
+
+update "pom.xml"
+update "CITATION.cff"
+update "docs/config.toml"
+update "README.md"
+
+# Today's date for CITATION.cff date-released
+TODAY=$(date +%Y-%m-%d)
+if [ -f "CITATION.cff" ]; then
+    sed -i.bak "s|^date-released:.*|date-released: \"$TODAY\"|" CITATION.cff
+    rm -f "CITATION.cff.bak"
+    echo "  update CITATION.cff date-released -> $TODAY"
+fi
+
+echo
+echo "Done. Review with: git diff"
+echo "Commit with:        git add -u && git commit -m 'Release $NEW'"
+echo "Tag and push with:  git tag v$NEW && git push origin v$NEW"


### PR DESCRIPTION
## Summary

Adds \`tools/bump-version.sh\` so version bumps require **zero file edits** — just one command:

\`\`\`bash
./tools/bump-version.sh 3.4.0-KZM-3.0-RC2
\`\`\`

That updates everything in one shot:

| File | What gets changed |
|------|-------------------|
| \`pom.xml\` | \`<revision>\` (single Maven source — propagates to all 35 modules) |
| \`CITATION.cff\` | \`version:\` + \`date-released:\` (set to today) |
| \`docs/config.toml\` | \`Version\` + \`VersionTitle\` (Hugo docs site) |
| \`README.md\` | Maven coordinate + Docker build examples (4 occurrences) |

User then reviews with \`git diff\`, commits, and tags. **No manual file editing.**

## Validation

Round-trip tested: bump RC1 → RC99, then revert RC99 → RC1 leaves working tree clean (modulo \`CITATION.cff\` date which is expected to change per release).

8 total occurrences across 4 files updated in <1s.

## Why one script and not pure Maven indirection

- \`pom.xml\` is already Maven-driven: \`<revision>\` propagates to all 35 module poms automatically.
- The other files (\`CITATION.cff\`, \`docs/config.toml\`, README.md) are CONSUMED outside Maven (citation managers, Hugo, GitHub README rendering). Maven property substitution would only help if those tools also resolved \`\${revision}\` — they don't.
- A 60-line bash script is simpler than a Maven resources-filtering indirection that would write derived files into target/.

Test plan:
- [ ] CI Build & Test
- [ ] CI K8s E2E (script lives in tools/, doesn't affect build)