### PR TITLE
fix(deps): revert slf4j 1.7.36 → 2.0.17 bump (broken release)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -115,7 +115,7 @@
         <scala.version>2.12.7</scala.version>
         <lz4-java.version>1.8.1</lz4-java.version>
         <flink-shaded-jackson.version>2.18.2-20.0</flink-shaded-jackson.version>
-        <slf4j-log4j12.version>2.0.17</slf4j-log4j12.version>
+        <slf4j-log4j12.version>1.7.36</slf4j-log4j12.version>
         <test.unit.pattern>**/*Test.*</test.unit.pattern>
 
         <maven-compiler-plugin.version>3.15.0</maven-compiler-plugin.version>

--- a/statefun-e2e-tests/statefun-e2e-k8s-native/pom.xml
+++ b/statefun-e2e-tests/statefun-e2e-k8s-native/pom.xml
@@ -20,7 +20,7 @@
         <awaitility.version>4.3.0</awaitility.version>
         <assertj.version>3.27.7</assertj.version>
         
-        <slf4j.version>2.0.17</slf4j.version>
+        <slf4j.version>2.0.9</slf4j.version>
         <!-- CI can set this true to keep the cluster alive for log collection -->
         <skip.teardown>false</skip.teardown>
     </properties>


### PR DESCRIPTION
## Urgent

Reverts [PR #141](https://github.com/kzmlabs/flink-statefun/pull/141) which is currently breaking the `release` branch CI and snapshot deploy.

## Root cause

PR #141 bumped `slf4j-log4j12` from `1.7.36` → `2.0.17` (Dependabot logging-group bump). The bumped slf4j-log4j12 2.0.17 transitively requires slf4j-api 2.0.17, but Apache Flink core's transitive graph still pulls slf4j-api 1.7.36. The maven-enforcer-plugin `dependencyConvergence` rule then fails the build at `statefun-smoke-e2e-common`:

```
[ERROR] Dependency convergence error for org.slf4j:slf4j-api:jar:1.7.36
```

This breaks:
- Post-merge CI on `release` (commit 817c95a6 = FAILURE)
- Snapshot deploy workflow (run 25420722237 = FAILURE)

## Why it slipped through

The original PR #141 CI ran on its own branch BEFORE the merge. The cancel-in-progress concurrency policy then cancelled re-runs on `release` post-merge as later admin-bypassed merges came in rapidly. The final commit's CI ran but had already been admin-merged. We trusted the bypass too aggressively.

## Why not fix forward

The slf4j 2.x migration is deliberately deferred per the project's [discoverability backlog](https://github.com/kzmlabs/flink-statefun/issues/149) — it requires proper transitive resolution across Flink + Kinesis + Kafka, not just a property bump. Reverting is correct here; the migration belongs in its own dedicated PR with proper convergence work.

## After this merges

Snapshot deploy will work: re-trigger by re-pushing `snapshot-3.4.0-KZM-3.3` tag.

## Test plan

- [ ] CI green on this PR (`mvn clean install` succeeds)
- [ ] Snapshot deploy succeeds after retag