### PR TITLE
ci(security): cosign-sign release manifest as GitHub Release asset

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -138,6 +138,61 @@ jobs:
           subject-digest: ${{ steps.build.outputs.digest }}
           push-to-registry: true
 
+      # Install cosign so we can sign a release manifest as a GitHub Release asset.
+      # Real signing of JARs happens via maven-gpg-plugin (uploaded to Maven Central) and
+      # of container images via actions/attest-build-provenance above. OpenSSF Scorecard's
+      # Signed-Releases check ONLY scans GitHub Release assets for signature files, so we
+      # also publish a cosign-signed manifest here that binds the release tag to the docker
+      # digest. Bumps Scorecard Signed-Releases from -1 to ~10 without weakening the real
+      # supply-chain signing already in place.
+      - name: Install cosign
+        if: steps.release_type.outputs.type == 'full'
+        uses: sigstore/cosign-installer@v3
+
+      - name: Generate and sign release manifest
+        if: steps.release_type.outputs.type == 'full'
+        env:
+          VERSION: ${{ steps.release_type.outputs.version }}
+          DIGEST: ${{ steps.build.outputs.digest }}
+        run: |
+          cat > release-manifest.txt <<EOF
+          Release: v${VERSION}
+          Built:   $(date -u +%Y-%m-%dT%H:%M:%SZ)
+          Source commit: ${GITHUB_SHA}
+          Source ref:    ${GITHUB_REF}
+
+          Docker image (immutable digest):
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${DIGEST}
+
+          Docker tag (mutable):
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${VERSION}
+
+          Maven Central artifacts (groupId io.github.kzmlabs.flinkstatefun, version ${VERSION}):
+            statefun-sdk-java
+            statefun-sdk-embedded
+            statefun-sdk-protos
+            statefun-flink-distribution
+            statefun-flink-runner
+
+          Signature verification (this manifest):
+            cosign verify-blob \\
+              --bundle release-manifest.txt.sigstore.bundle \\
+              --certificate-identity-regexp 'https://github.com/kzmlabs/flink-statefun/.github/workflows/release.yml@refs/tags/v.*' \\
+              --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' \\
+              release-manifest.txt
+
+          Container image attestation verification:
+            gh attestation verify oci://${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${VERSION} --owner kzmlabs
+
+          Maven Central JAR signature verification:
+            mvn dependency:copy -Dartifact=io.github.kzmlabs.flinkstatefun:statefun-sdk-java:${VERSION}:jar.asc
+            gpg --verify statefun-sdk-java-${VERSION}.jar.asc statefun-sdk-java-${VERSION}.jar
+          EOF
+
+          cosign sign-blob --yes \
+            --bundle release-manifest.txt.sigstore.bundle \
+            release-manifest.txt
+
       - name: Create GitHub Release
         if: steps.release_type.outputs.type == 'full'
         env:
@@ -164,7 +219,14 @@ jobs:
           docker pull ghcr.io/kzmlabs/flink-statefun:${VERSION}
           \`\`\`
 
+          ### Supply-chain signatures
+          Attached \`release-manifest.txt.sigstore.bundle\` is a cosign-signed (Sigstore keyless) bundle binding this tag to the docker digest. Verification commands are inside \`release-manifest.txt\`.
+          - Container image: signed via Sigstore keyless attestation, verifiable with \`gh attestation verify\`.
+          - Maven Central JARs: GPG-signed, \`.asc\` files alongside each JAR on Maven Central.
+
           ### Changes
           See [CHANGELOG](https://github.com/kzmlabs/flink-statefun/blob/release/CHANGELOG.md) for details.
           EOF
-          )"
+          )" \
+            release-manifest.txt \
+            release-manifest.txt.sigstore.bundle


### PR DESCRIPTION
## Summary

Fixes OpenSSF Scorecard's `Signed-Releases` check (currently scoring **-1 / no releases found**) by attaching a cosign-signed manifest to every GitHub Release.

## Why -1 today (false negative)

Real signing IS happening at three layers:
- **Maven Central JARs**: signed via `maven-gpg-plugin` (`.asc` files alongside each JAR)
- **Container images**: signed via `actions/attest-build-provenance@v4` (Sigstore keyless, attestations live in GitHub Attestations API)
- **SLSA provenance**: build provenance attached to GHCR images, verifiable with `gh attestation verify`

But Scorecard's `Signed-Releases` check **only scans GitHub Release assets** for signature suffixes (`.sig`, `.asc`, `.intoto.jsonl`, `.sigstore.bundle`). All your existing signatures live elsewhere, so Scorecard sees zero and scores -1.

## What this PR adds

Three new steps in `release.yml`'s `release` job, between the existing image-attestation step and the GitHub Release creation:

1. **Install cosign** (`sigstore/cosign-installer@v3`)
2. **Generate `release-manifest.txt`** — binds the release tag to the immutable docker digest, enumerates Maven Central artifacts, embeds verification commands for all three signature layers
3. **`cosign sign-blob --yes --bundle release-manifest.txt.sigstore.bundle`** — Sigstore keyless signing using the same `id-token: write` permission already required by `attest-build-provenance`

Modified the `gh release create` command to attach both files (`release-manifest.txt` + `release-manifest.txt.sigstore.bundle`) as release assets.

Updated the release notes template to mention the supply-chain signature stack so users know how to verify everything.

## Verification (after this PR merges + first signed release)

```bash
# Download the manifest + bundle from the release
gh release download v3.4.0-KZM-3.2 --pattern 'release-manifest.txt*' --repo kzmlabs/flink-statefun

# Verify the cosign signature
cosign verify-blob \
  --bundle release-manifest.txt.sigstore.bundle \
  --certificate-identity-regexp 'https://github.com/kzmlabs/flink-statefun/.github/workflows/release.yml@refs/tags/v.*' \
  --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' \
  release-manifest.txt
```

## Expected Scorecard impact

- `Signed-Releases`: -1 → ~10
- Overall: 7 → ~8 (after PR #153 lands)

## What this is NOT

- Not a replacement for the real signing (Maven GPG, image attestation) — those continue unchanged and remain the primary supply-chain trust roots
- Not increasing scope of any existing permission — the `id-token: write` and `contents: write` perms on the `release` job were already required for image attestation + tag push
- Not adding new external dependencies at runtime — cosign runs in CI only

## Test plan

- [ ] CI green on this PR
- [ ] Next release tag (v3.4.0-KZM-3.2 or whatever ships next) shows 2 attached assets on its GitHub Release page
- [ ] `cosign verify-blob` against the attached bundle succeeds with the expected identity
- [ ] Scorecard rerun in ~7 days shows Signed-Releases jumping to a high score
- [ ] Existing release flow (Maven Central deploy, GHCR push, image attestation, tag creation) still works unchanged