### PR TITLE
docs: add Hashnode syndication link for forking-statefun article

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ If you use StateFun Actors in research, please cite via the [`CITATION.cff`](CIT
 
 ## See also
 
-- 📝 **[We forked Apache Stateful Functions for Flink 2.x — here's why](https://kzmlabs.github.io/flink-statefun/articles/forking-statefun/)** — design rationale, what we changed, what stayed the same. Also on [dev.to](https://dev.to/okazimirov/we-forked-apache-stateful-functions-for-flink-2x-heres-why-18oj).
+- 📝 **[We forked Apache Stateful Functions for Flink 2.x — here's why](https://kzmlabs.github.io/flink-statefun/articles/forking-statefun/)** — design rationale, what we changed, what stayed the same. Also on [dev.to](https://dev.to/okazimirov/we-forked-apache-stateful-functions-for-flink-2x-heres-why-18oj) and [Hashnode](https://kzmlabs.hashnode.dev/we-forked-apache-stateful-functions-for-flink-2-x-here-s-why).
 - 🌟 **[awesome-statefun](https://github.com/kzmlabs/awesome-statefun)** — curated list of Stateful Functions runtimes, SDKs, examples, and adjacent actor frameworks.
 - 🔗 **[Apache Flink Stateful Functions](https://github.com/apache/flink-statefun)** — the upstream project this fork continues.
 - 🌊 **[awesome-flink](https://github.com/wuchong/awesome-flink)** — broader Apache Flink ecosystem.

--- a/docs/articles/forking-statefun.md
+++ b/docs/articles/forking-statefun.md
@@ -5,7 +5,7 @@ description: Apache Stateful Functions has been dormant since October 2024. Here
 
 # We forked Apache Stateful Functions for Flink 2.x — here's why
 
-*Published 2026-05-03 · by the kzmlabs maintainers · [Read on dev.to](https://dev.to/okazimirov/we-forked-apache-stateful-functions-for-flink-2x-heres-why-18oj)*
+*Published 2026-05-03 · by the kzmlabs maintainers · [Read on dev.to](https://dev.to/okazimirov/we-forked-apache-stateful-functions-for-flink-2x-heres-why-18oj) · [Read on Hashnode](https://kzmlabs.hashnode.dev/we-forked-apache-stateful-functions-for-flink-2-x-here-s-why)*
 
 [Apache Stateful Functions][upstream] is one of the quietly powerful frameworks in the Flink ecosystem — durable per-key state, exactly-once messaging, polyglot remote functions, all on top of Apache Flink. It's also been functionally dormant since **October 2024**, and it doesn't run on Flink 2.x.
 


### PR DESCRIPTION
## Summary

- Append Hashnode mirror to the existing `Also on dev.to` line in README.md `## See also`
- Append Hashnode mirror to the byline of the canonical article `docs/articles/forking-statefun.md`

The Hashnode mirror was published 2026-05-05 at https://kzmlabs.hashnode.dev/we-forked-apache-stateful-functions-for-flink-2-x-here-s-why with `canonical_url` pointing back to the docs site.

Two mirrors inline (dev.to + Hashnode) is fine; future syndications (Medium, etc.) will not be added — the canonical docs URL remains the single source of truth.

## Test plan

- [x] Render README.md and confirm the See also bullet shows both links
- [x] Verify Hashnode article canonical URL still points to the docs site (verified via Hashnode GraphQL: `canonicalUrl = https://kzmlabs.github.io/flink-statefun/articles/forking-statefun/`)