### PR TITLE
chore(deps): bump kafka-clients 3.9.1 → 3.9.2 (CVE fixes)

### DIFF
--- a/statefun-kafka-io/pom.xml
+++ b/statefun-kafka-io/pom.xml
@@ -13,7 +13,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <properties>
-        <kafka.version>3.9.1</kafka.version>
+        <kafka.version>3.9.2</kafka.version>
     </properties>
 
     <artifactId>statefun-kafka-io</artifactId>


### PR DESCRIPTION
Closes #143

Bumps `kafka.version` from 3.9.1 → 3.9.2 in `statefun-kafka-io/pom.xml`. 3.9.2 is a patch release; no API changes.

## CVEs fixed

- [GHSA-5qcv-4rpc-jp93](https://github.com/advisories/GHSA-5qcv-4rpc-jp93) — high — *Producer message corruption/misrouting via buffer pool race condition* (`>= 2.8.0, < 3.9.2`)
- [GHSA-wf66-mphr-4c4r](https://github.com/advisories/GHSA-wf66-mphr-4c4r) — medium — *Sensitive information exposure in DEBUG logs* (`>= 0.11.0, < 3.9.2`)

`kafka-clients` ships in the StateFun runtime classpath via `statefun-kafka-io` (no shade exclusion), so both CVEs are reachable from a deployed StateFun job.

