### PR TITLE
chore: drop dead java11 profile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -306,29 +306,6 @@
             </build>
         </profile>
 
-        <profile>
-            <id>java11</id>
-            <activation>
-                <jdk>[11,)</jdk>
-            </activation>
-
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-compiler-plugin</artifactId>
-                        <configuration>
-                            <source>21</source>
-                            <target>21</target>
-                            <compilerArgs combine.children="append">
-                                <arg>--add-exports=java.base/sun.net.util=ALL-UNNAMED</arg>
-                                <arg>--add-exports=java.management/sun.management=ALL-UNNAMED</arg>
-                            </compilerArgs>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
     </profiles>
 
     <build>
@@ -466,6 +443,10 @@
                 <configuration>
                     <source>21</source>
                     <target>21</target>
+                    <compilerArgs>
+                        <arg>--add-exports=java.base/sun.net.util=ALL-UNNAMED</arg>
+                        <arg>--add-exports=java.management/sun.management=ALL-UNNAMED</arg>
+                    </compilerArgs>
                     <annotationProcessorPaths>
                         <path>
                             <groupId>com.google.auto.service</groupId>


### PR DESCRIPTION
The \`java11\` profile activated on \`<jdk>[11,)</jdk>\` and added two \`--add-exports\` compiler args. With Java 21 as the baseline, it always activated — pure dead weight that *looks* like a Java-version gate but isn't.

## Change

- Move the two \`--add-exports\` flags into the main \`maven-compiler-plugin <compilerArgs>\`
- Delete the profile

## Net behaviour

Identical. Same compiler args reach the same plugin. The only visible difference is one fewer (noisy) profile in IDE Maven panels.

## Test plan

- [x] \`mvn -N validate -B\` clean
- [ ] CI build (this PR)