### PR TITLE
ci(security): add top-level read-only permissions to all workflows

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -12,6 +12,11 @@ concurrency:
   group: docker-release-${{ github.ref }}
   cancel-in-progress: false
 
+# Default to read-only for GITHUB_TOKEN (principle of least privilege).
+# The `docker` job overrides with the writes it actually needs (packages, attestations, id-token).
+permissions:
+  contents: read
+
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: kzmlabs/flink-statefun

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -11,6 +11,10 @@ concurrency:
   group: e2e-${{ github.ref }}
   cancel-in-progress: true
 
+# Read-only by default — this workflow only needs to fetch source and run tests.
+permissions:
+  contents: read
+
 jobs:
   k8s-e2e:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,6 +26,12 @@ concurrency:
   group: release-${{ github.ref }}
   cancel-in-progress: false
 
+# Default to read-only for GITHUB_TOKEN. The `release` job overrides with the writes it
+# actually needs (contents:write for tag/release push, packages:write for GHCR, id-token +
+# attestations for Sigstore signing).
+permissions:
+  contents: read
+
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: kzmlabs/flink-statefun


### PR DESCRIPTION
## Summary

OpenSSF Scorecard's `Token-Permissions` check scored 0/10 because three workflows had **no top-level `permissions:` block at all** — defaulting GITHUB_TOKEN to write-everything. This violates principle of least privilege and is the easiest single Scorecard win available.

Adding top-level `permissions: contents: read` to:
- `docker-release.yml`
- `e2e-test.yml`
- `release.yml`

Job-level overrides on the `docker` job (in docker-release) and `release` job (in release) — `packages: write`, `id-token: write`, `attestations: write`, `contents: write` for tag push — are **unchanged**. Those writes are required for actual function (GHCR push, Sigstore signing, GitHub Release creation). Job-level perms in GitHub Actions REPLACE top-level (not merge), so existing behavior is unaffected.

## Expected Scorecard impact

- `Token-Permissions`: 0 → 8-10
- Overall: 6 → 7

(Some `Warn:` lines in the Scorecard report are about job-level write perms that genuinely cannot be reduced — those don't affect the score once a top-level read default is in place.)

## Test plan

- [ ] CI green (no functional change, just metadata)
- [ ] Next release succeeds (release.yml can still push tags + create release + push to GHCR)
- [ ] Next docker-release dispatch succeeds (packages:write still active on the docker job)
- [ ] Scorecard rerun in ~7 days shows Token-Permissions improvement

## Other Scorecard findings (separate PRs)

Researched while here, NOT in this PR:

- **Pinned-Dependencies (0)**: needs SHA pinning for ~40 actions across 9 workflows. Mechanical, ~30 min, separate PR.
- **Signed-Releases (-1)**: confirmed every release has 0 attached assets. Real signing happens (Maven Central + GHCR Sigstore) but Scorecard only scans GH Release assets. Fix is to attach a cosign-signed release manifest (`.sigstore.bundle`). Separate ~15 min PR.
- **CII Best Practices (0)**: requires manual application at https://www.bestpractices.dev/en/projects/new — no code change, ~30 min user form-filling.