### PR TITLE
docs: mark non-Java SDKs as frozen / under-development / not released

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -79,7 +79,9 @@
         <module>statefun-sdk-embedded</module>
         <module>statefun-sdk-protos</module>
         <module>statefun-sdk-java</module>
-        <!-- Non-Java SDKs removed from reactor (empty pass-through modules) -->
+        <!-- Non-Java SDKs (statefun-sdk-{python,go,js}) are frozen — inherited from upstream
+             Apache Stateful Functions, not actively maintained on Flink 2.x. Each has a status
+             banner in its README. Re-introduction policy: see issue #160. -->
         <!-- Directories kept for reference: statefun-sdk-python, statefun-sdk-go, statefun-sdk-js -->
         <module>statefun-kafka-io</module>
         <module>statefun-kinesis-io</module>

--- a/statefun-sdk-go/README.md
+++ b/statefun-sdk-go/README.md
@@ -1,0 +1,24 @@
+> ## 🚧 Under development — not released
+>
+> This SDK is **inherited as-is from [Apache Stateful Functions](https://github.com/apache/flink-statefun)** and is **not actively maintained on the Flink 2.x runtime in this fork**.
+>
+> - **Not in the Maven reactor** — `mvn -B verify` does not build this module.
+> - **Not in CI** — no automated build, test, or version bump runs against this code.
+> - **Not released** — no Go module publication from this fork; not part of any release tag.
+> - **May be revived** if a consumer drives the modernization (toolchain, deps, protocol, CI). See [issue #160](https://github.com/kzmlabs/flink-statefun/issues/160) for the re-introduction policy.
+>
+> **For non-Java users today**: integrate via the [request/reply HTTP protocol](https://nightlies.apache.org/flink/flink-statefun-docs-release-3.4/docs/sdk/external/) directly. The wire format is language-agnostic; an official SDK is convenience, not a hard requirement.
+
+---
+
+# StateFun Go SDK
+
+Go SDK for [Apache Stateful Functions](https://github.com/apache/flink-statefun), inherited from upstream and currently kept frozen in this fork. See the status banner above.
+
+The source is preserved in-tree as a starting point for any future contributor who wants to take ownership of reviving the module — including modernization to current StateFun protocol revisions, current Go toolchain, dependency hygiene, and CI integration. Until then, treat this directory as **archival reference**, not as production code.
+
+## Why we keep it
+
+Deleting unmaintained code makes a "Java-only fork" statement that is stronger than what we actually mean. The fork's runtime is language-agnostic at the wire level — `request/reply` over HTTP+protobuf — and any language can call it. The only thing missing is an officially-maintained convenience wrapper. Keeping the upstream code in-tree (as a frozen reference) leaves the door open without making promises we can't keep on Flink 2.x compatibility today.
+
+See [issue #160](https://github.com/kzmlabs/flink-statefun/issues/160) for the policy on re-introducing this as a first-class module.

--- a/statefun-sdk-js/README.md
+++ b/statefun-sdk-js/README.md
@@ -1,3 +1,16 @@
+> ## 🚧 Under development — not released
+>
+> This SDK is **inherited as-is from [Apache Stateful Functions](https://github.com/apache/flink-statefun)** and is **not actively maintained on the Flink 2.x runtime in this fork**.
+>
+> - **Not in the Maven reactor** — `mvn -B verify` does not build this module.
+> - **Not in CI** — no automated build, test, lint, or version bump runs against this code.
+> - **Not released** — no npm publication from this fork; not part of any release tag.
+> - **May be revived** if a consumer drives the modernization (toolchain, deps, protocol, CI). See [issue #160](https://github.com/kzmlabs/flink-statefun/issues/160) for the re-introduction policy.
+>
+> **For non-Java users today**: integrate via the [request/reply HTTP protocol](https://nightlies.apache.org/flink/flink-statefun-docs-release-3.4/docs/sdk/external/) directly. The wire format is language-agnostic; an official SDK is convenience, not a hard requirement.
+
+---
+
 # Apache Flink Stateful Functions
 
 Stateful Functions is an API that simplifies the building of **distributed stateful applications** with a **runtime built for serverless architectures**.

--- a/statefun-sdk-python/README.md
+++ b/statefun-sdk-python/README.md
@@ -1,3 +1,16 @@
+> ## 🚧 Under development — not released
+>
+> This SDK is **inherited as-is from [Apache Stateful Functions](https://github.com/apache/flink-statefun)** and is **not actively maintained on the Flink 2.x runtime in this fork**.
+>
+> - **Not in the Maven reactor** — `mvn -B verify` does not build this module.
+> - **Not in CI** — no automated build, test, or version bump runs against this code.
+> - **Not released** — no PyPI publication from this fork; not part of any release tag.
+> - **May be revived** if a consumer drives the modernization (toolchain, deps, protocol, CI). See [issue #160](https://github.com/kzmlabs/flink-statefun/issues/160) for the re-introduction policy.
+>
+> **For non-Java users today**: integrate via the [request/reply HTTP protocol](https://nightlies.apache.org/flink/flink-statefun-docs-release-3.4/docs/sdk/external/) directly. The wire format is language-agnostic; an official SDK is convenience, not a hard requirement.
+
+---
+
 # Apache Flink Stateful Functions
 
 Stateful Functions is an API that simplifies the building of **distributed stateful applications** with a **runtime built for serverless architectures**.


### PR DESCRIPTION
Implements issue #160 with a softer approach: keep source in-tree as archival reference but make maintenance status unambiguous via prominent README banners. Banner says: not in reactor, not in CI, not released, may be revived per #160 policy, use HTTP request/reply protocol for non-Java users today.