### PR TITLE
fix(e2e): build remote-function against in-reactor SDK via -Drevision

### DIFF
--- a/statefun-k8s-native-e2e/pom.xml
+++ b/statefun-k8s-native-e2e/pom.xml
@@ -184,6 +184,7 @@
                                         <argument>-f</argument>
                                         <argument>${project.basedir}/remote-function/pom.xml</argument>
                                         <argument>-DskipTests</argument>
+                                        <argument>-Drevision=${project.version}</argument>
                                         <argument>-B</argument>
                                     </arguments>
                                 </configuration>

--- a/statefun-k8s-native-e2e/remote-function/pom.xml
+++ b/statefun-k8s-native-e2e/remote-function/pom.xml
@@ -7,13 +7,13 @@
 
     <groupId>io.github.kzmlabs.flinkstatefun</groupId>
     <artifactId>statefun-k8s-native-e2e-remote-function</artifactId>
-    <version>3.4.0-KZM-2.0-RC5</version>
+    <version>${revision}</version>
     <name>statefun-k8s-native-e2e-remote-function</name>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>21</java.version>
-        <statefun.version>3.4.0-KZM-2.0-RC5</statefun.version>
+        <statefun.version>${revision}</statefun.version>
         <protobuf.version>3.25.5</protobuf.version>
         <protoc-jar-maven-plugin.version>3.11.4</protoc-jar-maven-plugin.version>
     </properties>


### PR DESCRIPTION
The standalone \`statefun-k8s-native-e2e/remote-function/pom.xml\` was pinned to a published Maven Central version (\`3.4.0-KZM-2.0-RC5\`), so the K8s E2E silently tested the *previously-released* SDK bytes instead of any local SDK changes.

This forwards \`-Drevision=\${project.version}\` from the parent reactor into the standalone build and replaces the hardcoded version with \`\${revision}\`, leaving the root pom's \`<revision>\` as the single source of truth.

Closes #88.

## Test plan
- [x] Full local \`mvn clean install -B -Drat.skip=false\` (K8s E2E gate)