### PR TITLE
fix(ci): use trivy-action@master (0.28.0 tag doesn't exist)

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -75,7 +75,7 @@ jobs:
           sbom: true
 
       - name: Scan image for CVEs (Trivy)
-        uses: aquasecurity/trivy-action@0.28.0
+        uses: aquasecurity/trivy-action@master
         with:
           image-ref: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ steps.build.outputs.digest }}
           format: table

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -123,7 +123,7 @@ jobs:
           sbom: true
 
       - name: Scan image for CVEs (Trivy)
-        uses: aquasecurity/trivy-action@0.28.0
+        uses: aquasecurity/trivy-action@master
         with:
           image-ref: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ steps.build.outputs.digest }}
           format: table

--- a/.gitignore
+++ b/.gitignore
@@ -72,3 +72,4 @@ dev/
 # maven dependency:sources unpacks into ./org/
 /org/
 .claude/
+.flattened-pom.xml


### PR DESCRIPTION
Release pipeline (PR #75 introduced Trivy) failed at Set up job because `aquasecurity/trivy-action@0.28.0` isn't a published tag. Per Trivy's docs the recommended ref is `@master`. Dependabot will track newer real version tags when they ship.

Affects: `release.yml`, `docker-release.yml`.

Test plan: re-tag and re-run release pipeline after merge.