### PR TITLE
fix: update CODEOWNERS to current GitHub handle

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # Default code owners for kzmlabs/flink-statefun
-* @kazimio
+* @oleksandr-kazimirov


### PR DESCRIPTION
Last legacy `@kazimio` reference in the repo. Replaces with `@oleksandr-kazimirov` (matches MAINTAINERS.md).

Verified by full-tree grep — no other `kazimio` references remain.

Test plan: CI Build & Test, K8s E2E (always-on gate).