### PR TITLE
chore: remove .asf.yaml after fork detach

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -1,5 +1,0 @@
-github:
-  enabled_merge_buttons:
-    squash: true
-    merge: false
-    rebase: true


### PR DESCRIPTION
Apache-fork-only metadata. The repo was detached from apache/flink-statefun upstream — this file is no longer relevant. GitHub merge-button settings already managed via the project's GitHub UI.