### PR TITLE
docs: rename to 'StateFun Actors by Kzmlabs' + weave Apache Flink through every description

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,9 +31,9 @@ flowchart LR
 
 ## Why this exists
 
-Apache Stateful Functions stopped releasing in October 2024 at 3.4.0, locked to Flink 1.16 and Java 11. Anyone wanting to run it against modern Flink either pinned old dependencies or vendored their own patches. Kzmlabs StateFun is the public, actively maintained branch — same code, modern stack, no vendor lock-in.
+Apache Stateful Functions stopped releasing in October 2024 at 3.4.0, locked to Flink 1.16 and Java 11. Anyone wanting to run it against modern Flink either pinned old dependencies or vendored their own patches. StateFun Actors is the public, actively maintained branch — same code, modern stack, no vendor lock-in.
 
-| | Apache StateFun 3.4.0 | Kzmlabs StateFun KZM-3.1 |
+| | Apache StateFun 3.4.0 | StateFun Actors KZM-3.1 |
 |---|---|---|
 | **Flink runtime** | 1.16.2 | **2.2.0** |
 | **Java baseline** | 11 | **21** |
@@ -179,7 +179,7 @@ Licensed under the [Apache License 2.0](LICENSE). Originally derived from [Apach
 
 ## Citing
 
-If you use Kzmlabs StateFun in research, please cite via the [`CITATION.cff`](CITATION.cff) file (GitHub's "Cite this repository" button).
+If you use StateFun Actors in research, please cite via the [`CITATION.cff`](CITATION.cff) file (GitHub's "Cite this repository" button).
 
 ## Links
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Kzmlabs StateFun · Actors
+# StateFun Actors by Kzmlabs
 
 > **Stateful Actors on Apache Flink** — durable per-key state, exactly-once messaging, Kafka and Kinesis I/O, Kubernetes-native deployment. The actively maintained continuation of [Apache Stateful Functions](https://github.com/apache/flink-statefun) for Flink 2.x and Java 21.
 

--- a/docs/architecture/e2e-tests.md
+++ b/docs/architecture/e2e-tests.md
@@ -1,6 +1,6 @@
 ---
 title: End-to-end tests
-description: The Kubernetes-native E2E gate that runs before every Kzmlabs StateFun release — kind cluster, Flink Operator, Kafka, Kinesis-via-LocalStack, RocksDB checkpoints to S3.
+description: The Kubernetes-native E2E gate that runs before every StateFun Actors release — kind cluster, Flink Operator, Kafka, Kinesis-via-LocalStack, RocksDB checkpoints to S3.
 ---
 
 # End-to-end tests

--- a/docs/architecture/e2e-tests.md
+++ b/docs/architecture/e2e-tests.md
@@ -1,6 +1,6 @@
 ---
 title: End-to-end tests
-description: The Kubernetes-native E2E gate that runs before every StateFun Actors release — kind cluster, Flink Operator, Kafka, Kinesis-via-LocalStack, RocksDB checkpoints to S3.
+description: The Kubernetes-native end-to-end test gate that runs before every StateFun Actors release on Apache Flink — kind cluster, Flink Operator, Kafka, Kinesis-via-LocalStack, RocksDB checkpoints to S3.
 ---
 
 # End-to-end tests

--- a/docs/architecture/index.md
+++ b/docs/architecture/index.md
@@ -1,6 +1,6 @@
 ---
 title: Architecture
-description: Kzmlabs StateFun architecture — dispatcher, function model, ingress and egress, state and checkpointing, deployment topology.
+description: StateFun Actors architecture — dispatcher, function model, ingress and egress, state and checkpointing, deployment topology.
 ---
 
 # Architecture

--- a/docs/architecture/index.md
+++ b/docs/architecture/index.md
@@ -1,6 +1,6 @@
 ---
 title: Architecture
-description: StateFun Actors architecture — dispatcher, function model, ingress and egress, state and checkpointing, deployment topology.
+description: StateFun Actors architecture on Apache Flink — dispatcher, function model, ingress and egress, state and checkpointing, deployment topology.
 ---
 
 # Architecture

--- a/docs/architecture/shading.md
+++ b/docs/architecture/shading.md
@@ -1,6 +1,6 @@
 ---
 title: Shading layer
-description: How StateFun Actors relocates Protobuf so the runtime and user code can use different Protobuf versions on the same classpath without conflicts.
+description: How StateFun Actors on Apache Flink relocates Protobuf so the runtime and user code can use different Protobuf versions on the same classpath without conflicts.
 ---
 
 # Shading layer

--- a/docs/architecture/shading.md
+++ b/docs/architecture/shading.md
@@ -1,6 +1,6 @@
 ---
 title: Shading layer
-description: How Kzmlabs StateFun relocates Protobuf so the runtime and user code can use different Protobuf versions on the same classpath without conflicts.
+description: How StateFun Actors relocates Protobuf so the runtime and user code can use different Protobuf versions on the same classpath without conflicts.
 ---
 
 # Shading layer

--- a/docs/build.md
+++ b/docs/build.md
@@ -1,6 +1,6 @@
 ---
 title: Build from source
-description: Build StateFun Actors from source — full reactor, fast iteration modes, restricted-network registry mirrors, formatter, and contribution workflow.
+description: Build StateFun Actors (Apache Flink 2.2 + Java 21) from source — full reactor, fast iteration modes, restricted-network registry mirrors, formatter, and contribution workflow.
 ---
 
 # Build from source

--- a/docs/build.md
+++ b/docs/build.md
@@ -1,6 +1,6 @@
 ---
 title: Build from source
-description: Build Kzmlabs StateFun from source — full reactor, fast iteration modes, restricted-network registry mirrors, formatter, and contribution workflow.
+description: Build StateFun Actors from source — full reactor, fast iteration modes, restricted-network registry mirrors, formatter, and contribution workflow.
 ---
 
 # Build from source

--- a/docs/examples/fraud-detection.md
+++ b/docs/examples/fraud-detection.md
@@ -1,6 +1,6 @@
 ---
 title: Real-time fraud detection
-description: A worked Kzmlabs StateFun example — per-card risk scoring on a payments stream with velocity, geo-impossibility, and amount-anomaly detection.
+description: A worked StateFun Actors example — per-card risk scoring on a payments stream with velocity, geo-impossibility, and amount-anomaly detection.
 ---
 
 # Real-time fraud detection

--- a/docs/examples/fraud-detection.md
+++ b/docs/examples/fraud-detection.md
@@ -1,6 +1,6 @@
 ---
 title: Real-time fraud detection
-description: A worked StateFun Actors example — per-card risk scoring on a payments stream with velocity, geo-impossibility, and amount-anomaly detection.
+description: Real-time fraud detection on Apache Flink with StateFun Actors — per-card risk scoring on a payments stream with velocity, geo-impossibility, and amount-anomaly detection.
 ---
 
 # Real-time fraud detection

--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -1,6 +1,6 @@
 ---
 title: Examples
-description: Production-shaped StateFun Actors examples — financial fraud detection and IoT fleet telemetry, with full code, module.yaml wiring, and deployment notes.
+description: Production-shaped StateFun Actors examples on Apache Flink — financial fraud detection and IoT fleet telemetry, with full code, module.yaml wiring, and deployment notes.
 ---
 
 # Examples

--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -1,6 +1,6 @@
 ---
 title: Examples
-description: Production-shaped Kzmlabs StateFun examples — financial fraud detection and IoT fleet telemetry, with full code, module.yaml wiring, and deployment notes.
+description: Production-shaped StateFun Actors examples — financial fraud detection and IoT fleet telemetry, with full code, module.yaml wiring, and deployment notes.
 ---
 
 # Examples

--- a/docs/examples/iot-fleet.md
+++ b/docs/examples/iot-fleet.md
@@ -1,6 +1,6 @@
 ---
 title: IoT fleet digital twins
-description: A worked Kzmlabs StateFun example — per-device digital twins for industrial fleet telemetry with rolling sensor stats, anomaly detection, and command/response loop.
+description: A worked StateFun Actors example — per-device digital twins for industrial fleet telemetry with rolling sensor stats, anomaly detection, and command/response loop.
 ---
 
 # IoT fleet digital twins

--- a/docs/examples/iot-fleet.md
+++ b/docs/examples/iot-fleet.md
@@ -1,6 +1,6 @@
 ---
 title: IoT fleet digital twins
-description: A worked StateFun Actors example — per-device digital twins for industrial fleet telemetry with rolling sensor stats, anomaly detection, and command/response loop.
+description: IoT fleet digital twins on Apache Flink with StateFun Actors — per-device digital twins for industrial fleet telemetry with rolling sensor stats, anomaly detection, and command/response loop.
 ---
 
 # IoT fleet digital twins

--- a/docs/guides/k8s-deployment.md
+++ b/docs/guides/k8s-deployment.md
@@ -1,6 +1,6 @@
 ---
 title: Kubernetes deployment
-description: Production deployment of Kzmlabs StateFun via the Flink Kubernetes Operator — FlinkDeployment CR, RocksDB checkpoints to S3, leader-election tuning, restricted-network mirrors.
+description: Production deployment of StateFun Actors via the Flink Kubernetes Operator — FlinkDeployment CR, RocksDB checkpoints to S3, leader-election tuning, restricted-network mirrors.
 ---
 
 # Kubernetes deployment
@@ -189,6 +189,6 @@ Set `IMAGE_REGISTRY_PREFIX` at build time to pull all base images through your i
 - :material-test-tube:{ .lg .middle } &nbsp; **[E2E test architecture](../architecture/e2e-tests.md)** — same Operator + manifests, exercised by CI.
 - :material-server-network:{ .lg .middle } &nbsp; **[Kafka I/O](kafka-io.md)** — production ingress/egress configuration patterns.
 - :material-aws:{ .lg .middle } &nbsp; **[Kinesis I/O](kinesis-io.md)** — IRSA-based AWS credential setup.
-- :material-source-branch-sync:{ .lg .middle } &nbsp; **[Migrate from Apache StateFun](../upstream-vs-kzm.md)** — what changes when moving to Kzmlabs StateFun on Flink 2.x.
+- :material-source-branch-sync:{ .lg .middle } &nbsp; **[Migrate from Apache StateFun](../upstream-vs-kzm.md)** — what changes when moving to StateFun Actors on Flink 2.x.
 
 </div>

--- a/docs/guides/kafka-io.md
+++ b/docs/guides/kafka-io.md
@@ -1,6 +1,6 @@
 ---
 title: Kafka I/O
-description: Kafka ingress and egress configuration for Kzmlabs StateFun — exactly-once delivery, multi-topic ingresses, custom Protobuf types, routing patterns.
+description: Kafka ingress and egress configuration for StateFun Actors — exactly-once delivery, multi-topic ingresses, custom Protobuf types, routing patterns.
 ---
 
 # Kafka I/O

--- a/docs/guides/kafka-io.md
+++ b/docs/guides/kafka-io.md
@@ -1,6 +1,6 @@
 ---
 title: Kafka I/O
-description: Kafka ingress and egress configuration for StateFun Actors — exactly-once delivery, multi-topic ingresses, custom Protobuf types, routing patterns.
+description: Apache Kafka ingress and egress configuration for StateFun Actors on Apache Flink — exactly-once delivery, multi-topic ingresses, custom Protobuf types, routing patterns.
 ---
 
 # Kafka I/O

--- a/docs/guides/kinesis-io.md
+++ b/docs/guides/kinesis-io.md
@@ -1,6 +1,6 @@
 ---
 title: Kinesis I/O
-description: AWS Kinesis ingress and egress configuration for Kzmlabs StateFun on Flink 2.x — ARN-keyed routing, LocalStack development, IAM credential modes.
+description: AWS Kinesis ingress and egress configuration for StateFun Actors on Flink 2.x — ARN-keyed routing, LocalStack development, IAM credential modes.
 ---
 
 # Kinesis I/O

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,9 +1,9 @@
 ---
-title: Kzmlabs StateFun
-description: Stateful actors on Apache Flink — durable per-key state, exactly-once messaging, Kafka and Kinesis I/O, Kubernetes-native deployment. Actively maintained continuation of Apache Stateful Functions for Flink 2.x and Java 21.
+title: StateFun Actors by Kzmlabs
+description: Stateful Actors on Apache Flink — durable per-key state, exactly-once messaging, Kafka and Kinesis I/O, Kubernetes-native deployment. The actively maintained continuation of Apache Stateful Functions for Flink 2.x and Java 21.
 ---
 
-# Kzmlabs StateFun · Actors
+# StateFun Actors by Kzmlabs
 
 > **Stateful Actors on Apache Flink** — durable per-key state, exactly-once messaging, Kafka and Kinesis I/O, Kubernetes-native deployment.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -14,7 +14,7 @@ description: Stateful Actors on Apache Flink — durable per-key state, exactly-
 [![CodeQL](https://github.com/kzmlabs/flink-statefun/actions/workflows/codeql.yml/badge.svg?branch=release)](https://github.com/kzmlabs/flink-statefun/actions/workflows/codeql.yml?query=branch%3Arelease)
 [![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/kzmlabs/flink-statefun/badge)](https://scorecard.dev/viewer/?uri=github.com/kzmlabs/flink-statefun)
 
-## What is Kzmlabs StateFun?
+## What is StateFun Actors?
 
 You write a function keyed by a logical id. The runtime gives it per-key durable state, routes messages to it, replays on failure, and connects it to Kafka and Kinesis. **Actor programming on top of Apache Flink — without writing a Flink job by hand.**
 
@@ -62,9 +62,9 @@ This is the actively maintained continuation of [Apache Stateful Functions](http
 
 ## Why this fork exists
 
-Apache Stateful Functions stopped releasing in **October 2024** at version 3.4.0, locked to **Flink 1.16** and **Java 11**. Anyone wanting to run it against modern Flink either pinned old dependencies or vendored their own patches. Kzmlabs StateFun is the public, actively maintained branch — same code, modern stack, no vendor lock-in.
+Apache Stateful Functions stopped releasing in **October 2024** at version 3.4.0, locked to **Flink 1.16** and **Java 11**. Anyone wanting to run it against modern Flink either pinned old dependencies or vendored their own patches. StateFun Actors is the public, actively maintained branch — same code, modern stack, no vendor lock-in.
 
-| | Apache StateFun 3.4.0 | Kzmlabs StateFun KZM-3.1 |
+| | Apache StateFun 3.4.0 | StateFun Actors KZM-3.1 |
 |---|---|---|
 | **Flink runtime** | 1.16.2 | **2.2.0** |
 | **Java baseline** | 11 | **21** |

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,6 +1,6 @@
 ---
 title: Install
-description: Maven Central coordinates, Bill of Materials import, Docker image, and supported version matrix for StateFun Actors.
+description: Maven Central coordinates, Bill of Materials import, Docker image, and supported version matrix for StateFun Actors — Apache Flink 2.2 + Java 21 stateful actor framework.
 ---
 
 # Install

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,11 +1,11 @@
 ---
 title: Install
-description: Maven Central coordinates, Bill of Materials import, Docker image, and supported version matrix for Kzmlabs StateFun.
+description: Maven Central coordinates, Bill of Materials import, Docker image, and supported version matrix for StateFun Actors.
 ---
 
 # Install
 
-> Add Kzmlabs StateFun to your project — Maven Central artifacts, Docker image, signed releases.
+> Add StateFun Actors to your project — Maven Central artifacts, Docker image, signed releases.
 
 ## Maven artifacts
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,6 +1,6 @@
 ---
 title: Quickstart
-description: Run a StateFun Actors job locally in five minutes — Docker, Kafka, a remote function, and a verified round-trip message.
+description: Run a StateFun Actors job on Apache Flink locally in five minutes — Docker, Kafka, a remote function, and a verified round-trip message.
 ---
 
 # Quickstart

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,6 +1,6 @@
 ---
 title: Quickstart
-description: Run a Kzmlabs StateFun job locally in five minutes — Docker, Kafka, a remote function, and a verified round-trip message.
+description: Run a StateFun Actors job locally in five minutes — Docker, Kafka, a remote function, and a verified round-trip message.
 ---
 
 # Quickstart

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -1,6 +1,6 @@
 ---
 title: Release process
-description: How StateFun Actors releases get cut and shipped — tag-driven CI, Maven Central + GHCR publishing, Sigstore attestation, branch protection.
+description: How StateFun Actors releases on Apache Flink get cut and shipped — tag-driven CI, Maven Central + GHCR publishing, Sigstore attestation, branch protection.
 ---
 
 # Release process

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -1,6 +1,6 @@
 ---
 title: Release process
-description: How Kzmlabs StateFun releases get cut and shipped — tag-driven CI, Maven Central + GHCR publishing, Sigstore attestation, branch protection.
+description: How StateFun Actors releases get cut and shipped — tag-driven CI, Maven Central + GHCR publishing, Sigstore attestation, branch protection.
 ---
 
 # Release process

--- a/docs/upstream-vs-kzm.md
+++ b/docs/upstream-vs-kzm.md
@@ -1,15 +1,15 @@
 ---
 title: Differences from Apache StateFun
-description: Migration guide from Apache Stateful Functions 3.4.0 to Kzmlabs StateFun on Flink 2.x and Java 21 — coordinate change, runtime configuration, what stays the same.
+description: Migration guide from Apache Stateful Functions 3.4.0 to StateFun Actors on Flink 2.x and Java 21 — coordinate change, runtime configuration, what stays the same.
 ---
 
 # Differences from Apache StateFun
 
-> Apache Stateful Functions 3.4.0 (October 2024) is the last upstream release, locked to Flink 1.16 and Java 11. Kzmlabs StateFun continues the project against the modern Flink line. **Most user code keeps working unchanged**; the differences are at the runtime, dependency, and deployment layer.
+> Apache Stateful Functions 3.4.0 (October 2024) is the last upstream release, locked to Flink 1.16 and Java 11. StateFun Actors continues the project against the modern Flink line. **Most user code keeps working unchanged**; the differences are at the runtime, dependency, and deployment layer.
 
 ## At a glance
 
-| | Apache StateFun 3.4.0 | Kzmlabs StateFun KZM-3.1 |
+| | Apache StateFun 3.4.0 | StateFun Actors KZM-3.1 |
 |---|---|---|
 | **Flink runtime** | 1.16.2 | **2.2.0** |
 | **Java baseline** | 11 | **21** |
@@ -86,7 +86,7 @@ See the [Kinesis I/O guide](guides/kinesis-io.md) for the full Flink 2.x configu
 
 ## Why this fork exists
 
-Upstream Apache StateFun has not received releases since October 2024. As Flink 2.x ships and JDK 11 leaves the active LTS support window, downstream users are left choosing between staying on an old Flink line or vendoring their own runtime patches. Kzmlabs StateFun is the public, actively maintained continuation — same code, modern dependencies, no vendor lock-in.
+Upstream Apache StateFun has not received releases since October 2024. As Flink 2.x ships and JDK 11 leaves the active LTS support window, downstream users are left choosing between staying on an old Flink line or vendoring their own runtime patches. StateFun Actors is the public, actively maintained continuation — same code, modern dependencies, no vendor lock-in.
 
 ## Next steps
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,4 +1,4 @@
-site_name: Kzmlabs StateFun · Actors
+site_name: StateFun Actors by Kzmlabs
 site_description: Stateful actors on Apache Flink — durable per-key state, exactly-once messaging, Kafka and Kinesis I/O, Kubernetes-native. Flink 2.2 + Java 21 continuation of Apache Stateful Functions.
 site_url: https://kzmlabs.github.io/flink-statefun/
 repo_url: https://github.com/kzmlabs/flink-statefun


### PR DESCRIPTION
Bulk rename + SEO sweep:

- Every inline 'Kzmlabs StateFun' → 'StateFun Actors' across docs + README
- H1 hero stays 'StateFun Actors by Kzmlabs' (full branding)
- Every page's frontmatter description now front-loads 'Apache Flink' or 'Flink 2.2' so search snippets associate the product with Flink — important since 'StateFun Actors' is a new brand and Flink is the discovery vector