### PR TITLE
chore: bump to 3.4.0-KZM-3.3-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -95,7 +95,7 @@
     </modules>
 
     <properties>
-        <revision>3.4.0-KZM-3.1</revision>
+        <revision>3.4.0-KZM-3.3-SNAPSHOT</revision>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <java.version>21</java.version>


### PR DESCRIPTION
## Summary

Bumps `<revision>` from `3.4.0-KZM-3.1` to `3.4.0-KZM-3.3-SNAPSHOT` so we can deploy a development build to Sonatype Snapshots (OSSRH).

## What ships in this snapshot

Cumulative changes since `3.4.0-KZM-3.1`:

- ✅ JaCoCo code coverage Phase 1 (PR #150)
- ✅ Two-flag coverage separation: `unittests` + `e2e` (PR #150)
- ✅ Coverage aggregator README with mermaid diagrams (PR #150, #152)
- ✅ Hashnode article syndication links (PR #148)
- ✅ Kafka-clients 3.9.2 CVE bump (PR #151)
- ✅ OpenSSF Scorecard Token-Permissions hardening (PR #153)
- ⏸️ Cosign-signed release manifest (PR #154) — pending merge, but only fires on `v*` tags so won't be in this snapshot

## Why skip 3.4.0-KZM-3.2

Leaving 3.2 reserved as a potential patch slot against the KZM-3.1 line in case a critical hotfix is ever needed without pulling in the full KZM-3.3 changeset. Going straight to 3.3 for the next dev iteration.

## Snapshot deploy flow (after this PR merges)

```bash
git checkout release && git pull
git tag snapshot-3.4.0-KZM-3.3 -m "Snapshot: coverage + Scorecard hardening"
git push origin snapshot-3.4.0-KZM-3.3
```

Workflow `.github/workflows/snapshot.yml` triggers on `snapshot-*` tags and deploys to https://central.sonatype.com/repository/maven-snapshots/io/github/kzmlabs/flinkstatefun/

## Test plan

- [ ] CI green (compile + tests still pass with the new revision)
- [ ] No accidental docs updates (latest stable docs still reference `3.4.0-KZM-3.1` — snapshots are dev-only, not user-facing)
- [ ] After merge: snapshot tag triggers OSSRH deploy