### PR TITLE
fix(e2e): IMAGE_REGISTRY_PREFIX for k8s manifests

### DIFF
--- a/statefun-k8s-native-e2e/scripts/setup-cluster.sh
+++ b/statefun-k8s-native-e2e/scripts/setup-cluster.sh
@@ -22,6 +22,8 @@ KAFKA_TOPICS=(counter.commands counter.results greeter.commands greeter.results)
 KINESIS_STREAMS=(counter.commands counter.results)
 S3_BUCKET=statefun-checkpoints
 
+IMAGE_REGISTRY_PREFIX="${IMAGE_REGISTRY_PREFIX:-}"
+
 BASEDIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null && pwd)"
 K8S_MANIFESTS="${BASEDIR}/../src/test/resources/k8s"
 
@@ -92,8 +94,10 @@ helm install flink-kubernetes-operator flink-operator-repo/flink-kubernetes-oper
 echo "=== Deploying namespace, RBAC, Kafka, LocalStack, remote function, module ==="
 kubectl apply -f "${K8S_MANIFESTS}/namespace.yaml"
 kubectl apply -f "${K8S_MANIFESTS}/flink-rbac.yaml"
-kubectl apply -f "${K8S_MANIFESTS}/kafka.yaml"
-kubectl apply -f "${K8S_MANIFESTS}/localstack.yaml"
+sed -e "s|\${IMAGE_REGISTRY_PREFIX}|${IMAGE_REGISTRY_PREFIX}|g" \
+    "${K8S_MANIFESTS}/kafka.yaml" | kubectl apply -f -
+sed -e "s|\${IMAGE_REGISTRY_PREFIX}|${IMAGE_REGISTRY_PREFIX}|g" \
+    "${K8S_MANIFESTS}/localstack.yaml" | kubectl apply -f -
 kubectl apply -f "${K8S_MANIFESTS}/remote-function.yaml"
 kubectl apply -f "${K8S_MANIFESTS}/module-configmap.yaml"
 

--- a/statefun-k8s-native-e2e/src/test/resources/k8s/kafka.yaml
+++ b/statefun-k8s-native-e2e/src/test/resources/k8s/kafka.yaml
@@ -20,7 +20,7 @@ spec:
     spec:
       containers:
         - name: kafka
-          image: apache/kafka:3.9.0
+          image: ${IMAGE_REGISTRY_PREFIX}apache/kafka:3.9.0
           env:
             - name: KAFKA_NODE_ID
               value: "1"

--- a/statefun-k8s-native-e2e/src/test/resources/k8s/localstack.yaml
+++ b/statefun-k8s-native-e2e/src/test/resources/k8s/localstack.yaml
@@ -18,7 +18,7 @@ spec:
     spec:
       containers:
         - name: localstack
-          image: localstack/localstack:4.1
+          image: ${IMAGE_REGISTRY_PREFIX}localstack/localstack:4.1
           ports:
             - containerPort: 4566
           env:


### PR DESCRIPTION
Restricted-network builds set \`IMAGE_REGISTRY_PREFIX\` (e.g. \`harbor.example.com/dockerhub-proxy/\`) so kafka and localstack pods pull base images through an internal registry without forking the manifests. Default empty preserves existing Docker Hub behaviour.

\`sed\` (universally available, including Git Bash on Windows) substitutes the placeholder at apply time — no \`envsubst\` dependency.

Closes #94.

## Test plan
- [x] Full local \`mvn clean install -B -Drat.skip=false\` (K8s E2E gate)