### PR TITLE
docs(seo): fix Bing meta description length and duplicate canonical

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,5 @@
 site_name: StateFun Actors by Kzmlabs
-site_description: Stateful actors on Apache Flink — durable per-key state, exactly-once messaging, Kafka and Kinesis I/O, Kubernetes-native. Flink 2.2 + Java 21 continuation of Apache Stateful Functions.
+site_description: Stateful actors on Apache Flink — durable per-key state, exactly-once Kafka/Kinesis I/O, Kubernetes-native. Flink 2.2 + Java 21.
 site_url: https://kzmlabs.github.io/flink-statefun/
 repo_url: https://github.com/kzmlabs/flink-statefun
 repo_name: kzmlabs/flink-statefun

--- a/overrides/main.html
+++ b/overrides/main.html
@@ -31,10 +31,7 @@
   <meta name="twitter:description" content="{{ page_description }}">
   <meta name="twitter:image" content="{{ image }}">
 
-  <!-- Canonical -->
-  {% if page and page.canonical_url %}
-  <link rel="canonical" href="{{ page.canonical_url }}">
-  {% endif %}
+  {# Canonical is already emitted by Material's base.html — do not duplicate here. #}
 
   {% if is_home %}
   <!-- JSON-LD: SoftwareApplication schema for Google rich-result eligibility -->


### PR DESCRIPTION
## Summary
- Shorten `site_description` in `mkdocs.yml` from ~188 → ~127 chars so Bing stops flagging "Meta Description too long" (limit: 25–160).
- Remove duplicate `<link rel="canonical">` from `overrides/main.html` — Material's `base.html` already emits one, which produced two canonical tags per page (Bing flagged 2 instances).

Found via Bing Webmaster Tools "Analyze SEO/GEO issues" panel after site verification.

## Test plan
- [ ] Local `mkdocs build` succeeds
- [ ] After Pages deploy, view-source on https://kzmlabs.github.io/flink-statefun/ shows exactly one `<link rel="canonical">` and a `<meta name="description">` ≤160 chars
- [ ] Re-run Bing SEO analyzer; both issues clear