### PR TITLE
build: pin jsr305 to 3.0.2 in dependencyManagement

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -228,6 +228,14 @@
                 <version>4.1.91.Final-17.0</version>
             </dependency>
 
+            <!-- Resolve convergence: Flink 2.2 transitively pulls jsr305 1.3.9
+                 via flink-datastream-api/flink-rpc-core; SDK modules want 3.0.2. -->
+            <dependency>
+                <groupId>com.google.code.findbugs</groupId>
+                <artifactId>jsr305</artifactId>
+                <version>3.0.2</version>
+            </dependency>
+
         </dependencies>
     </dependencyManagement>
 


### PR DESCRIPTION
Resolves the convergence error that blocked #117.

## Problem

Flink 2.2 transitively ships **jsr305 1.3.9** via \`flink-datastream-api\` / \`flink-rpc-core\`. SDK modules (\`statefun-sdk-embedded\`, \`statefun-flink\`) pull **3.0.2\`. The enforcer's \`dependencyConvergence\` rule rejects the mismatch:

\`\`\`
Dependency convergence error for com.google.code.findbugs:jsr305:jar:3.0.2.
[direct path]      → 3.0.2
[via flink-runtime]→ 1.3.9
\`\`\`

## Fix

Pin jsr305 to 3.0.2 in root \`<dependencyManagement>\`. Maven's nearest-wins is overridden by dependencyManagement, so every transitive 1.3.9 is rewritten to 3.0.2 across the reactor.

This same pattern is already used in the parent pom for \`commons-lang3\`, \`commons-compress\`, \`commons-io\`, \`flink-shaded-netty\` (same root cause: Flink 2.2 ships old transitives).

## Why not merge #117 instead

#117 only bumped two SDK module poms; it doesn't address Flink's transitive 1.3.9, so the convergence rule still fails. This pom-level pin is the correct shape and supersedes #117.