### PR TITLE
fix(docs): pin docs deps so workflow pip cache resolves

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -29,5 +29,6 @@ jobs:
         with:
           python-version: "3.13"
           cache: pip
-      - run: pip install mkdocs-material pymdown-extensions
+          cache-dependency-path: docs/requirements.txt
+      - run: pip install -r docs/requirements.txt
       - run: mkdocs gh-deploy --force

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,2 @@
+mkdocs-material==9.6.20
+pymdown-extensions==10.18


### PR DESCRIPTION
Docs workflow was failing at `actions/setup-python@v5` with:

```
No file in /home/runner/work/flink-statefun/flink-statefun matched to
[**/requirements.txt or **/pyproject.toml]
```

`cache: pip` needs an explicit dependency manifest. Added `docs/requirements.txt` pinning `mkdocs-material` and `pymdown-extensions`, then pointed `cache-dependency-path` at it. Workflow now reproducibly installs the same versions every run.