### PR TITLE
fix(e2e): pin operator image.tag and use sudo install for non-root runners

### DIFF
--- a/statefun-k8s-native-e2e/scripts/setup-cluster.sh
+++ b/statefun-k8s-native-e2e/scripts/setup-cluster.sh
@@ -44,8 +44,13 @@ ensure_tool() {
     command -v scoop >/dev/null 2>&1 || { echo "ERROR: install ${tool} manually (no scoop available)"; exit 1; }
     scoop install "${tool}"
   else
-    curl -fsSL "${linux_url}" -o "/usr/local/bin/${tool}"
-    chmod +x "/usr/local/bin/${tool}"
+    curl -fsSL "${linux_url}" -o "/tmp/${tool}"
+    if [[ $EUID -eq 0 ]]; then
+      install -m 0755 "/tmp/${tool}" "/usr/local/bin/${tool}"
+    else
+      sudo install -m 0755 "/tmp/${tool}" "/usr/local/bin/${tool}"
+    fi
+    rm -f "/tmp/${tool}"
   fi
 }
 
@@ -85,7 +90,8 @@ helm repo add flink-operator-repo \
   "https://archive.apache.org/dist/flink/flink-kubernetes-operator-${FLINK_OPERATOR_VERSION}/" || true
 helm repo update
 helm install flink-kubernetes-operator flink-operator-repo/flink-kubernetes-operator \
-  --namespace flink-operator --create-namespace --wait --timeout 5m
+  --namespace flink-operator --create-namespace --wait --timeout 5m \
+  --set image.tag="${FLINK_OPERATOR_VERSION}"
 
 # --- In-namespace infra -----------------------------------------------------
 


### PR DESCRIPTION
Two independent CI-robustness fixes for \`statefun-k8s-native-e2e/scripts/setup-cluster.sh\`:

- **\`ensure_tool\`**: stage downloads in \`/tmp\` and \`install\` into \`/usr/local/bin\` via \`sudo\` (no-op when already root via \`\$EUID\` check) so non-root CI runners no longer fail with EACCES on direct \`/usr/local/bin\` writes.
- **\`helm install\`**: explicitly \`--set image.tag=\${FLINK_OPERATOR_VERSION}\` so the operator binary stays in lock-step with the chart's RBAC even if the chart is ever sourced from a release branch instead of a release artifact (where \`:latest\` would otherwise drift).

Closes #89, #90.

## Test plan
- [x] Full local \`mvn clean install -B -Drat.skip=false\` (K8s E2E gate)