### PR TITLE
build: silence module-info shading warnings; pin central plugin; bump testcontainers

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -413,6 +413,22 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-shade-plugin</artifactId>
                     <version>${maven-shade-plugin.version}</version>
+                    <configuration>
+                        <filters combine.children="append">
+                            <filter>
+                                <artifact>*:*</artifact>
+                                <excludes>
+                                    <exclude>module-info.class</exclude>
+                                    <exclude>META-INF/versions/*/module-info.class</exclude>
+                                </excludes>
+                            </filter>
+                        </filters>
+                    </configuration>
+                </plugin>
+                <plugin>
+                    <groupId>org.sonatype.central</groupId>
+                    <artifactId>central-publishing-maven-plugin</artifactId>
+                    <version>${central-publishing-maven-plugin.version}</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>

--- a/statefun-e2e-tests/pom.xml
+++ b/statefun-e2e-tests/pom.xml
@@ -15,7 +15,7 @@
     <packaging>pom</packaging>
 
     <properties>
-        <testcontainers.version>2.0.3</testcontainers.version>
+        <testcontainers.version>2.0.5</testcontainers.version>
         <central.skip>true</central.skip>
     </properties>
 


### PR DESCRIPTION
Three independent build-hygiene fixes:

- **maven-shade-plugin**: add a default \`<filters combine.children=\"append\">\` in root pluginManagement that excludes \`module-info.class\` and \`META-INF/versions/*/module-info.class\`. Drops 34 \"Discovered module-info.class. Shading will break its strong encapsulation\" warnings to 0. Child shade configs inherit it via combine.children=append, so any per-module filters keep working.
- **central-publishing-maven-plugin**: add to root \`pluginManagement\` (was only declared inside the release-profile \`<plugins>\`). Drops 10 \"plugin version is missing\" warnings to 0.
- **testcontainers**: bump 2.0.3 → 2.0.5 (latest 2.x patch).

## Test plan
- [x] \`mvn install -DskipTests -B\` — green; module-info warnings 34 → 0; central-publishing warnings 10 → 0.