### PR TITLE
feat(docs): 8-bit / neobrutalist theme overlay

### DIFF
--- a/docs/assets/css/8bit.css
+++ b/docs/assets/css/8bit.css
@@ -1,0 +1,202 @@
+/*
+ * 8-bit / neobrutalist theme overlay for MkDocs Material
+ * Pixel headings + chunky borders + hard drop shadows.
+ * Body text stays readable for long technical docs.
+ */
+
+@import url('https://fonts.googleapis.com/css2?family=Press+Start+2P&family=VT323&family=JetBrains+Mono:wght@400;700&display=swap');
+
+:root {
+  --md-text-font: "JetBrains Mono", ui-monospace, "SFMono-Regular", monospace;
+  --md-code-font: "JetBrains Mono", ui-monospace, monospace;
+
+  --8bit-shadow: 4px 4px 0 var(--md-default-fg-color);
+  --8bit-shadow-hover: 6px 6px 0 var(--md-default-fg-color);
+  --8bit-border: 3px solid var(--md-default-fg-color);
+}
+
+/* NES-ish palette overrides */
+[data-md-color-scheme="default"] {
+  --md-primary-fg-color: #1a1a2e;
+  --md-accent-fg-color: #ff5470;
+  --md-typeset-a-color: #2563eb;
+}
+[data-md-color-scheme="slate"] {
+  --md-default-bg-color: #0d1b3e;
+  --md-default-bg-color--light: #142450;
+  --md-default-fg-color: #f8f8f8;
+  --md-typeset-color: #f8f8f8;
+  --md-primary-fg-color: #ffd700;
+  --md-accent-fg-color: #00d4aa;
+  --md-typeset-a-color: #00d4aa;
+}
+
+/* ───── Pixel typography ─────────────────────────────────────── */
+
+.md-header__title,
+.md-typeset h1,
+.md-typeset h2,
+.md-typeset .admonition-title,
+.md-typeset summary,
+.md-typeset .md-button,
+.md-typeset table:not([class]) th,
+.md-typeset .grid.cards > ol > li > p:first-child,
+.md-typeset .grid.cards > ul > li > p:first-child {
+  font-family: "Press Start 2P", system-ui, sans-serif !important;
+  letter-spacing: 0;
+}
+
+.md-header__title { font-size: 0.85rem; line-height: 1.6; }
+.md-typeset h1 { font-size: 1.7rem; line-height: 1.6; margin-top: 1.5em; }
+.md-typeset h2 { font-size: 1.1rem; line-height: 1.7; margin-top: 2em; padding-bottom: 0.5em; border-bottom: 3px solid var(--md-default-fg-color); }
+.md-typeset .admonition-title,
+.md-typeset summary { font-size: 0.7rem !important; text-transform: uppercase; letter-spacing: 1px; }
+.md-typeset table:not([class]) th { font-size: 0.65rem !important; text-transform: uppercase; letter-spacing: 1px; }
+
+/* ───── Neobrutalist cards (the "Where next" grids) ──────────── */
+
+.md-typeset .grid.cards > ol > li,
+.md-typeset .grid.cards > ul > li {
+  border: var(--8bit-border) !important;
+  border-radius: 0 !important;
+  box-shadow: var(--8bit-shadow);
+  transition: transform 0.1s ease, box-shadow 0.1s ease;
+  background: var(--md-default-bg-color);
+}
+.md-typeset .grid.cards > ol > li:hover,
+.md-typeset .grid.cards > ul > li:hover {
+  transform: translate(-2px, -2px);
+  box-shadow: var(--8bit-shadow-hover);
+}
+.md-typeset .grid.cards > ol > li > p:first-child,
+.md-typeset .grid.cards > ul > li > p:first-child {
+  font-size: 0.75rem !important;
+  line-height: 1.6;
+}
+
+/* ───── Admonitions as dialog boxes ──────────────────────────── */
+
+.md-typeset .admonition,
+.md-typeset details {
+  border: var(--8bit-border) !important;
+  border-radius: 0 !important;
+  box-shadow: var(--8bit-shadow);
+}
+
+/* ───── Code blocks: chunky border, no rounding ──────────────── */
+
+.md-typeset pre > code,
+.md-typeset .highlight,
+.md-typeset code {
+  border-radius: 0 !important;
+}
+.md-typeset .highlight {
+  border: 2px solid var(--md-default-fg-color);
+}
+
+/* ───── Buttons: hard border + chunky shadow ─────────────────── */
+
+.md-typeset .md-button {
+  border: var(--8bit-border);
+  border-radius: 0;
+  box-shadow: var(--8bit-shadow);
+  font-size: 0.7rem !important;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  padding: 0.6em 1em;
+  transition: transform 0.1s, box-shadow 0.1s;
+}
+.md-typeset .md-button:hover {
+  transform: translate(-2px, -2px);
+  box-shadow: var(--8bit-shadow-hover);
+}
+
+/* ───── Tables ───────────────────────────────────────────────── */
+
+.md-typeset table:not([class]) {
+  border: var(--8bit-border) !important;
+  border-radius: 0 !important;
+  box-shadow: var(--8bit-shadow);
+}
+
+/* ───── Blockquote = NES dialog box, with subtle scanlines ──── */
+
+.md-typeset blockquote {
+  border: var(--8bit-border);
+  border-left: var(--8bit-border);
+  border-radius: 0;
+  box-shadow: var(--8bit-shadow);
+  padding: 1em 1.2em;
+  background: var(--md-default-bg-color);
+  position: relative;
+  color: var(--md-typeset-color);
+  font-style: normal;
+}
+.md-typeset blockquote::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: repeating-linear-gradient(
+    0deg,
+    transparent 0px,
+    transparent 2px,
+    rgba(127, 127, 127, 0.06) 2px,
+    rgba(127, 127, 127, 0.06) 3px
+  );
+  pointer-events: none;
+}
+
+/* ───── Search box, nav, footer: square corners ──────────────── */
+
+.md-search__form,
+.md-search__inner,
+.md-tabs__link,
+.md-nav__link,
+.md-footer-meta {
+  border-radius: 0 !important;
+}
+
+/* ───── Inline code: chunky monospace ────────────────────────── */
+
+.md-typeset code:not(.highlight code) {
+  background: var(--md-default-bg-color--light, rgba(0,0,0,0.05));
+  padding: 0.1em 0.4em;
+  border: 1px solid var(--md-default-fg-color);
+  border-radius: 0 !important;
+}
+
+/* ───── Mermaid containers also get the brutalist border ─────── */
+
+.md-typeset .mermaid {
+  border: var(--8bit-border);
+  box-shadow: var(--8bit-shadow);
+  background: var(--md-default-bg-color);
+  padding: 1em;
+}
+
+/* ───── Smoother on small screens — drop shadows scale down ──── */
+
+@media (max-width: 600px) {
+  :root {
+    --8bit-shadow: 2px 2px 0 var(--md-default-fg-color);
+    --8bit-shadow-hover: 4px 4px 0 var(--md-default-fg-color);
+  }
+  .md-header__title { font-size: 0.7rem; }
+  .md-typeset h1 { font-size: 1.3rem; }
+  .md-typeset h2 { font-size: 0.95rem; }
+}
+
+/* ───── Optional: reduce motion respects user setting ────────── */
+
+@media (prefers-reduced-motion: reduce) {
+  .md-typeset .grid.cards > ol > li,
+  .md-typeset .grid.cards > ul > li,
+  .md-typeset .md-button {
+    transition: none;
+  }
+  .md-typeset .grid.cards > ol > li:hover,
+  .md-typeset .grid.cards > ul > li:hover,
+  .md-typeset .md-button:hover {
+    transform: none;
+  }
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -83,6 +83,9 @@ extra:
       link: https://central.sonatype.com/artifact/io.github.kzmlabs.flinkstatefun/statefun-bom
       name: Maven Central
 
+extra_css:
+  - assets/css/8bit.css
+
 extra_javascript:
   - https://unpkg.com/mermaid@11/dist/mermaid.min.js
   - assets/js/mermaid-init.js


### PR DESCRIPTION
Pixel headings + chunky borders + NES palette. Body text stays JetBrains Mono so long technical pages remain readable; the retro signal lives on titles, cards, admonitions, buttons, tables. Build green locally.