### PR TITLE
feat: Tier-1 discoverability bundle — OG/Twitter/JSON-LD + robots + traction badges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
-All notable changes to the Kzmlabs StateFun fork are documented in this file.
+All notable changes to **StateFun Actors by Kzmlabs** are documented in this file. The fork continues the [Apache Stateful Functions](https://github.com/apache/flink-statefun) programming model on Apache Flink 2.x and Java 21.
+
+> **Reading guide:** "KZM-x.y" releases are this fork's versions on Flink 2.x. Apache StateFun's last release was [3.4.0](https://github.com/apache/flink-statefun/releases/tag/release-3.4.0) (October 2024) on Flink 1.16. See [docs/upstream-vs-kzm.md](https://kzmlabs.github.io/flink-statefun/upstream-vs-kzm/) for the full migration matrix.
 
 ## [3.4.0-KZM-3.0-RC1] - 2026-04-23
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,13 @@
 [![CodeQL](https://github.com/kzmlabs/flink-statefun/actions/workflows/codeql.yml/badge.svg?branch=release)](https://github.com/kzmlabs/flink-statefun/actions/workflows/codeql.yml?query=branch%3Arelease)
 [![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/kzmlabs/flink-statefun/badge)](https://scorecard.dev/viewer/?uri=github.com/kzmlabs/flink-statefun)
 
-📖 **[Documentation](https://kzmlabs.github.io/flink-statefun/)** &nbsp;·&nbsp; ⚡ **[Quickstart](https://kzmlabs.github.io/flink-statefun/quickstart/)** &nbsp;·&nbsp; 📦 **[Maven Central](https://central.sonatype.com/namespace/io.github.kzmlabs.flinkstatefun)** &nbsp;·&nbsp; 🐳 **[GHCR](https://github.com/kzmlabs/flink-statefun/pkgs/container/flink-statefun)** &nbsp;·&nbsp; 🆚 **[vs Apache StateFun](https://kzmlabs.github.io/flink-statefun/upstream-vs-kzm/)**
+[![Stars](https://img.shields.io/github/stars/kzmlabs/flink-statefun?style=social)](https://github.com/kzmlabs/flink-statefun/stargazers)
+[![Forks](https://img.shields.io/github/forks/kzmlabs/flink-statefun?style=social)](https://github.com/kzmlabs/flink-statefun/network/members)
+[![Contributors](https://img.shields.io/github/contributors/kzmlabs/flink-statefun)](https://github.com/kzmlabs/flink-statefun/graphs/contributors)
+[![Last commit](https://img.shields.io/github/last-commit/kzmlabs/flink-statefun/release)](https://github.com/kzmlabs/flink-statefun/commits/release)
+[![Open issues](https://img.shields.io/github/issues/kzmlabs/flink-statefun)](https://github.com/kzmlabs/flink-statefun/issues)
+
+📖 **[Documentation](https://kzmlabs.github.io/flink-statefun/)** &nbsp;·&nbsp; ⚡ **[Quickstart](https://kzmlabs.github.io/flink-statefun/quickstart/)** &nbsp;·&nbsp; 📦 **[Maven Central](https://central.sonatype.com/namespace/io.github.kzmlabs.flinkstatefun)** &nbsp;·&nbsp; 🐳 **[GHCR](https://github.com/kzmlabs/flink-statefun/pkgs/container/flink-statefun)** &nbsp;·&nbsp; 🆚 **[vs Apache StateFun](https://kzmlabs.github.io/flink-statefun/upstream-vs-kzm/)** &nbsp;·&nbsp; 🌟 **[Awesome StateFun](https://github.com/kzmlabs/awesome-statefun)**
 
 ---
 
@@ -180,6 +186,12 @@ Licensed under the [Apache License 2.0](LICENSE). Originally derived from [Apach
 ## Citing
 
 If you use StateFun Actors in research, please cite via the [`CITATION.cff`](CITATION.cff) file (GitHub's "Cite this repository" button).
+
+## See also
+
+- 🌟 **[awesome-statefun](https://github.com/kzmlabs/awesome-statefun)** — curated list of Stateful Functions runtimes, SDKs, examples, and adjacent actor frameworks.
+- 🔗 **[Apache Flink Stateful Functions](https://github.com/apache/flink-statefun)** — the upstream project this fork continues.
+- 🌊 **[awesome-flink](https://github.com/wuchong/awesome-flink)** — broader Apache Flink ecosystem.
 
 ## Links
 

--- a/docs/robots.txt
+++ b/docs/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://kzmlabs.github.io/flink-statefun/sitemap.xml

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -7,6 +7,7 @@ edit_uri: edit/release/docs/
 
 theme:
   name: material
+  custom_dir: overrides
   palette:
     - media: "(prefers-color-scheme: light)"
       scheme: default

--- a/overrides/main.html
+++ b/overrides/main.html
@@ -1,0 +1,66 @@
+{% extends "base.html" %}
+
+{% block extrahead %}
+  {% set page_title = (page and page.title) or config.site_name %}
+  {% set page_description = (page and page.meta and page.meta.description) or config.site_description %}
+  {% set image = "https://kzmlabs.github.io/flink-statefun/assets/social-preview.png" %}
+  {% set page_url = (page and page.canonical_url) or config.site_url %}
+  {% set is_home = page and page.is_homepage %}
+
+  <!-- OpenGraph -->
+  <meta property="og:type" content="website">
+  <meta property="og:title" content="{{ page_title }}">
+  <meta property="og:description" content="{{ page_description }}">
+  <meta property="og:image" content="{{ image }}">
+  <meta property="og:url" content="{{ page_url }}">
+  <meta property="og:site_name" content="{{ config.site_name }}">
+  <meta property="og:locale" content="en_US">
+
+  <!-- Twitter card -->
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="{{ page_title }}">
+  <meta name="twitter:description" content="{{ page_description }}">
+  <meta name="twitter:image" content="{{ image }}">
+
+  <!-- Canonical -->
+  {% if page and page.canonical_url %}
+  <link rel="canonical" href="{{ page.canonical_url }}">
+  {% endif %}
+
+  {% if is_home %}
+  <!-- JSON-LD: SoftwareApplication schema for Google rich-result eligibility -->
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "SoftwareApplication",
+    "name": "StateFun Actors by Kzmlabs",
+    "alternateName": "Kzmlabs StateFun",
+    "description": "Stateful actors on Apache Flink 2.x and Java 21 — durable per-key state, exactly-once messaging, Kafka and Kinesis I/O, Kubernetes-native deployment. Continues the Apache Stateful Functions programming model on the modern Flink line.",
+    "applicationCategory": "DeveloperApplication",
+    "applicationSubCategory": "Stream Processing Framework",
+    "operatingSystem": "Cross-platform (JVM)",
+    "softwareRequirements": "Java 21, Apache Flink 2.2",
+    "programmingLanguage": ["Java", "Python", "Go", "JavaScript"],
+    "offers": {
+      "@type": "Offer",
+      "price": "0",
+      "priceCurrency": "USD"
+    },
+    "license": "https://www.apache.org/licenses/LICENSE-2.0",
+    "codeRepository": "https://github.com/kzmlabs/flink-statefun",
+    "downloadUrl": "https://central.sonatype.com/namespace/io.github.kzmlabs.flinkstatefun",
+    "softwareVersion": "3.4.0-KZM-3.1",
+    "author": {
+      "@type": "Organization",
+      "name": "Kzmlabs",
+      "url": "https://github.com/kzmlabs"
+    },
+    "isBasedOn": {
+      "@type": "SoftwareApplication",
+      "name": "Apache Stateful Functions",
+      "url": "https://github.com/apache/flink-statefun"
+    }
+  }
+  </script>
+  {% endif %}
+{% endblock %}


### PR DESCRIPTION
Five-in-one Tier-1 visibility ship: OpenGraph + Twitter card meta on every page (rich previews on Slack/Discord/X/HN), JSON-LD SoftwareApplication schema on homepage (Google rich-result eligibility), robots.txt + sitemap (crawl guidance), traction badges in README (stars/forks/contributors/last-commit), awesome-statefun cross-link, CHANGELOG header reframed for new product name.