### PR TITLE
build: add JaCoCo code coverage with Codecov upload (Phase 1)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,10 +42,47 @@ jobs:
           test -s "$REPORT"
           grep -q '<counter ' "$REPORT" || { echo "::error::jacoco.xml has no <counter> elements - argLine likely broken again"; exit 1; }
 
+      # Render coverage table directly in the Actions run summary — visible without
+      # leaving GitHub, no third-party dependency.
+      - name: Coverage summary in run UI
+        if: always()
+        run: |
+          REPORT=statefun-coverage-report/target/site/jacoco-aggregate/jacoco.xml
+          [ -s "$REPORT" ] || { echo "No coverage report to summarize"; exit 0; }
+          python3 - <<'PY'
+          import xml.etree.ElementTree as ET, os
+          root = ET.parse('statefun-coverage-report/target/site/jacoco-aggregate/jacoco.xml').getroot()
+          # Top-level <counter> elements are the project totals.
+          counters = [c for c in root if c.tag == 'counter']
+          with open(os.environ['GITHUB_STEP_SUMMARY'], 'a') as f:
+              f.write('## Coverage report (aggregate)\n\n')
+              f.write('| Metric | Covered | Total | % |\n')
+              f.write('|---|---:|---:|---:|\n')
+              for c in counters:
+                  t, m, cv = c.get('type').title(), int(c.get('missed')), int(c.get('covered'))
+                  total = m + cv
+                  pct = 100 * cv / total if total else 0.0
+                  f.write(f'| {t} | {cv:,} | {total:,} | **{pct:.1f}%** |\n')
+              f.write('\nFull HTML report attached as artifact `coverage-report-html` (drill-down by module / package / class / line).\n')
+          PY
+
+      # Upload the full HTML report as a downloadable artifact. No external service required —
+      # anyone with read access to the repo can grab the ZIP from the Actions run page.
+      - name: Upload coverage HTML report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-report-html
+          path: statefun-coverage-report/target/site/jacoco-aggregate/
+          retention-days: 30
+          if-no-files-found: warn
+
       - name: Upload coverage to Codecov
+        if: always()
         uses: codecov/codecov-action@v5
         with:
           files: ./statefun-coverage-report/target/site/jacoco-aggregate/jacoco.xml
           flags: unittests
           fail_ci_if_error: false
+          disable_search: true
           use_oidc: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,7 @@ on:
 
 permissions:
   contents: read
+  id-token: write   # required for codecov-action OIDC token verification (use_oidc: true)
 
 concurrency:
   group: ci-${{ github.ref }}
@@ -32,3 +33,19 @@ jobs:
 
       - name: Build and test
         run: mvn clean install -B
+
+      # Fail loud if argLine regresses and the agent silently writes nothing.
+      - name: Sanity-check coverage report is non-empty
+        run: |
+          set -e
+          REPORT=statefun-coverage-report/target/site/jacoco-aggregate/jacoco.xml
+          test -s "$REPORT"
+          grep -q '<counter ' "$REPORT" || { echo "::error::jacoco.xml has no <counter> elements - argLine likely broken again"; exit 1; }
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          files: ./statefun-coverage-report/target/site/jacoco-aggregate/jacoco.xml
+          flags: unittests
+          fail_ci_if_error: false
+          use_oidc: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,12 +77,66 @@ jobs:
           retention-days: 30
           if-no-files-found: warn
 
-      - name: Upload coverage to Codecov
+      - name: Upload unit-test coverage to Codecov
         if: always()
         uses: codecov/codecov-action@v5
         with:
           files: ./statefun-coverage-report/target/site/jacoco-aggregate/jacoco.xml
           flags: unittests
+          fail_ci_if_error: false
+          disable_search: true
+          use_oidc: true
+
+      # ---- E2E coverage (separate flag, separate aggregator) ----
+      # In-process E2E only — statefun-smoke-e2e-embedded runs via statefun-flink-harness in
+      # the surefire JVM where the agent can attach. Container-based E2E (driver/java/multilang/k8s)
+      # runs production code in separate JVMs; not instrumented (see statefun-coverage-report/README.md).
+
+      - name: Sanity-check E2E coverage report is non-empty
+        if: always()
+        run: |
+          set -e
+          REPORT=statefun-e2e-coverage-report/target/site/jacoco-e2e-aggregate/jacoco.xml
+          test -s "$REPORT"
+          grep -q '<counter ' "$REPORT" || { echo "::error::jacoco-e2e-aggregate/jacoco.xml has no <counter> elements - destFile likely broken"; exit 1; }
+
+      - name: E2E coverage summary in run UI
+        if: always()
+        run: |
+          REPORT=statefun-e2e-coverage-report/target/site/jacoco-e2e-aggregate/jacoco.xml
+          [ -s "$REPORT" ] || { echo "No E2E coverage report to summarize"; exit 0; }
+          python3 - <<'PY'
+          import xml.etree.ElementTree as ET, os
+          root = ET.parse('statefun-e2e-coverage-report/target/site/jacoco-e2e-aggregate/jacoco.xml').getroot()
+          counters = [c for c in root if c.tag == 'counter']
+          with open(os.environ['GITHUB_STEP_SUMMARY'], 'a') as f:
+              f.write('## E2E coverage report (in-process embedded)\n\n')
+              f.write('Source: `statefun-smoke-e2e-embedded` running StateFun in-process via `statefun-flink-harness`.\n\n')
+              f.write('| Metric | Covered | Total | % |\n')
+              f.write('|---|---:|---:|---:|\n')
+              for c in counters:
+                  t, m, cv = c.get('type').title(), int(c.get('missed')), int(c.get('covered'))
+                  total = m + cv
+                  pct = 100 * cv / total if total else 0.0
+                  f.write(f'| {t} | {cv:,} | {total:,} | **{pct:.1f}%** |\n')
+              f.write('\nFull HTML report attached as artifact `coverage-report-e2e-html`.\n')
+          PY
+
+      - name: Upload E2E coverage HTML report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-report-e2e-html
+          path: statefun-e2e-coverage-report/target/site/jacoco-e2e-aggregate/
+          retention-days: 30
+          if-no-files-found: warn
+
+      - name: Upload E2E coverage to Codecov
+        if: always()
+        uses: codecov/codecov-action@v5
+        with:
+          files: ./statefun-e2e-coverage-report/target/site/jacoco-e2e-aggregate/jacoco.xml
+          flags: e2e
           fail_ci_if_error: false
           disable_search: true
           use_oidc: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,7 +86,7 @@ jobs:
         run: |
           # Exclude e2e tests from deployment
           mvn deploy -Prelease -DskipTests -B \
-            -pl '!:statefun-flink-runner,!:statefun-docker,!:statefun-e2e-tests,!:statefun-e2e-tests-common,!:statefun-smoke-e2e-common,!:statefun-smoke-e2e-driver,!:statefun-smoke-e2e-embedded,!:statefun-smoke-e2e-multilang-base,!:statefun-smoke-e2e-multilang-harness,!:statefun-smoke-e2e-java,!:statefun-smoke-e2e-golang,!:statefun-smoke-e2e-js,!:statefun-e2e-k8s-native'
+            -pl '!:statefun-flink-runner,!:statefun-docker,!:statefun-e2e-tests,!:statefun-e2e-tests-common,!:statefun-smoke-e2e-common,!:statefun-smoke-e2e-driver,!:statefun-smoke-e2e-embedded,!:statefun-smoke-e2e-multilang-base,!:statefun-smoke-e2e-multilang-harness,!:statefun-smoke-e2e-java,!:statefun-smoke-e2e-golang,!:statefun-smoke-e2e-js,!:statefun-e2e-k8s-native,!:statefun-coverage-report'
         env:
           CENTRAL_USERNAME: ${{ secrets.OSSRH_USERNAME }}
           CENTRAL_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,7 +86,7 @@ jobs:
         run: |
           # Exclude e2e tests from deployment
           mvn deploy -Prelease -DskipTests -B \
-            -pl '!:statefun-flink-runner,!:statefun-docker,!:statefun-e2e-tests,!:statefun-e2e-tests-common,!:statefun-smoke-e2e-common,!:statefun-smoke-e2e-driver,!:statefun-smoke-e2e-embedded,!:statefun-smoke-e2e-multilang-base,!:statefun-smoke-e2e-multilang-harness,!:statefun-smoke-e2e-java,!:statefun-smoke-e2e-golang,!:statefun-smoke-e2e-js,!:statefun-e2e-k8s-native,!:statefun-coverage-report'
+            -pl '!:statefun-flink-runner,!:statefun-docker,!:statefun-e2e-tests,!:statefun-e2e-tests-common,!:statefun-smoke-e2e-common,!:statefun-smoke-e2e-driver,!:statefun-smoke-e2e-embedded,!:statefun-smoke-e2e-multilang-base,!:statefun-smoke-e2e-multilang-harness,!:statefun-smoke-e2e-java,!:statefun-smoke-e2e-golang,!:statefun-smoke-e2e-js,!:statefun-e2e-k8s-native,!:statefun-coverage-report,!:statefun-e2e-coverage-report'
         env:
           CENTRAL_USERNAME: ${{ secrets.OSSRH_USERNAME }}
           CENTRAL_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}

--- a/pom.xml
+++ b/pom.xml
@@ -87,6 +87,9 @@
         <!-- e2e tests before testutil so a publishable module is last for Central -->
         <module>statefun-e2e-tests</module>
         <module>statefun-testutil</module>
+
+        <!-- coverage aggregator: must be last so all modules' jacoco.exec files exist before report-aggregate runs -->
+        <module>statefun-coverage-report</module>
     </modules>
 
     <properties>
@@ -131,6 +134,7 @@
         <maven-assembly-plugin.version>3.8.0</maven-assembly-plugin.version>
         <exec-maven-plugin.version>3.6.3</exec-maven-plugin.version>
         <central-publishing-maven-plugin.version>0.10.0</central-publishing-maven-plugin.version>
+        <jacoco-maven-plugin.version>0.8.14</jacoco-maven-plugin.version>
     </properties>
 
     <dependencies>
@@ -439,6 +443,40 @@
                     <artifactId>exec-maven-plugin</artifactId>
                     <version>${exec-maven-plugin.version}</version>
                 </plugin>
+                <plugin>
+                    <groupId>org.jacoco</groupId>
+                    <artifactId>jacoco-maven-plugin</artifactId>
+                    <version>${jacoco-maven-plugin.version}</version>
+                    <configuration>
+                        <excludes>
+                            <exclude>**/generated/**</exclude>
+                            <exclude>**/*Proto*.class</exclude>
+                            <exclude>**/*OuterClass*.class</exclude>
+                            <exclude>org/apache/flink/statefun/sdk/shaded/**</exclude>
+                        </excludes>
+                    </configuration>
+                    <executions>
+                        <execution>
+                            <id>jacoco-prepare-agent</id>
+                            <goals>
+                                <goal>prepare-agent</goal>
+                            </goals>
+                        </execution>
+                        <execution>
+                            <id>jacoco-prepare-agent-integration</id>
+                            <goals>
+                                <goal>prepare-agent-integration</goal>
+                            </goals>
+                        </execution>
+                        <execution>
+                            <id>jacoco-report</id>
+                            <phase>verify</phase>
+                            <goals>
+                                <goal>report</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                </plugin>
             </plugins>
         </pluginManagement>
 
@@ -529,7 +567,7 @@
                         <forkNumber>0${surefire.forkNumber}</forkNumber>
                         <project.basedir>${project.basedir}</project.basedir>
                     </systemPropertyVariables>
-                    <argLine>-Xms256m -Xmx2048m -Dmvn.forkNumber=${surefire.forkNumber} -XX:+UseG1GC</argLine>
+                    <argLine>@{argLine} -Xms256m -Xmx2048m -Dmvn.forkNumber=${surefire.forkNumber} -XX:+UseG1GC</argLine>
                 </configuration>
                 <executions>
                     <!--execute all the unit tests-->
@@ -564,6 +602,12 @@
                         </configuration>
                     </execution>
                 </executions>
+            </plugin>
+
+            <!-- JaCoCo: prepare-agent injects the coverage agent into surefire's @{argLine}; report generates per-module HTML/XML in verify phase. Aggregated report lives in statefun-coverage-report. -->
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
             </plugin>
         </plugins>
     </build>

--- a/pom.xml
+++ b/pom.xml
@@ -455,6 +455,14 @@
                             <exclude>org/apache/flink/statefun/sdk/shaded/**</exclude>
                         </excludes>
                     </configuration>
+                    <!--
+                        Both prepare-agent* executions write the JaCoCo agent flag into the same
+                        ${argLine} property. The default phase ordering (initialize → test →
+                        pre-integration-test → integration-test) is what keeps unit-test coverage
+                        intact: surefire reads argLine in `test` before prepare-agent-integration
+                        overwrites it for failsafe in `pre-integration-test`. Reordering the
+                        executions or rebinding their phases will silently break unit coverage.
+                    -->
                     <executions>
                         <execution>
                             <id>jacoco-prepare-agent</id>
@@ -462,6 +470,11 @@
                                 <goal>prepare-agent</goal>
                             </goals>
                         </execution>
+                        <!--
+                            No-op today: the project has no maven-failsafe-plugin configured, so
+                            target/jacoco-it.exec is never written. Kept as forward-compat scaffolding
+                            for Phase 3, when failsafe ITs may be added and would need this binding.
+                        -->
                         <execution>
                             <id>jacoco-prepare-agent-integration</id>
                             <goals>

--- a/pom.xml
+++ b/pom.xml
@@ -88,8 +88,10 @@
         <module>statefun-e2e-tests</module>
         <module>statefun-testutil</module>
 
-        <!-- coverage aggregator: must be last so all modules' jacoco.exec files exist before report-aggregate runs -->
+        <!-- coverage aggregators: must be last so all modules' jacoco*.exec files exist before report-aggregate runs.
+             Two separate aggregators keep unit and E2E coverage as independent Codecov flags rather than mixed. -->
         <module>statefun-coverage-report</module>
+        <module>statefun-e2e-coverage-report</module>
     </modules>
 
     <properties>

--- a/statefun-coverage-report/README.md
+++ b/statefun-coverage-report/README.md
@@ -1,0 +1,187 @@
+# statefun-coverage-report
+
+Aggregates JaCoCo code coverage across every production module in the reactor and produces a single project-wide report.
+
+This module has **no source code** and produces **no published artifact**. Its only job is to run JaCoCo's `report-aggregate` goal in the `verify` phase, after every other module has written its own `target/jacoco.exec` file.
+
+---
+
+## End-to-end flow
+
+How a single `mvn install` run turns into a coverage number, from JVM agent injection to GitHub Actions UI:
+
+```mermaid
+flowchart TB
+    subgraph "Reactor build (per production module)"
+        A[mvn verify] --> B[jacoco:prepare-agent]
+        B -->|sets ${argLine} to<br/>-javaagent:jacocoagent.jar| C[surefire:test]
+        C -->|forks JVM with agent attached| D[Tests run<br/>agent instruments classes<br/>as they load]
+        D -->|on JVM exit| E[target/jacoco.exec<br/>binary trace data]
+        E --> F[jacoco:report<br/>verify phase]
+        F --> G[target/site/jacoco/<br/>per-module HTML + XML]
+    end
+
+    subgraph "statefun-coverage-report (LAST in reactor)"
+        H[jacoco:report-aggregate<br/>verify phase] -->|walks ${project.build.directory}<br/>of every dependency module| I[Reads each module's<br/>target/jacoco.exec<br/>+ target/classes]
+        I --> J[Merges + filters<br/>via class-level excludes]
+        J --> K[target/site/jacoco-aggregate/<br/>jacoco.xml + index.html]
+    end
+
+    G -.->|all per-module .exec files exist| H
+
+    subgraph "CI consumption (.github/workflows/ci.yml)"
+        K --> L[Sanity check:<br/>grep '&lt;counter ' jacoco.xml]
+        L -->|empty = loud failure| M[Job summary:<br/>markdown table in run UI]
+        L --> N[Upload HTML artifact<br/>retention: 30 days]
+        L --> O[Upload jacoco.xml<br/>to Codecov via OIDC]
+    end
+
+    style B fill:#e1f5ff
+    style F fill:#e1f5ff
+    style H fill:#fff4e1
+    style L fill:#ffe1e1
+```
+
+**Key invariants:**
+
+- The aggregator is the **last module in the reactor** (root `pom.xml` `<modules>`). Maven processes modules in declared order, so `report-aggregate` runs only after every dependency module has written its `jacoco.exec`.
+- The agent JVM flag is injected via the parent pom's `surefire` `<argLine>@{argLine} -Xms256m...</argLine>` Maven late-binding. **Without `@{argLine}` the literal value silently swallows the agent**, producing an empty report with no error. The CI sanity check (`grep '<counter '`) turns this silent failure into a loud build failure.
+
+---
+
+## How E2E tests fit in (and why they don't)
+
+E2E tests **do not contribute coverage**, by design. Three independent mechanisms enforce this:
+
+```mermaid
+flowchart LR
+    subgraph "Production module (e.g. statefun-flink-core)"
+        P1[parent pom<br/>jacoco-prepare-agent execution<br/>jacoco.skip = false] -->|injects agent| P2[surefire test JVM<br/>argLine = -javaagent:...]
+        P2 --> P3[target/jacoco.exec<br/>WRITTEN]
+    end
+
+    subgraph "E2E module (e.g. statefun-smoke-e2e-driver)"
+        E1[statefun-e2e-tests/pom.xml<br/>cascades jacoco.skip = true] -.->|skips| E2[jacoco-prepare-agent<br/>NO-OP]
+        E2 --> E3[surefire/failsafe test JVM<br/>argLine = empty]
+        E3 --> E4[NO target/jacoco.exec written]
+    end
+
+    P3 -->|listed as dep<br/>in aggregator| AGG[report-aggregate]
+    E4 -.->|NOT listed as dep<br/>in aggregator| AGG
+
+    AGG --> RPT[Coverage % reflects<br/>unit tests only]
+
+    style E1 fill:#ffe1e1
+    style E4 fill:#ffe1e1
+    style P3 fill:#e1ffe1
+```
+
+**Three layers preventing E2E from polluting coverage:**
+
+1. **`<jacoco.skip>true</jacoco.skip>`** in `statefun-e2e-tests/pom.xml` cascades to all 10 child modules. The `prepare-agent` execution becomes a no-op, so no `-javaagent` flag is injected into the test JVM.
+2. **No `jacoco.exec` is written** for any E2E module. Even if `report-aggregate` tried to scan them (it doesn't), there would be no data.
+3. **The aggregator's `<dependencies>` block does not list any `statefun-e2e-tests/*` module**. `report-aggregate` walks declared dependencies only, so E2E modules are never inspected.
+
+**Cross-JVM isolation matters too.** When `statefun-smoke-e2e-driver` boots a Flink job that exercises code in `statefun-flink-core`, the executions happen in **separate JVMs** (Testcontainers spawns containers; kind launches Flink JM/TM pods). Those JVMs don't have the agent attached, so `statefun-flink-core`'s coverage data is unaffected by E2E activity.
+
+**Net effect**: the headline coverage number is **honest unit-test reach** — not "tested by anything". E2E tests still run (validate end-to-end behavior, fail loudly on regressions), they just don't show up as covered lines in the report.
+
+### When E2E coverage WOULD be added
+
+Three trigger conditions, documented in [issue #149 §E2E](https://github.com/kzmlabs/flink-statefun/issues/149):
+
+1. A module's unit-test coverage plateaus low (<40%) and the gap is provably in E2E-only code paths (Kinesis source bootstrap, K8s manifest binder, module-loader classpath scanning).
+2. A regression slips through unit tests but is caught by E2E.
+3. Apache Flink upstream ships a coverage-friendly E2E harness pattern.
+
+Until then, the multi-day plumbing required to extract `.exec` files from kind-cluster pods is not worth the marginal gain (<5% across the project, mostly already covered by unit tests).
+
+---
+
+## Two-layer exclusion model
+
+```mermaid
+flowchart TB
+    M[All modules in reactor] --> CHK{Module type?}
+
+    CHK -->|Production code| P[prepare-agent active<br/>jacoco.exec written]
+    CHK -->|Test scaffolding<br/>statefun-testutil<br/>statefun-e2e-tests/*| S1[<jacoco.skip>true</jacoco.skip><br/>module-level skip]
+    CHK -->|Aggregator self<br/>statefun-coverage-report| S2[<jacoco.skip>true</jacoco.skip><br/>only report-aggregate runs]
+
+    P --> CL{Class matches<br/>plugin-level excludes?}
+    CL -->|Yes:<br/>**/generated/**<br/>**/*Proto*.class<br/>**/*OuterClass*.class<br/>org/.../sdk/shaded/**| EX[Excluded from instrumentation<br/>AND from report]
+    CL -->|No| INC[Instrumented<br/>counted in jacoco.xml]
+
+    S1 --> SKIP[No jacoco.exec written<br/>NOT in aggregator deps<br/>invisible in report]
+
+    style EX fill:#ffe1e1
+    style SKIP fill:#ffe1e1
+    style INC fill:#e1ffe1
+```
+
+**Why two layers (module-level skip + class-level exclude)?**
+
+| Approach | What it does | Used for |
+|---|---|---|
+| **Module-level `<jacoco.skip>true</jacoco.skip>`** | Disables the agent entirely; module vanishes from per-module view | Test scaffolding only — these modules have no production code worth measuring |
+| **Class-level `<excludes>` in plugin config** | Agent ignores matching classes during instrumentation; they show as 0/0 in per-module view, not "vanished" | Generated protobuf code, shaded/relocated bytecode in production modules — the *module* matters (may grow real code later), the *classes* don't |
+
+This matters for `statefun-flink-runner`, `statefun-sdk-protos`, and `statefun-shaded/*`: today they're assembly/generated/shaded with no instrumentable code. **They are still listed in the aggregator's `<dependencies>`** so they appear as N/A in the per-module view rather than vanishing. If a future PR adds real code to one of them, the per-module view immediately shows the new uncovered lines instead of silently bypassing coverage tracking.
+
+`statefun-bom` and `statefun-docker` are NOT in the aggregator dependencies — they have no JAR / no Java code at all, so there's nothing for `report-aggregate` to walk.
+
+---
+
+## Three publication guards
+
+The aggregator must never be published to Maven Central or Docker Hub. Four independent mechanisms enforce this — any one failing still blocks publication:
+
+```mermaid
+flowchart LR
+    PUB{Try to publish<br/>statefun-coverage-report?} --> G1{central.skip<br/>= true?}
+    G1 -->|yes| BLOCK1[Sonatype Central plugin<br/>refuses upload]
+    G1 -.->|no| G2{maven.deploy.skip<br/>= true?}
+    G2 -->|yes| BLOCK2[maven-deploy-plugin<br/>refuses upload]
+    G2 -.->|no| G3{maven.install.skip<br/>= true?}
+    G3 -->|yes| BLOCK3[maven-install-plugin<br/>refuses local install]
+    G3 -.->|no| G4{In release.yml<br/>-pl exclusion?}
+    G4 -->|yes| BLOCK4[Reactor never<br/>runs deploy here]
+    G4 -.->|no| LEAK[would publish]
+
+    style BLOCK1 fill:#e1ffe1
+    style BLOCK2 fill:#e1ffe1
+    style BLOCK3 fill:#e1ffe1
+    style BLOCK4 fill:#e1ffe1
+    style LEAK fill:#ffe1e1
+```
+
+`<central.skip>` only covers the Sonatype plugin path. `maven-deploy-plugin` and `maven-install-plugin` are independent and would still try to push to whatever `<distributionManagement>` resolves to if the `-pl` exclusion were ever edited. The four-guard design means an aggregator pom edit that accidentally removes one guard still leaves three intact.
+
+---
+
+## Where to view the results
+
+| Location | What you get | Latency from CI run |
+|---|---|---|
+| **GitHub Actions run summary** | Markdown table with all 6 JaCoCo metric counters (Instruction, Branch, Line, Complexity, Method, Class) | Visible immediately in the run UI |
+| **`coverage-report-html` artifact** on the run page | Full drillable JaCoCo HTML site (per-module → package → class → line-level red/green) — download ZIP, open `index.html` | Available as soon as the upload step completes (~10 sec after build) |
+| **Codecov dashboard** at `app.codecov.io/gh/kzmlabs/flink-statefun` | Trend graphs, PR coverage delta comments, per-module breakdown, badge URL | ~30 sec after CI uploads (Phase 2 — optional, third-party) |
+| **Local `mvn install`** | `statefun-coverage-report/target/site/jacoco-aggregate/index.html` | Immediate — same as the CI artifact, just generated locally |
+
+---
+
+## Skip flag reference
+
+| Module / pattern | `jacoco.skip` | In aggregator deps | Reason |
+|---|---|---|---|
+| `statefun-flink/*` (rich tests) | false | yes | Production code with unit tests — primary signal |
+| `statefun-sdk-java`, `statefun-sdk-embedded` | false | yes | SDK code with unit tests |
+| `statefun-kafka-io`, `statefun-kinesis-io` | false | yes | Connector code with unit tests |
+| `statefun-sdk-protos` | false | yes | Generated protobuf — class-level excludes drop content; appears as N/A |
+| `statefun-flink-runner` | false | yes | Assembly module today; future-proof for code growth |
+| `statefun-shaded/*` | false | yes | Relocated bytecode — class-level excludes drop content; appears as N/A |
+| `statefun-bom` | n/a | **no** | No JAR, no `.class` files; nothing to walk |
+| `statefun-docker` | n/a | **no** | Docker assembly only, no Java |
+| `statefun-testutil` | **true** | no | Test scaffolding only |
+| `statefun-e2e-tests/*` (10 modules) | **true** | no | E2E in containers; see flow diagram above |
+| `statefun-coverage-report` (this module) | **true** | n/a | Aggregator itself; only `report-aggregate` execution runs |

--- a/statefun-coverage-report/README.md
+++ b/statefun-coverage-report/README.md
@@ -12,28 +12,28 @@ How a single `mvn install` run turns into a coverage number, from JVM agent inje
 
 ```mermaid
 flowchart TB
-    subgraph "Reactor build (per production module)"
-        A[mvn verify] --> B[jacoco:prepare-agent]
-        B -->|sets ${argLine} to<br/>-javaagent:jacocoagent.jar| C[surefire:test]
-        C -->|forks JVM with agent attached| D[Tests run<br/>agent instruments classes<br/>as they load]
-        D -->|on JVM exit| E[target/jacoco.exec<br/>binary trace data]
-        E --> F[jacoco:report<br/>verify phase]
-        F --> G[target/site/jacoco/<br/>per-module HTML + XML]
+    subgraph PROD["Reactor build (per production module)"]
+        A["mvn verify"] --> B["jacoco:prepare-agent"]
+        B -->|"sets argLine to -javaagent flag"| C["surefire:test"]
+        C -->|"forks JVM with agent attached"| D["Tests run<br/>agent instruments classes<br/>as they load"]
+        D -->|"on JVM exit"| E["target/jacoco.exec<br/>binary trace data"]
+        E --> F["jacoco:report<br/>verify phase"]
+        F --> G["target/site/jacoco/<br/>per-module HTML + XML"]
     end
 
-    subgraph "statefun-coverage-report (LAST in reactor)"
-        H[jacoco:report-aggregate<br/>verify phase] -->|walks ${project.build.directory}<br/>of every dependency module| I[Reads each module's<br/>target/jacoco.exec<br/>+ target/classes]
-        I --> J[Merges + filters<br/>via class-level excludes]
-        J --> K[target/site/jacoco-aggregate/<br/>jacoco.xml + index.html]
+    subgraph AGG["statefun-coverage-report (LAST in reactor)"]
+        H["jacoco:report-aggregate<br/>verify phase"] -->|"walks project.build.directory<br/>of every dependency module"| I["Reads each module's<br/>target/jacoco.exec<br/>plus target/classes"]
+        I --> J["Merges + filters<br/>via class-level excludes"]
+        J --> K["target/site/jacoco-aggregate/<br/>jacoco.xml + index.html"]
     end
 
-    G -.->|all per-module .exec files exist| H
+    G -.->|"all per-module exec files exist"| H
 
-    subgraph "CI consumption (.github/workflows/ci.yml)"
-        K --> L[Sanity check:<br/>grep '&lt;counter ' jacoco.xml]
-        L -->|empty = loud failure| M[Job summary:<br/>markdown table in run UI]
-        L --> N[Upload HTML artifact<br/>retention: 30 days]
-        L --> O[Upload jacoco.xml<br/>to Codecov via OIDC]
+    subgraph CI["CI consumption (.github/workflows/ci.yml)"]
+        K --> L["Sanity check:<br/>grep counter in jacoco.xml"]
+        L -->|"empty = loud failure"| M["Job summary:<br/>markdown table in run UI"]
+        L --> N["Upload HTML artifact<br/>retention: 30 days"]
+        L --> O["Upload jacoco.xml<br/>to Codecov via OIDC"]
     end
 
     style B fill:#e1f5ff

--- a/statefun-coverage-report/README.md
+++ b/statefun-coverage-report/README.md
@@ -1,8 +1,47 @@
 # statefun-coverage-report
 
-Aggregates JaCoCo code coverage across every production module in the reactor and produces a single project-wide report.
+Aggregates JaCoCo **unit-test** coverage across every production module in the reactor and produces a single project-wide report. There's a **sibling aggregator**, [`statefun-e2e-coverage-report`](../statefun-e2e-coverage-report/pom.xml), that does the same thing for in-process E2E coverage — see §Two-flag separation below.
 
 This module has **no source code** and produces **no published artifact**. Its only job is to run JaCoCo's `report-aggregate` goal in the `verify` phase, after every other module has written its own `target/jacoco.exec` file.
+
+## Two-flag separation: unit vs E2E
+
+```mermaid
+flowchart LR
+    subgraph PROD["Production modules (statefun-flink-core, statefun-sdk-java, ...)"]
+        P1[surefire test JVM<br/>agent attached] --> P2[target/jacoco.exec]
+    end
+
+    subgraph EMB["statefun-smoke-e2e-embedded (in-process E2E)"]
+        E1[surefire test JVM<br/>agent attached<br/>destFile overridden] --> E2[target/jacoco-e2e.exec]
+    end
+
+    P2 -->|scanned by **/jacoco.exec| AGG1[statefun-coverage-report<br/>report-aggregate]
+    E2 -->|scanned by **/jacoco-e2e.exec| AGG2[statefun-e2e-coverage-report<br/>report-aggregate]
+
+    AGG1 --> CV1[Codecov flag: unittests<br/>jacoco-aggregate/jacoco.xml]
+    AGG2 --> CV2[Codecov flag: e2e<br/>jacoco-e2e-aggregate/jacoco.xml]
+
+    style AGG1 fill:#e1f5ff
+    style AGG2 fill:#fff4e1
+    style CV1 fill:#e1f5ff
+    style CV2 fill:#fff4e1
+```
+
+**How separation is enforced (three layers):**
+
+1. **Different output filenames**: production modules write `target/jacoco.exec` (JaCoCo default); `statefun-smoke-e2e-embedded` overrides `<destFile>` in its prepare-agent execution to `target/jacoco-e2e.exec`.
+2. **Different `dataFileIncludes` patterns**: this aggregator scans `**/jacoco.exec` (default); the E2E aggregator scans `**/jacoco-e2e.exec` only. Each ignores the other's data files even if they were in the same module.
+3. **Different aggregator dependency lists**: this aggregator does NOT list `statefun-smoke-e2e-embedded` as a dep, so `report-aggregate` never even walks its `target/`. The E2E aggregator lists it FIRST.
+
+**What's in each flag:**
+
+| Flag | Source modules | Coverage signal |
+|---|---|---|
+| `unittests` | All `*Test.java` in production modules + `**/*ITCase.*` integration tests | Per-module unit-test reach against production code |
+| `e2e` | `statefun-smoke-e2e-embedded` only — runs StateFun via `statefun-flink-harness` in the surefire JVM | End-to-end scenarios exercising real production paths in-process |
+
+**Container-based E2E (Testcontainers smoke + kind K8s) is intentionally NOT instrumented.** Those tests run production code in separate JVMs (TC containers, K8s pods) where the agent cannot reach without multi-day plumbing (image bake-in, volume mounts, post-run `.exec` extraction). Defer indefinitely per [issue #149 §E2E](https://github.com/kzmlabs/flink-statefun/issues/149) trigger conditions.
 
 ---
 

--- a/statefun-coverage-report/pom.xml
+++ b/statefun-coverage-report/pom.xml
@@ -1,0 +1,179 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!-- Copyright 2014 The Apache Software Foundation -->
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>statefun-parent</artifactId>
+        <groupId>io.github.kzmlabs.flinkstatefun</groupId>
+        <version>${revision}</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>statefun-coverage-report</artifactId>
+    <name>statefun-coverage-report</name>
+    <packaging>pom</packaging>
+
+    <properties>
+        <!-- Belt + suspenders: three independent guards against ever publishing this aggregator. -->
+        <central.skip>true</central.skip>
+        <maven.deploy.skip>true</maven.deploy.skip>
+        <maven.install.skip>true</maven.install.skip>
+        <!-- This module has no source code of its own; only consumes other modules' jacoco.exec files. -->
+        <jacoco.skip>true</jacoco.skip>
+    </properties>
+
+    <!--
+        Aggregate JaCoCo coverage across every production module in the reactor.
+        Test-scaffolding modules (statefun-testutil, statefun-e2e-tests/*) and the BOM are NOT listed here —
+        they either have no tests worth measuring or are excluded via <jacoco.skip>true</jacoco.skip>.
+        Modules with no Java code or only generated/shaded bytecode (statefun-bom, statefun-docker,
+        statefun-shaded/*, statefun-sdk-protos, statefun-flink-runner) ARE listed: class-level excludes
+        in the parent pom's jacoco config keep them at N/A in the per-module table rather than vanished.
+    -->
+    <dependencies>
+        <dependency>
+            <groupId>io.github.kzmlabs.flinkstatefun</groupId>
+            <artifactId>statefun-sdk-embedded</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.github.kzmlabs.flinkstatefun</groupId>
+            <artifactId>statefun-sdk-protos</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.github.kzmlabs.flinkstatefun</groupId>
+            <artifactId>statefun-sdk-java</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.github.kzmlabs.flinkstatefun</groupId>
+            <artifactId>statefun-kafka-io</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.github.kzmlabs.flinkstatefun</groupId>
+            <artifactId>statefun-kinesis-io</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.github.kzmlabs.flinkstatefun</groupId>
+            <artifactId>statefun-flink-common</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.github.kzmlabs.flinkstatefun</groupId>
+            <artifactId>statefun-flink-core</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.github.kzmlabs.flinkstatefun</groupId>
+            <artifactId>statefun-flink-datastream</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.github.kzmlabs.flinkstatefun</groupId>
+            <artifactId>statefun-flink-distribution</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.github.kzmlabs.flinkstatefun</groupId>
+            <artifactId>statefun-flink-extensions</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.github.kzmlabs.flinkstatefun</groupId>
+            <artifactId>statefun-flink-harness</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.github.kzmlabs.flinkstatefun</groupId>
+            <artifactId>statefun-flink-io</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.github.kzmlabs.flinkstatefun</groupId>
+            <artifactId>statefun-flink-io-bundle</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.github.kzmlabs.flinkstatefun</groupId>
+            <artifactId>statefun-flink-launcher</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.github.kzmlabs.flinkstatefun</groupId>
+            <artifactId>statefun-flink-state-processor</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.github.kzmlabs.flinkstatefun</groupId>
+            <artifactId>statefun-protobuf-shaded</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.github.kzmlabs.flinkstatefun</groupId>
+            <artifactId>statefun-protocol-shaded</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.github.kzmlabs.flinkstatefun</groupId>
+            <artifactId>statefun-flink-runner</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <!-- This module aggregates other modules' coverage data; it produces no artifact and has no source.
+                 The parent's dependencyConvergence rule checks the merged transitive graph here, but the only
+                 reason we depend on those modules is to give report-aggregate something to walk — convergence
+                 conflicts (httpcore 4.4.13 vs 4.4.16 from the AWS connector) are already resolved in the parent
+                 pom's dependencyManagement and don't affect the aggregator's purpose. -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>aggregate-report</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>report-aggregate</goal>
+                        </goals>
+                        <configuration>
+                            <!-- report-aggregate ignores parent <jacoco.skip>; we set it explicitly here so the agent execution stays disabled but reporting runs. -->
+                            <skip>false</skip>
+                            <outputDirectory>${project.build.directory}/site/jacoco-aggregate</outputDirectory>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <!-- Belt + suspenders against accidental publication. -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-deploy-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-install-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/statefun-e2e-coverage-report/pom.xml
+++ b/statefun-e2e-coverage-report/pom.xml
@@ -1,0 +1,181 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!-- Copyright 2014 The Apache Software Foundation -->
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>statefun-parent</artifactId>
+        <groupId>io.github.kzmlabs.flinkstatefun</groupId>
+        <version>${revision}</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>statefun-e2e-coverage-report</artifactId>
+    <name>statefun-e2e-coverage-report</name>
+    <packaging>pom</packaging>
+
+    <properties>
+        <!-- Belt + suspenders: three independent guards against ever publishing this aggregator. -->
+        <central.skip>true</central.skip>
+        <maven.deploy.skip>true</maven.deploy.skip>
+        <maven.install.skip>true</maven.install.skip>
+        <!-- This module has no source code of its own. -->
+        <jacoco.skip>true</jacoco.skip>
+    </properties>
+
+    <!--
+        Aggregates JaCoCo coverage from in-process E2E suites (statefun-smoke-e2e-embedded today)
+        against the production code they exercise. report-aggregate is configured below to scan
+        only **/jacoco-e2e.exec so it never conflates with unit-test data (which lives in
+        **/jacoco.exec and is aggregated by statefun-coverage-report).
+
+        The embedded module itself is listed FIRST so report-aggregate finds the .exec there;
+        production modules follow so coverage attributes against their classes/source.
+
+        WHY the embedded module: it runs StateFun entirely in-process via statefun-flink-harness —
+        no Testcontainers, no kind cluster — so the surefire JVM agent captures real production
+        code paths. Container-based E2E (statefun-smoke-e2e-driver/-java/-multilang-*, kind
+        cluster) is NOT included here: those run production code in separate JVMs (TC containers,
+        K8s pods) where the agent cannot reach without multi-day plumbing. See
+        statefun-coverage-report/README.md §"How E2E tests fit in".
+    -->
+    <dependencies>
+        <!-- E2E source (.exec lives in this module's target/) -->
+        <dependency>
+            <groupId>io.github.kzmlabs.flinkstatefun</groupId>
+            <artifactId>statefun-smoke-e2e-embedded</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <!-- Production modules whose classes the E2E exercises -->
+        <dependency>
+            <groupId>io.github.kzmlabs.flinkstatefun</groupId>
+            <artifactId>statefun-sdk-embedded</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.github.kzmlabs.flinkstatefun</groupId>
+            <artifactId>statefun-sdk-protos</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.github.kzmlabs.flinkstatefun</groupId>
+            <artifactId>statefun-sdk-java</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.github.kzmlabs.flinkstatefun</groupId>
+            <artifactId>statefun-flink-common</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.github.kzmlabs.flinkstatefun</groupId>
+            <artifactId>statefun-flink-core</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.github.kzmlabs.flinkstatefun</groupId>
+            <artifactId>statefun-flink-datastream</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.github.kzmlabs.flinkstatefun</groupId>
+            <artifactId>statefun-flink-distribution</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.github.kzmlabs.flinkstatefun</groupId>
+            <artifactId>statefun-flink-extensions</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.github.kzmlabs.flinkstatefun</groupId>
+            <artifactId>statefun-flink-harness</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.github.kzmlabs.flinkstatefun</groupId>
+            <artifactId>statefun-flink-io</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.github.kzmlabs.flinkstatefun</groupId>
+            <artifactId>statefun-flink-io-bundle</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.github.kzmlabs.flinkstatefun</groupId>
+            <artifactId>statefun-flink-launcher</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.github.kzmlabs.flinkstatefun</groupId>
+            <artifactId>statefun-flink-state-processor</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.github.kzmlabs.flinkstatefun</groupId>
+            <artifactId>statefun-kafka-io</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.github.kzmlabs.flinkstatefun</groupId>
+            <artifactId>statefun-kinesis-io</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <!-- See statefun-coverage-report/pom.xml for the dependency-convergence rationale. -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>aggregate-e2e-report</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>report-aggregate</goal>
+                        </goals>
+                        <configuration>
+                            <!-- Override the parent jacoco.skip=true so this execution actually runs. -->
+                            <skip>false</skip>
+                            <!-- Critical: scan ONLY for the E2E exec file. Default would be **/jacoco.exec,
+                                 which would conflate with unit-test data. -->
+                            <dataFileIncludes>
+                                <dataFileInclude>**/jacoco-e2e.exec</dataFileInclude>
+                            </dataFileIncludes>
+                            <outputDirectory>${project.build.directory}/site/jacoco-e2e-aggregate</outputDirectory>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <!-- Belt + suspenders against accidental publication. -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-deploy-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-install-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/statefun-e2e-tests/pom.xml
+++ b/statefun-e2e-tests/pom.xml
@@ -17,6 +17,8 @@
     <properties>
         <testcontainers.version>2.0.5</testcontainers.version>
         <central.skip>true</central.skip>
+        <!-- E2E suites run inside kind-cluster JM/TM pods; agent injection requires container plumbing not worth the marginal coverage. See issue #149 §E2E. -->
+        <jacoco.skip>true</jacoco.skip>
     </properties>
 
     <modules>

--- a/statefun-e2e-tests/statefun-smoke-e2e-embedded/pom.xml
+++ b/statefun-e2e-tests/statefun-smoke-e2e-embedded/pom.xml
@@ -15,6 +15,14 @@
 
     <properties>
         <central.skip>true</central.skip>
+        <!--
+            Override the parent statefun-e2e-tests cascade (which sets jacoco.skip=true).
+            This module runs StateFun entirely in-process via statefun-flink-harness — no
+            Testcontainers, no kind cluster — so the JaCoCo agent CAN attach to the surefire
+            JVM and capture genuine production-code coverage from end-to-end scenarios.
+            See statefun-e2e-coverage-report/README.md for the two-flag separation rationale.
+        -->
+        <jacoco.skip>false</jacoco.skip>
     </properties>
 
     <dependencies>
@@ -53,6 +61,26 @@
 
     <build>
         <plugins>
+            <!--
+                JaCoCo agent writes to jacoco-e2e.exec (NOT the default jacoco.exec) so the
+                main aggregator's report-aggregate (which scans for **/jacoco.exec by default)
+                will not pick this data up. The dedicated statefun-e2e-coverage-report
+                aggregator scans for **/jacoco-e2e.exec — keeps unit and E2E coverage as
+                two separate Codecov flags rather than one mixed number.
+            -->
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>jacoco-prepare-agent</id>
+                        <configuration>
+                            <destFile>${project.build.directory}/jacoco-e2e.exec</destFile>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
             <!-- embedded module should be built into a fat-jar -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/statefun-testutil/pom.xml
+++ b/statefun-testutil/pom.xml
@@ -14,6 +14,11 @@
     <artifactId>statefun-testutil</artifactId>
     <name>statefun-testutil</name>
 
+    <properties>
+        <!-- Test scaffolding only; no production code to cover. -->
+        <jacoco.skip>true</jacoco.skip>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>io.github.kzmlabs.flinkstatefun</groupId>


### PR DESCRIPTION
## Summary

Implements [issue #149](https://github.com/kzmlabs/flink-statefun/issues/149) Phase 1 — minimum viable JaCoCo code coverage with Codecov upload.

- **JaCoCo 0.8.14** plugin in root pom (`pluginManagement` + active `plugins`); `prepare-agent` + `prepare-agent-integration` + `report` executions.
- **Critical fix at `pom.xml`**: surefire `argLine` was literal `<argLine>-Xms256m...</argLine>`, silently swallowing the JaCoCo agent. Switched to `<argLine>@{argLine} -Xms256m...</argLine>` Maven late-binding form so `prepare-agent` can prepend `-javaagent:jacocoagent.jar`. This was the documented blocker in the issue.
- **New aggregator module** `statefun-coverage-report/` (`<packaging>pom</packaging>`) depending on every production module that produces a JAR with classes; runs `report-aggregate` in `verify` phase. Output: `statefun-coverage-report/target/site/jacoco-aggregate/jacoco.xml`.
- **Test-only modules skipped**: `statefun-testutil` and `statefun-e2e-tests/*` (cascades to all 10 children) get `<jacoco.skip>true</jacoco.skip>`.
- **Production modules with no tests / generated / shaded bytecode**: kept in the aggregator's `<dependencies>` (so they show as N/A in per-module Codecov view rather than vanishing). Specifically listed: `statefun-sdk-protos`, `statefun-flink-runner`, `statefun-protobuf-shaded`, `statefun-protocol-shaded`. Class-level excludes (`**/generated/**`, `**/*Proto*.class`, `**/*OuterClass*.class`, `org/apache/flink/statefun/sdk/shaded/**`) keep them at 0/0 instructions in the headline number. NOT listed: `statefun-bom` (no JAR, only manages dependencies) and `statefun-docker` (no Java code, Docker assembly only) — these have nothing for `report-aggregate` to walk.
- **Three publication guards** on the aggregator (`central.skip`, `maven.deploy.skip`, `maven.install.skip`) + `,!:statefun-coverage-report` in `release.yml` deploy `-pl` exclusion. Maven enforcer skipped on the aggregator (no source code, no artifact, dependency convergence is enforced at the production-module level where it matters).
- **CI updates** in `ci.yml`: empty-report sanity check (greps for `<counter ` in `jacoco.xml`) — turns the silent-failure mode that motivated this issue into a loud build failure. Codecov upload via `codecov-action@v5` with `use_oidc: true` (no `CODECOV_TOKEN` needed). Workflow now requests `id-token: write` permission.

## Phase 2 + 3 deferred

- Phase 2 (badge + Codecov account registration): follow-up issue. Codecov auto-accepts the upload on first run; badge URL works once.
- Phase 3 (thresholds via `codecov.yml` + Maven `<rules>`): wait 2-4 weeks for baseline data per issue plan, then ratchet.

## Local verification

`mvn install -B -Drat.skip=false` (with E2E modules excluded — they don't contribute coverage and were saturating my local disk):

- ✅ BUILD SUCCESS
- ✅ Aggregator `jacoco.xml` produced (1.39 MB, 75 packages instrumented)
- ✅ JaCoCo `prepare-agent` fired on every production module with tests (verified 9 `target/jacoco.exec` files written)
- ✅ E2E modules ran tests but produced zero coverage data (skip flag working)
- ✅ Headline coverage: **15,494 / 29,644 instructions = 52.3%** (honest baseline; matches the test-density snapshot in #149 — rich modules pull the average up, zero-test modules pull it down)

## Test plan

- [ ] CI green on this PR (compile + unit tests + integration tests)
- [ ] Sanity-check step succeeds (`<counter ` present in `jacoco.xml`)
- [ ] Codecov receives the report (visible in the action log even before the org/repo is registered)
- [ ] Maven Central deploy unaffected (verify on next release tag — aggregator excluded by all four guards)
- [ ] No regression in surefire test reporting

## Review follow-ups (from #150 review)

- [x] Comment the implicit phase-ordering dependency between `prepare-agent` and `prepare-agent-integration` — both write `argLine`, reordering silently breaks unit coverage. (commit `cb3dc2a9`)
- [x] Comment that `prepare-agent-integration` is a no-op today (no failsafe configured) and is forward-compat scaffolding. (commit `cb3dc2a9`)
- [x] Correct PR description aggregator-deps wording (this commit).
- [ ] **Phase 2 verification**: confirm via Codecov per-module view that generated proto classes don't inflate the denominator. Plugin-level `<excludes>` is consumed by the agent (instrumentation-time); the `report` / `report-aggregate` executions inherit it via Maven's normal cascade. If the per-module view shows artificially-low numbers on `statefun-flink-core` or `statefun-sdk-java` due to uncovered generated classes, mirror the excludes inside the `report` and `aggregate-report` executions explicitly.
