### PR TITLE
chore(security): silence generated-source CodeQL noise + scope attest-image perms

### DIFF
--- a/.github/workflows/attest-image.yml
+++ b/.github/workflows/attest-image.yml
@@ -18,9 +18,6 @@ on:
         required: true
 
 permissions:
-  id-token: write
-  attestations: write
-  packages: write
   contents: read
 
 env:
@@ -31,6 +28,11 @@ jobs:
   attest:
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    permissions:
+      id-token: write
+      attestations: write
+      packages: write
+      contents: read
 
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -43,6 +43,9 @@ jobs:
         with:
           languages: ${{ matrix.language }}
           queries: security-and-quality
+          paths-ignore: |
+            **/target/generated-sources/**
+            **/target/generated-test-sources/**
 
       - name: Build (skip tests)
         run: mvn install -DskipTests -B -Drat.skip=true -Dskip.k8s.e2e


### PR DESCRIPTION
Two small security-tab cleanups.

## codeql.yml — exclude generated sources

Adds:
\`\`\`yaml
paths-ignore: |
  **/target/generated-sources/**
  **/target/generated-test-sources/**
\`\`\`

Drops the 18 false-positive notes raised against protobuf-generated classes (\`E2EProtos.java\` and similar): \`java/unused-parameter\`, \`java/confusing-method-signature\`, \`java/missing-override-annotation\`. CodeQL's own analysis stays clean (already 0 real alerts).

## attest-image.yml — job-level permissions

Moves \`id-token: write\`, \`attestations: write\`, \`packages: write\` from workflow-level to job-level. Top-level retains \`contents: read\`. Resolves OpenSSF Scorecard \`TokenPermissionsID\` finding — write perms now scoped to only the job that needs them.

## Test plan

- [x] \`gh workflow run attest-image.yml\` semantics unchanged — same perms reach the runtime job
- [ ] CI on this PR (CodeQL + Build + E2E)