### PR TITLE
ci(snapshot): publish snapshots to GitHub Packages instead of Sonatype

### DIFF
--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -3,15 +3,16 @@ name: Deploy Snapshot
 on:
   push:
     tags:
-      - 'snapshot-*'  # e.g., snapshot-2024-02-01, snapshot-1
+      - 'snapshot-*'  # e.g., snapshot-3.4.0-KZM-3.3, snapshot-2026-05-06
 
 permissions:
   contents: read
+  packages: write   # required to publish to GitHub Packages Maven registry
 
 jobs:
   snapshot:
     runs-on: ubuntu-latest
-    name: Deploy Snapshot to OSSRH
+    name: Deploy Snapshot to GitHub Packages
     timeout-minutes: 60
 
     steps:
@@ -24,22 +25,21 @@ jobs:
           java-version: '21'
           distribution: 'temurin'
           cache: 'maven'
-          # server-id matches the pom's <distributionManagement><snapshotRepository><id>
-          # which is "central" (Sonatype migrated from OSSRH to central.sonatype.com).
-          # Mismatch causes 401 Unauthorized on deploy.
-          server-id: central
-          server-username: CENTRAL_USERNAME
-          server-password: CENTRAL_PASSWORD
+          # server-id matches the pom's <distributionManagement><snapshotRepository><id>.
+          # GitHub Packages auth uses the workflow's built-in GITHUB_TOKEN — no external
+          # secrets needed.
+          server-id: github
+          server-username: GITHUB_ACTOR
+          server-password: GITHUB_TOKEN
 
       - name: Build
         run: mvn clean install -DskipTests -B
 
       - name: Deploy Snapshot
-        # Exclude same modules as release.yml (assembly + e2e + coverage aggregators)
-        # to keep snapshot artifacts publishable to Maven Central.
+        # Exclude assembly + E2E + coverage-aggregator modules (same -pl as release.yml).
         run: |
           mvn deploy -DskipTests -B \
             -pl '!:statefun-flink-runner,!:statefun-docker,!:statefun-e2e-tests,!:statefun-e2e-tests-common,!:statefun-smoke-e2e-common,!:statefun-smoke-e2e-driver,!:statefun-smoke-e2e-embedded,!:statefun-smoke-e2e-multilang-base,!:statefun-smoke-e2e-multilang-harness,!:statefun-smoke-e2e-java,!:statefun-smoke-e2e-golang,!:statefun-smoke-e2e-js,!:statefun-e2e-k8s-native,!:statefun-coverage-report,!:statefun-e2e-coverage-report'
         env:
-          CENTRAL_USERNAME: ${{ secrets.OSSRH_USERNAME }}
-          CENTRAL_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
+          GITHUB_ACTOR: ${{ github.actor }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/docs/snapshots.md
+++ b/docs/snapshots.md
@@ -1,0 +1,77 @@
+# Using snapshot builds
+
+Stable releases ship to **Maven Central** (`central.sonatype.com`). Development snapshots between releases ship to **GitHub Packages** under the `kzmlabs/flink-statefun` repository.
+
+## Why two channels
+
+| Channel | Used for | Why |
+|---|---|---|
+| Maven Central | Stable releases (`v*` tags) | Industry-standard public discovery, no consumer auth required |
+| GitHub Packages | Snapshots (`snapshot-*` tags) | Zero per-namespace permission gates, uses the kzmlabs org's existing GitHub auth |
+
+Sonatype Central Portal blocks snapshot publishing to `io.github.kzmlabs.flinkstatefun` with HTTP 403 absent a namespace-level toggle that isn't currently exposed in the UI. Routing snapshots to GitHub Packages is the friction-free alternative — release credibility (Maven Central) is reserved for stable artifacts where it matters most.
+
+## Consumer setup
+
+Snapshots are not normally needed unless you're testing in-progress changes. For stable production use, just consume the latest Maven Central version and skip the rest of this page.
+
+### 1. Add the GitHub Packages repository to your `pom.xml`
+
+```xml
+<repositories>
+    <repository>
+        <id>kzmlabs-snapshots</id>
+        <url>https://maven.pkg.github.com/kzmlabs/flink-statefun</url>
+        <snapshots>
+            <enabled>true</enabled>
+        </snapshots>
+        <releases>
+            <enabled>false</enabled>
+        </releases>
+    </repository>
+</repositories>
+```
+
+### 2. Authenticate to GitHub Packages
+
+GitHub Packages requires authentication even for public repositories. Generate a Personal Access Token at https://github.com/settings/tokens (classic) with the `read:packages` scope only — no other permissions needed for read-only consumption.
+
+Add to your `~/.m2/settings.xml`:
+
+```xml
+<settings>
+    <servers>
+        <server>
+            <id>kzmlabs-snapshots</id>
+            <username>YOUR_GITHUB_USERNAME</username>
+            <password>YOUR_GITHUB_PAT</password>
+        </server>
+    </servers>
+</settings>
+```
+
+The `<id>` in `settings.xml` must match the `<id>` of the `<repository>` block in your `pom.xml`.
+
+### 3. Add the snapshot dependency
+
+```xml
+<dependency>
+    <groupId>io.github.kzmlabs.flinkstatefun</groupId>
+    <artifactId>statefun-sdk-java</artifactId>
+    <version>3.4.0-KZM-3.3-SNAPSHOT</version>
+</dependency>
+```
+
+Replace the version with whichever in-progress snapshot you want. Browse available versions: https://github.com/orgs/kzmlabs/packages?repo_name=flink-statefun
+
+## Maintainer flow — publishing a new snapshot
+
+1. Bump the `<revision>` in root `pom.xml` to a `-SNAPSHOT` version (e.g. `3.4.0-KZM-3.4-SNAPSHOT`)
+2. Merge that bump to `release` branch
+3. Tag and push:
+   ```bash
+   git tag snapshot-3.4.0-KZM-3.4 -m "Snapshot 3.4.0-KZM-3.4"
+   git push origin snapshot-3.4.0-KZM-3.4
+   ```
+4. The `Deploy Snapshot` workflow runs (~5-7 min) and publishes to GitHub Packages
+5. Verify upload at https://github.com/orgs/kzmlabs/packages?repo_name=flink-statefun

--- a/pom.xml
+++ b/pom.xml
@@ -60,10 +60,15 @@
     </ciManagement>
 
     <distributionManagement>
+        <!-- Snapshots → GitHub Packages: zero per-namespace permission gates, uses the kzmlabs
+             org's existing GitHub auth (workflow GITHUB_TOKEN). Sonatype Central Portal blocks
+             snapshot publishing to io.github.kzmlabs.flinkstatefun with HTTP 403 absent a
+             namespace-level toggle that isn't currently exposed in the UI. -->
         <snapshotRepository>
-            <id>central</id>
-            <url>https://central.sonatype.com/repository/maven-snapshots/</url>
+            <id>github</id>
+            <url>https://maven.pkg.github.com/kzmlabs/flink-statefun</url>
         </snapshotRepository>
+        <!-- Stable releases continue to ship to Maven Central via Sonatype Central Portal. -->
         <repository>
             <id>central</id>
             <url>https://central.sonatype.com/</url>


### PR DESCRIPTION
## Why

Sonatype Central Portal blocks snapshot publishing to namespace `io.github.kzmlabs.flinkstatefun` with HTTP 403 absent a per-namespace toggle that isn't currently exposed in the Central Portal UI. `release.yml` flow to Maven Central proper continues to work for stable releases — only snapshot publishing is gated.

Route snapshots to GitHub Packages instead:
- Zero external service config; uses kzmlabs org's existing GitHub auth
- No new secrets required beyond the workflow `GITHUB_TOKEN`
- Same publishing semantics consumers expect

## Changes

| File | Change |
|---|---|
| `pom.xml` | `<distributionManagement><snapshotRepository>` → `https://maven.pkg.github.com/kzmlabs/flink-statefun` (id `github`). Stable repository unchanged. |
| `.github/workflows/snapshot.yml` | `server-id: github`, auth via `GITHUB_ACTOR` + `GITHUB_TOKEN`, declares `packages: write`. No longer reads `OSSRH_USERNAME`/`OSSRH_PASSWORD`. |
| `docs/snapshots.md` (new) | Explains two-channel model + consumer setup (repository + GitHub PAT auth + dependency declaration). |

## Verification after merge

1. Re-tag snapshot:
   ```bash
   git tag -d snapshot-3.4.0-KZM-3.3
   git push origin :refs/tags/snapshot-3.4.0-KZM-3.3
   git tag snapshot-3.4.0-KZM-3.3 -m "Snapshot via GitHub Packages"
   git push origin snapshot-3.4.0-KZM-3.3
   ```
2. Watch deploy: https://github.com/kzmlabs/flink-statefun/actions/workflows/snapshot.yml
3. Verify artifact: https://github.com/orgs/kzmlabs/packages?repo_name=flink-statefun

## Test plan

- [ ] CI green on this PR
- [ ] After merge + re-tag, Deploy Snapshot workflow succeeds
- [ ] At least `statefun-sdk-java:3.4.0-KZM-3.3-SNAPSHOT` appears under kzmlabs org packages
- [ ] Maven Central release flow (release.yml) unaffected