### PR TITLE
fix(docs): pin pygments 2.18.0 to fix mkdocs build

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,2 +1,3 @@
 mkdocs-material==9.6.20
 pymdown-extensions==10.18
+pygments==2.18.0


### PR DESCRIPTION
Latest pygments regresses on `html.escape(None)` when pymdownx.highlight passes `filename=None`. Pin 2.18.0 which still falls back to ''.