### PR TITLE
fix(docs): render homepage SDK/I-O icons

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -99,17 +99,17 @@ More patterns work the same way — order workflows, payment sagas, polyglot mic
 Write functions in whichever language fits the team. Plug into the streaming and storage substrate you already run.
 
 <div class="kzm-logo-grid" markdown>
-<div>:fontawesome-brands-java:{ .twemoji } &nbsp; Java SDK</div>
-<div>:fontawesome-brands-python:{ .twemoji } &nbsp; Python SDK</div>
-<div>:fontawesome-brands-golang:{ .twemoji } &nbsp; Go SDK</div>
-<div>:fontawesome-brands-js:{ .twemoji } &nbsp; JavaScript SDK</div>
+<div markdown="span">:fontawesome-brands-java:{ .twemoji } &nbsp; Java SDK</div>
+<div markdown="span">:fontawesome-brands-python:{ .twemoji } &nbsp; Python SDK</div>
+<div markdown="span">:fontawesome-brands-golang:{ .twemoji } &nbsp; Go SDK</div>
+<div markdown="span">:fontawesome-brands-js:{ .twemoji } &nbsp; JavaScript SDK</div>
 </div>
 
 <div class="kzm-logo-grid" markdown>
-<div>:simple-apachekafka:{ .twemoji } &nbsp; Apache Kafka</div>
-<div>:simple-amazonaws:{ .twemoji } &nbsp; AWS Kinesis</div>
-<div>:simple-kubernetes:{ .twemoji } &nbsp; Kubernetes</div>
-<div>:material-database:{ .twemoji } &nbsp; S3 checkpoints</div>
+<div markdown="span">:simple-apachekafka:{ .twemoji } &nbsp; Apache Kafka</div>
+<div markdown="span">:simple-amazonaws:{ .twemoji } &nbsp; AWS Kinesis</div>
+<div markdown="span">:simple-kubernetes:{ .twemoji } &nbsp; Kubernetes</div>
+<div markdown="span">:material-database:{ .twemoji } &nbsp; S3 checkpoints</div>
 </div>
 
 ## Why this continuation exists


### PR DESCRIPTION
## Summary
The "Polyglot SDKs and pluggable I/O" homepage section was rendering icon shortcodes as raw text:

> `:fontawesome-brands-java:{ .twemoji }   Java SDK`

instead of expanding into the Java / Python / Kafka / Kinesis / Kubernetes / S3 icons.

**Root cause:** the outer `<div class="kzm-logo-grid" markdown>` enables markdown processing for its children, but inner `<div>` blocks are opaque to `md_in_html` unless they themselves declare a `markdown` attribute. Without it, `pymdownx.emoji` (and indeed any markdown extension) never descends into them — so the shortcodes are emitted verbatim and `&nbsp;` isn't even decoded.

**Fix:** add `markdown="span"` to each inner `<div>`. That tells `md_in_html` the contents are inline markdown and to parse them — which lets `pymdownx.emoji` resolve the icon shortcodes against Material's twemoji index.

## Test plan
- [ ] After Pages rebuild, view-source on the homepage shows `<svg>` icons inside each `kzm-logo-grid > div`
- [ ] No `:fontawesome-brands-*:` or `:simple-*:` shortcodes appear as literal text anywhere on the rendered page
- [ ] Both rows (SDKs and I/O) render with their icons centered next to the labels