### PR TITLE
docs: drop 'actively maintained' filler + draft awesome-flink submission

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # StateFun Actors by Kzmlabs
 
-> **Stateful Actors on Apache Flink** — durable per-key state, exactly-once messaging, Kafka and Kinesis I/O, Kubernetes-native deployment. The actively maintained continuation of [Apache Stateful Functions](https://github.com/apache/flink-statefun) for Flink 2.x and Java 21.
+> **Stateful actors on Apache Flink 2.x and Java 21** — durable per-key state, exactly-once messaging, Kafka and Kinesis I/O, Kubernetes-native deployment. Continues the [Apache Stateful Functions](https://github.com/apache/flink-statefun) programming model on the modern Flink line, with active releases on Maven Central and GHCR.
 
 [![Maven Central](https://img.shields.io/maven-central/v/io.github.kzmlabs.flinkstatefun/statefun-bom?label=Maven%20Central)](https://central.sonatype.com/artifact/io.github.kzmlabs.flinkstatefun/statefun-bom)
 [![GitHub Release](https://img.shields.io/github/v/release/kzmlabs/flink-statefun?label=GHCR)](https://github.com/kzmlabs/flink-statefun/pkgs/container/flink-statefun)

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,11 +1,11 @@
 ---
 title: StateFun Actors by Kzmlabs
-description: Stateful Actors on Apache Flink — durable per-key state, exactly-once messaging, Kafka and Kinesis I/O, Kubernetes-native deployment. The actively maintained continuation of Apache Stateful Functions for Flink 2.x and Java 21.
+description: Stateful actors on Apache Flink 2.x and Java 21 — durable per-key state, exactly-once messaging, Kafka and Kinesis I/O, Kubernetes-native deployment. Continues the Apache Stateful Functions programming model on the modern Flink line.
 ---
 
 # StateFun Actors by Kzmlabs
 
-> **Stateful Actors on Apache Flink** — durable per-key state, exactly-once messaging, Kafka and Kinesis I/O, Kubernetes-native deployment.
+> **Stateful actors on Apache Flink 2.x and Java 21** — durable per-key state, exactly-once messaging, Kafka and Kinesis I/O, Kubernetes-native deployment.
 
 [![Maven Central](https://img.shields.io/maven-central/v/io.github.kzmlabs.flinkstatefun/statefun-bom?label=Maven%20Central)](https://central.sonatype.com/artifact/io.github.kzmlabs.flinkstatefun/statefun-bom){ .md-button-link }
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue)](https://github.com/kzmlabs/flink-statefun/blob/release/LICENSE)

--- a/docs/submissions/awesome-flink.md
+++ b/docs/submissions/awesome-flink.md
@@ -1,0 +1,45 @@
+# Submission to awesome-flink
+
+Ready-to-paste markdown for [wuchong/awesome-flink](https://github.com/wuchong/awesome-flink) and similar curated lists.
+
+## Recommended placement
+
+Section: **Libraries** or **Stateful Functions** (whichever the list uses).
+
+## Single-line entry
+
+```markdown
+- [Kzmlabs StateFun Actors](https://github.com/kzmlabs/flink-statefun) — Stateful actors on Apache Flink 2.x and Java 21. Durable per-key state, exactly-once messaging, Kafka and Kinesis I/O, Kubernetes-native deployment.
+```
+
+## Why this phrasing
+
+- **Leads with what it does** ("stateful actors"), not what it's a continuation of — readers self-qualify based on capability, not pedigree.
+- **Names two constraints** (Flink 2.x, Java 21) — signals modernity without using marketing words like "modern", "active", or "maintained" that awesome-list reviewers typically flag as filler.
+- **All SEO keywords appear naturally** — Apache Flink, stateful actors, Kafka, Kinesis, Kubernetes — without keyword-stuffing.
+- **Single sentence** — fits the typical awesome-list one-line format.
+
+## How to submit
+
+1. Fork [wuchong/awesome-flink](https://github.com/wuchong/awesome-flink)
+2. Find the appropriate section (Libraries / Stateful Functions / similar)
+3. Insert the bullet alphabetically
+4. Run `npx awesome-lint` if the project uses it
+5. Open a PR with title: `Add Kzmlabs StateFun Actors`
+6. PR body — three lines is enough:
+
+```markdown
+Adds Kzmlabs StateFun Actors, a continuation of Apache Stateful Functions
+on Flink 2.x and Java 21. Maintained on Maven Central + GHCR with a
+Kubernetes-native E2E gate. Fits under the Stateful Functions section.
+```
+
+## Other lists worth a PR
+
+| List | Section to target |
+|---|---|
+| [manuzhang/awesome-streaming](https://github.com/manuzhang/awesome-streaming) | "Stream Processing Frameworks" or "Libraries" |
+| [infoslack/awesome-kafka](https://github.com/infoslack/awesome-kafka) | "Frameworks" — frame as Kafka I/O |
+| [ramitsurana/awesome-kubernetes](https://github.com/ramitsurana/awesome-kubernetes) | "Stream Processing" — frame as the K8s-native deployment story |
+
+For each list, the same one-line entry works; just adjust the framing in the PR body to match the list's audience (Kafka users care about exactly-once delivery, K8s users care about Operator integration, etc.).


### PR DESCRIPTION
Replaces defensive 'actively maintained continuation' phrasing with concrete capability framing leading with what the project does. Adds docs/submissions/awesome-flink.md as a ready-to-paste markdown for the upstream curated-list PR.