### PR TITLE
docs(site): brand consistency between docs site and social preview

### DIFF
--- a/docs/assets/css/8bit.css
+++ b/docs/assets/css/8bit.css
@@ -69,8 +69,15 @@ body { font-size: clamp(16px, 1rem + 0.1vw, 17px); }
   letter-spacing: 0;
   text-shadow: 0 0 8px var(--8bit-glow-cyan), 0 0 18px rgba(0, 212, 170, 0.35);
 }
+/* In light mode, Press Start 2P + a pink shadow renders as washed-out
+   ASCII art. Drop the pixel font for h1 in light mode and use Inter
+   Bold instead — the rest of the 8-bit chrome (square borders, hard
+   shadows) still carries the brand. */
 [data-md-color-scheme="default"] .md-typeset h1 {
-  text-shadow: 0 0 6px rgba(255, 84, 112, 0.25), 0 0 14px rgba(255, 84, 112, 0.12);
+  font-family: var(--md-text-font) !important;
+  font-weight: 800;
+  text-shadow: none;
+  letter-spacing: -0.01em;
 }
 .md-typeset h1::after {
   content: "▮";
@@ -107,11 +114,17 @@ body { font-size: clamp(16px, 1rem + 0.1vw, 17px); }
   margin-top: 1.8em;
 }
 
+/* Header title hidden — the theme.logo (horizontal wordmark image)
+   replaces the textual brand entirely in the navbar. Keeps the rule
+   here for fallback if the logo fails to load. */
 .md-header__title {
   font-family: "Press Start 2P", system-ui, sans-serif !important;
   font-size: clamp(0.7rem, 0.6rem + 0.4vw, 0.9rem);
   line-height: 1.6;
   letter-spacing: 0;
+}
+.md-header__topic > .md-ellipsis {
+  display: none;  /* hide repeated text title — the logo image is enough */
 }
 
 /* ═══ Subtle pixel grid background ═══════════════════════════ */

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -8,19 +8,21 @@ edit_uri: edit/release/docs/
 theme:
   name: material
   custom_dir: overrides
-  logo: assets/logo-mark.png
+  logo: assets/logo-horizontal.png
   favicon: assets/favicon-32.png
   palette:
-    - media: "(prefers-color-scheme: light)"
-      scheme: default
-      primary: deep purple
-      accent: amber
-      toggle: { icon: material/brightness-7, name: Switch to dark mode }
-    - media: "(prefers-color-scheme: dark)"
-      scheme: slate
+    # Default: slate (dark) — matches the social preview's deep-navy +
+    # cyan-glow aesthetic. Press Start 2P H1 only reads right against
+    # this dark background; on the previous light default it rendered
+    # as washed-out ASCII art with a pink hard-shadow.
+    - scheme: slate
       primary: deep purple
       accent: amber
       toggle: { icon: material/brightness-4, name: Switch to light mode }
+    - scheme: default
+      primary: deep purple
+      accent: amber
+      toggle: { icon: material/brightness-7, name: Switch to dark mode }
   features:
     - navigation.tabs
     - navigation.sections


### PR DESCRIPTION
## Summary

Fixes the docs site so it visually matches the social preview that just shipped.

The deployed `kzmlabs.github.io/flink-statefun/` was landing in **light mode** by default, where Press Start 2P H1 renders as washed-out ASCII art on white with a faint pink hard-shadow — the worst-looking part of the brand was on the most-seen page. The social preview is built around the dark / navy / cyan-glow / gold aesthetic, so the site needed to default there too.

## Changes

- **`mkdocs.yml`** — palette order flipped: **slate (dark) is now the default**. Light mode still available via the toggle.
- **`mkdocs.yml`** — `theme.logo` switched from the tiny `logo-mark.png` to the full `logo-horizontal.png` wordmark.
- **`docs/assets/css/8bit.css`** — hide the duplicated Press Start 2P text title in the header (the logo image carries it now). Drop Press Start 2P + glow on h1 in light mode (fall back to Inter Bold there). The rest of the 8-bit chrome — square borders, hard shadows, ▶/▮ markers — still carries the brand in both modes.

## Test plan

- [ ] Build locally: `pip install -r docs/requirements.txt && mkdocs serve`
- [ ] Visit homepage — confirm slate is the default, navbar shows horizontal wordmark, no duplicated text title.
- [ ] Toggle to light mode — confirm h1 renders in Inter Bold cleanly (no Press Start 2P + pink shadow combo).
- [ ] Compare side-by-side with `docs/assets/social-preview.png` — same color palette, same aesthetic.