### PR TITLE
feat(docs): style polish + 'Actors' added alongside StateFun

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Kzmlabs StateFun
+# Kzmlabs StateFun · Actors
 
-> Stateful actors on Apache Flink — durable per-key state, exactly-once messaging, Kafka and Kinesis I/O, Kubernetes-native deployment. The actively maintained continuation of [Apache Stateful Functions](https://github.com/apache/flink-statefun) for Flink 2.x and Java 21.
+> **Stateful Actors on Apache Flink** — durable per-key state, exactly-once messaging, Kafka and Kinesis I/O, Kubernetes-native deployment. The actively maintained continuation of [Apache Stateful Functions](https://github.com/apache/flink-statefun) for Flink 2.x and Java 21.
 
 [![Maven Central](https://img.shields.io/maven-central/v/io.github.kzmlabs.flinkstatefun/statefun-bom?label=Maven%20Central)](https://central.sonatype.com/artifact/io.github.kzmlabs.flinkstatefun/statefun-bom)
 [![GitHub Release](https://img.shields.io/github/v/release/kzmlabs/flink-statefun?label=GHCR)](https://github.com/kzmlabs/flink-statefun/pkgs/container/flink-statefun)

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,9 +3,9 @@ title: Kzmlabs StateFun
 description: Stateful actors on Apache Flink — durable per-key state, exactly-once messaging, Kafka and Kinesis I/O, Kubernetes-native deployment. Actively maintained continuation of Apache Stateful Functions for Flink 2.x and Java 21.
 ---
 
-# Kzmlabs StateFun
+# Kzmlabs StateFun · Actors
 
-> Stateful actors on Apache Flink — durable per-key state, exactly-once messaging, Kafka and Kinesis I/O, Kubernetes-native deployment.
+> **Stateful Actors on Apache Flink** — durable per-key state, exactly-once messaging, Kafka and Kinesis I/O, Kubernetes-native deployment.
 
 [![Maven Central](https://img.shields.io/maven-central/v/io.github.kzmlabs.flinkstatefun/statefun-bom?label=Maven%20Central)](https://central.sonatype.com/artifact/io.github.kzmlabs.flinkstatefun/statefun-bom){ .md-button-link }
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue)](https://github.com/kzmlabs/flink-statefun/blob/release/LICENSE)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,4 +1,4 @@
-site_name: Kzmlabs StateFun · Actors on Flink
+site_name: Kzmlabs StateFun · Actors
 site_description: Stateful actors on Apache Flink — durable per-key state, exactly-once messaging, Kafka and Kinesis I/O, Kubernetes-native. Flink 2.2 + Java 21 continuation of Apache Stateful Functions.
 site_url: https://kzmlabs.github.io/flink-statefun/
 repo_url: https://github.com/kzmlabs/flink-statefun


### PR DESCRIPTION
Naming: 'Kzmlabs StateFun · Actors' — keeps StateFun keyword for SEO continuity while adding Actors as a new keyword surface. README + repo description aligned.

Style polish: clean Inter body font, CRT cyan glow on H1 with animated blink cursor, ▶ arrow prefixes on H2/admonition titles, subtle pixel-grid background, terminal-header strip on code blocks, fattening underlines on hover, glow on button hover. Mobile: cleaner sizing.