### PR TITLE
docs(seo): emit a single H1 on the homepage

### DIFF
--- a/overrides/main.html
+++ b/overrides/main.html
@@ -71,13 +71,23 @@
   {% endif %}
 {% endblock %}
 
+{% block content %}
+  {# On the homepage, skip Material's auto-injected <h1> (page.title fallback)
+     so the hero <h1> in the tabs block is the only <h1> in the DOM.
+     Two <h1> tags trip Bing's SEO checks even when one is CSS-hidden. #}
+  {% if page and page.is_homepage %}
+  <article class="md-content__inner md-typeset">
+    {{ page.content }}
+  </article>
+  {% else %}
+  {{ super() }}
+  {% endif %}
+{% endblock %}
+
 {% block tabs %}
   {{ super() }}
   {% if page and page.is_homepage %}
   <style>
-    /* Homepage-only: hide the auto-generated H1 (Material falls back to
-       the nav label "Home" when the markdown has no H1; the hero replaces it). */
-    article.md-content__inner > h1:first-of-type { display: none; }
     /* Tighten the gap between the hero and the first content section. */
     article.md-content__inner > h2:first-of-type { margin-top: 1rem; }
   </style>


### PR DESCRIPTION
## Summary
Bing's SEO analyzer flagged the homepage with "More than one H1 tag". Material's `partials/content.html` auto-injects an `<h1>` from `page.title` whenever the rendered markdown contains no `<h1>`; we were hiding that auto-h1 with `display: none`, but the element is still in the DOM.

Override the `content` block on the homepage so the auto-h1 is never emitted. The hero `<h1>` rendered in the `tabs` block remains as the single H1, which is also the SEO-meaningful one ("Stateful actors on Apache Flink").

Other pages: unchanged — they fall through to `{{ super() }}` and render exactly one H1 as before.

## Test plan
- [ ] Local `mkdocs build` succeeds
- [ ] After deploy, view-source on https://kzmlabs.github.io/flink-statefun/ has exactly one `<h1>` (the hero)
- [ ] Inner pages (e.g. `/quickstart/`) still render one `<h1>` from page title or markdown
- [ ] Bing's SEO analyzer "More than one H1 tag" notice clears after re-crawl