### PR TITLE
fix(docs): use Python 3.12 — 3.13 trips pygments

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -27,7 +27,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.13"
+          python-version: "3.12"
           cache: pip
           cache-dependency-path: docs/requirements.txt
       - run: pip install -r docs/requirements.txt


### PR DESCRIPTION
Follow-up to #122. The docs workflow now installs deps via requirements.txt cleanly, but mkdocs-build fails on Python 3.13 with:

```
AttributeError: 'NoneType' object has no attribute 'replace'
  at pygments html.escape(self._decodeifneeded(options.get('filename', '')))
```

pymdown-extensions passes `filename=None` to pygments; pygments doesn't fall back to '' when the value is None (only when the key is missing). Python 3.12 is MkDocs Material's tested baseline — moving to it sidesteps the issue without pinning pygments.