### PR TITLE
feat(e2e): multi-stage jlink-stripped JRE for remote-function image (~80 MB)

### DIFF
--- a/statefun-k8s-native-e2e/remote-function/Dockerfile
+++ b/statefun-k8s-native-e2e/remote-function/Dockerfile
@@ -1,7 +1,20 @@
 # SPDX-License-Identifier: Apache-2.0
 
 
-FROM eclipse-temurin:21-jre-alpine
+ARG IMAGE_REGISTRY_PREFIX=
+ARG JDK_BUILDER_IMAGE=${IMAGE_REGISTRY_PREFIX}eclipse-temurin:21-jdk-alpine
+ARG RUNTIME_BASE_IMAGE=${IMAGE_REGISTRY_PREFIX}alpine:3.21
+
+FROM ${JDK_BUILDER_IMAGE} AS jre-builder
+RUN "${JAVA_HOME}/bin/jlink" \
+        --add-modules java.base,java.compiler,java.desktop,java.instrument,java.logging,java.management,java.naming,java.net.http,java.security.jgss,java.security.sasl,java.sql,java.xml,jdk.crypto.ec,jdk.unsupported \
+        --strip-debug --no-man-pages --no-header-files --compress=2 \
+        --include-locales=en \
+        --output /opt/jre
+
+FROM ${RUNTIME_BASE_IMAGE}
+COPY --from=jre-builder /opt/jre /opt/jre
+ENV PATH="/opt/jre/bin:${PATH}"
 
 COPY target/statefun-k8s-native-e2e-remote-function-*.jar /opt/remote-function.jar
 


### PR DESCRIPTION
Replaces \`eclipse-temurin:21-jre-alpine\` (~210 MB) with a multi-stage jlink build on \`alpine:3.21\` for \`statefun-k8s-native-e2e/remote-function/Dockerfile\`. Final image is ~80 MB.

Both base images (JDK builder + alpine runtime) are parametric via \`IMAGE_REGISTRY_PREFIX\` — closes the remaining file from #93.

## Test plan
- [x] Full local \`mvn clean install -B -Drat.skip=false\` (K8s E2E gate, image built and run end-to-end)