### PR TITLE
fix(sdk): exclude test libs from shaded SDK JAR + bump test deps

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -148,7 +148,7 @@
             <dependency>
                 <groupId>org.junit</groupId>
                 <artifactId>junit-bom</artifactId>
-                <version>5.11.4</version>
+                <version>5.12.2</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/statefun-k8s-native-e2e/pom.xml
+++ b/statefun-k8s-native-e2e/pom.xml
@@ -17,7 +17,7 @@
         <central.skip>true</central.skip>
         <skipTests>false</skipTests>
         <kafka-clients.version>3.9.0</kafka-clients.version>
-        <awaitility.version>4.2.2</awaitility.version>
+        <awaitility.version>4.3.0</awaitility.version>
         <assertj.version>3.27.3</assertj.version>
         
         <slf4j.version>2.0.9</slf4j.version>

--- a/statefun-sdk-java/pom.xml
+++ b/statefun-sdk-java/pom.xml
@@ -26,10 +26,12 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest</artifactId>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 
@@ -47,6 +49,27 @@
                         </goals>
                         <configuration>
                             <createDependencyReducedPom>false</createDependencyReducedPom>
+                            <!--
+                                Industry-best approach: minimizeJar drops classes not reachable
+                                from project bytecode. Combined with <scope>test</scope> on test
+                                deps, ensures NO test framework classes leak into the published
+                                SDK. Belt-and-suspenders excludes catch any accidental
+                                introduction by transitive deps.
+                            -->
+                            <minimizeJar>true</minimizeJar>
+                            <artifactSet>
+                                <excludes>
+                                    <exclude>org.junit.jupiter:*</exclude>
+                                    <exclude>org.junit.platform:*</exclude>
+                                    <exclude>org.junit:*</exclude>
+                                    <exclude>org.opentest4j:*</exclude>
+                                    <exclude>org.apiguardian:*</exclude>
+                                    <exclude>org.hamcrest:*</exclude>
+                                    <exclude>org.assertj:*</exclude>
+                                    <exclude>org.mockito:*</exclude>
+                                    <exclude>org.awaitility:*</exclude>
+                                </excludes>
+                            </artifactSet>
                         </configuration>
                     </execution>
                 </executions>


### PR DESCRIPTION
## Summary

Published `statefun-sdk-java-3.4.0-KZM-3.0.jar` was 3.8 MB and contained JUnit Jupiter, Hamcrest, opentest4j, apiguardian — test framework classes that have no business in a published library JAR.

## Root causes

1. `statefun-sdk-java/pom.xml` declared `junit-jupiter` and `hamcrest` without `<scope>test</scope>` → Maven shade-plugin bundled them.
2. `maven-shade-plugin` had no `<minimizeJar>` or `<artifactSet><excludes>` → shaded everything reachable.

## Fix (industry-best)

1. **`<scope>test</scope>`** on junit-jupiter and hamcrest — the proper Maven way. Test-scope deps don't get packaged.
2. **`<minimizeJar>true</minimizeJar>`** in shade config — automatically drops classes not reachable from project bytecode. Maintenance-free; works as deps evolve.
3. **`<artifactSet><excludes>`** belt-and-suspenders for junit/jupiter/platform/opentest4j/apiguardian/hamcrest/assertj/mockito/awaitility.

## Bumps included

- `junit-bom` 5.11.4 → 5.12.2 (latest stable 5.x; staying on 5 since 6.x has surefire incompat per closed PR #64)
- `awaitility` 4.2.2 → 4.3.0 (latest stable)

## Result

| | Before | After |
|---|---|---|
| Size | 3.8 MB | **1.8 MB** (-52%) |
| Classes | 1812 | **696** |
| Top-level packages | `org/junit/jupiter`, `org/junit/platform`, `org/apiguardian`, `org/opentest4j`, `com/google/auto`, `META-INF/versions/9`, `org/apache/flink` | **`org/apache/flink` only** |

## Test plan

- [x] Local: clean build produces `statefun-sdk-java-3.4.0-KZM-3.0.jar` (1.8 MB) with no test libs
- [ ] CI Build & Test
- [ ] CI K8s E2E
- Effective on next release tag.