### PR TITLE
docs(articles): add dev.to syndication link to forking-statefun post

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,7 @@ If you use StateFun Actors in research, please cite via the [`CITATION.cff`](CIT
 
 ## See also
 
+- 📝 **[We forked Apache Stateful Functions for Flink 2.x — here's why](https://kzmlabs.github.io/flink-statefun/articles/forking-statefun/)** — design rationale, what we changed, what stayed the same. Also on [dev.to](https://dev.to/okazimirov/we-forked-apache-stateful-functions-for-flink-2x-heres-why-18oj).
 - 🌟 **[awesome-statefun](https://github.com/kzmlabs/awesome-statefun)** — curated list of Stateful Functions runtimes, SDKs, examples, and adjacent actor frameworks.
 - 🔗 **[Apache Flink Stateful Functions](https://github.com/apache/flink-statefun)** — the upstream project this fork continues.
 - 🌊 **[awesome-flink](https://github.com/wuchong/awesome-flink)** — broader Apache Flink ecosystem.

--- a/docs/articles/forking-statefun.md
+++ b/docs/articles/forking-statefun.md
@@ -5,7 +5,7 @@ description: Apache Stateful Functions has been dormant since October 2024. Here
 
 # We forked Apache Stateful Functions for Flink 2.x — here's why
 
-*Published 2026-05-03 · by the kzmlabs maintainers*
+*Published 2026-05-03 · by the kzmlabs maintainers · [Read on dev.to](https://dev.to/okazimirov/we-forked-apache-stateful-functions-for-flink-2x-heres-why-18oj)*
 
 [Apache Stateful Functions][upstream] is one of the quietly powerful frameworks in the Flink ecosystem — durable per-key state, exactly-once messaging, polyglot remote functions, all on top of Apache Flink. It's also been functionally dormant since **October 2024**, and it doesn't run on Flink 2.x.
 


### PR DESCRIPTION
## Summary
The forking-statefun article was published to dev.to: https://dev.to/okazimirov/we-forked-apache-stateful-functions-for-flink-2x-heres-why-18oj

This PR closes the syndication loop:
- The article's byline now includes a "Read on dev.to" link.
- README "See also" section adds the article (with both canonical and dev.to URLs).

The docs URL remains the canonical for SEO; the dev.to link is for discoverability and discussion.

## Test plan
- [ ] After Pages rebuild, /articles/forking-statefun/ shows the dev.to link in the byline
- [ ] README on github.com/kzmlabs/flink-statefun shows the article in "See also"