### PR TITLE
fix(ci): snapshot deploy 401 — use server-id 'central' + exclude unpublishable modules

### DIFF
--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -24,15 +24,22 @@ jobs:
           java-version: '21'
           distribution: 'temurin'
           cache: 'maven'
-          server-id: ossrh
-          server-username: OSSRH_USERNAME
-          server-password: OSSRH_PASSWORD
+          # server-id matches the pom's <distributionManagement><snapshotRepository><id>
+          # which is "central" (Sonatype migrated from OSSRH to central.sonatype.com).
+          # Mismatch causes 401 Unauthorized on deploy.
+          server-id: central
+          server-username: CENTRAL_USERNAME
+          server-password: CENTRAL_PASSWORD
 
       - name: Build
         run: mvn clean install -DskipTests -B
 
       - name: Deploy Snapshot
-        run: mvn deploy -DskipTests -B
+        # Exclude same modules as release.yml (assembly + e2e + coverage aggregators)
+        # to keep snapshot artifacts publishable to Maven Central.
+        run: |
+          mvn deploy -DskipTests -B \
+            -pl '!:statefun-flink-runner,!:statefun-docker,!:statefun-e2e-tests,!:statefun-e2e-tests-common,!:statefun-smoke-e2e-common,!:statefun-smoke-e2e-driver,!:statefun-smoke-e2e-embedded,!:statefun-smoke-e2e-multilang-base,!:statefun-smoke-e2e-multilang-harness,!:statefun-smoke-e2e-java,!:statefun-smoke-e2e-golang,!:statefun-smoke-e2e-js,!:statefun-e2e-k8s-native,!:statefun-coverage-report,!:statefun-e2e-coverage-report'
         env:
-          OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}
-          OSSRH_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
+          CENTRAL_USERNAME: ${{ secrets.OSSRH_USERNAME }}
+          CENTRAL_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}


### PR DESCRIPTION
## Summary

Snapshot deploy run [25398846629](https://github.com/kzmlabs/flink-statefun/actions/runs/25398846629) failed with **HTTP 401 Unauthorized** uploading to `central.sonatype.com/repository/maven-snapshots/`.

## Root cause

`snapshot.yml` had:
```yaml
server-id: ossrh
server-username: OSSRH_USERNAME
server-password: OSSRH_PASSWORD
```

But the pom's `<distributionManagement><snapshotRepository><id>` is `central` (the project migrated from OSSRH to central.sonatype.com last year). When Maven tried to deploy, it looked for credentials under server-id `central` in the settings.xml — found none → 401.

The release workflow (`release.yml`) already uses `server-id: central` correctly. Snapshot was the only one missed during the migration.

## Fix

1. `server-id: ossrh` → `server-id: central`
2. Var names `OSSRH_USERNAME/PASSWORD` → `CENTRAL_USERNAME/PASSWORD` (the underlying `secrets.OSSRH_USERNAME/PASSWORD` GitHub Secret still has the right token value — just the var names that get propagated into settings.xml change to match what setup-java emits when `server-id: central` is set)
3. Added the same `-pl` exclusion list `release.yml` uses, so snapshot deploy doesn't try to push assembly modules, E2E modules, or the new coverage aggregators (which would fail Sonatype validation)

## Test plan

- [ ] CI green on PR
- [ ] After merge, delete + re-create `snapshot-3.4.0-KZM-3.3` tag to retrigger the workflow
- [ ] Workflow completes BUILD SUCCESS
- [ ] Snapshot artifact appears at https://central.sonatype.com/repository/maven-snapshots/io/github/kzmlabs/flinkstatefun/statefun-sdk-java/3.4.0-KZM-3.3-SNAPSHOT/