### PR TITLE
test(io): cover Routable[Kinesis|Kafka]IngressDeserializer routing

### DIFF
--- a/statefun-flink/statefun-flink-io-bundle/src/test/java/org/apache/flink/statefun/flink/io/kafka/binders/ingress/v1/RoutableKafkaIngressDeserializerTest.java
+++ b/statefun-flink/statefun-flink-io-bundle/src/test/java/org/apache/flink/statefun/flink/io/kafka/binders/ingress/v1/RoutableKafkaIngressDeserializerTest.java
@@ -13,6 +13,8 @@ import org.apache.flink.statefun.flink.io.generated.AutoRoutable;
 import org.apache.flink.statefun.flink.io.generated.RoutingConfig;
 import org.apache.flink.statefun.flink.io.generated.TargetFunctionType;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -27,25 +29,26 @@ class RoutableKafkaIngressDeserializerTest {
   private static final String ORDERS_VALUE_TYPE = "com.googleapis/com.mycomp.foo.OrderMessage";
   private static final TargetFunctionType ORDERS_TARGET =
       TargetFunctionType.newBuilder().setNamespace("com.mycomp.foo").setType("orders-fn").build();
+  private static final RoutingConfig ORDERS_ROUTING =
+      RoutingConfig.newBuilder()
+          .setTypeUrl(ORDERS_VALUE_TYPE)
+          .addTargetFunctionTypes(ORDERS_TARGET)
+          .build();
 
+  private RoutableKafkaIngressDeserializer deserializer;
+
+  @BeforeEach
+  void setUp() {
+    deserializer =
+        new RoutableKafkaIngressDeserializer(routingMap(ORDERS_TOPIC, ORDERS_ROUTING));
+  }
+
+  @DisplayName("routes records on a configured topic to the configured value type and targets")
   @Test
   void deserialize_withConfiguredTopic_routesToTargets() {
-    final RoutingConfig ordersRouting =
-        RoutingConfig.newBuilder()
-            .setTypeUrl(ORDERS_VALUE_TYPE)
-            .addTargetFunctionTypes(ORDERS_TARGET)
-            .build();
-
-    final Map<String, RoutingConfig> routings = new HashMap<>();
-    routings.put(ORDERS_TOPIC, ordersRouting);
-
-    final RoutableKafkaIngressDeserializer deserializer =
-        new RoutableKafkaIngressDeserializer(routings);
-
     final byte[] payload = "order-payload".getBytes(StandardCharsets.UTF_8);
     final byte[] key = "pk-7".getBytes(StandardCharsets.UTF_8);
-    final ConsumerRecord<byte[], byte[]> record =
-        new ConsumerRecord<>(ORDERS_TOPIC, 0, 0L, key, payload);
+    final ConsumerRecord<byte[], byte[]> record = consumerRecord(ORDERS_TOPIC, key, payload);
 
     final Message result = deserializer.deserialize(record);
 
@@ -57,25 +60,12 @@ class RoutableKafkaIngressDeserializerTest {
     assertThat(routable.getConfig().getTargetFunctionTypesList()).containsExactly(ORDERS_TARGET);
   }
 
+  @DisplayName("throws routing-miss error when topic is not in the routing map")
   @Test
   void deserialize_withUnknownTopic_throwsRoutingMissError() {
-    final RoutingConfig ordersRouting =
-        RoutingConfig.newBuilder()
-            .setTypeUrl(ORDERS_VALUE_TYPE)
-            .addTargetFunctionTypes(ORDERS_TARGET)
-            .build();
-
-    final Map<String, RoutingConfig> routings = new HashMap<>();
-    routings.put(ORDERS_TOPIC, ordersRouting);
-
-    final RoutableKafkaIngressDeserializer deserializer =
-        new RoutableKafkaIngressDeserializer(routings);
-
     final ConsumerRecord<byte[], byte[]> record =
-        new ConsumerRecord<>(
+        consumerRecord(
             "unknown-topic",
-            0,
-            0L,
             "pk".getBytes(StandardCharsets.UTF_8),
             "x".getBytes(StandardCharsets.UTF_8));
 
@@ -83,5 +73,18 @@ class RoutableKafkaIngressDeserializerTest {
         .isInstanceOf(IllegalStateException.class)
         .hasMessageContaining("unknown-topic")
         .hasMessageContaining("no routing config");
+  }
+
+  // --- helpers ---------------------------------------------------------------------------------
+
+  private static Map<String, RoutingConfig> routingMap(String key, RoutingConfig value) {
+    final Map<String, RoutingConfig> map = new HashMap<>(1);
+    map.put(key, value);
+    return map;
+  }
+
+  private static ConsumerRecord<byte[], byte[]> consumerRecord(
+      String topic, byte[] partitionKey, byte[] payload) {
+    return new ConsumerRecord<>(topic, 0, 0L, partitionKey, payload);
   }
 }

--- a/statefun-flink/statefun-flink-io-bundle/src/test/java/org/apache/flink/statefun/flink/io/kafka/binders/ingress/v1/RoutableKafkaIngressDeserializerTest.java
+++ b/statefun-flink/statefun-flink-io-bundle/src/test/java/org/apache/flink/statefun/flink/io/kafka/binders/ingress/v1/RoutableKafkaIngressDeserializerTest.java
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2014 The Apache Software Foundation
+package org.apache.flink.statefun.flink.io.kafka.binders.ingress.v1;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.google.protobuf.Message;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.flink.statefun.flink.io.generated.AutoRoutable;
+import org.apache.flink.statefun.flink.io.generated.RoutingConfig;
+import org.apache.flink.statefun.flink.io.generated.TargetFunctionType;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Lifts {@link RoutableKafkaIngressDeserializer} off zero unit-test coverage with a happy-path
+ * routing test plus a missing-topic regression guard. The Kafka path is keyed by topic name (not
+ * ARN), so the failure modes differ from the Kinesis side, but the envelope-building contract is
+ * the same.
+ */
+class RoutableKafkaIngressDeserializerTest {
+
+  private static final String ORDERS_TOPIC = "orders";
+  private static final String ORDERS_VALUE_TYPE = "com.googleapis/com.mycomp.foo.OrderMessage";
+  private static final TargetFunctionType ORDERS_TARGET =
+      TargetFunctionType.newBuilder().setNamespace("com.mycomp.foo").setType("orders-fn").build();
+
+  @Test
+  void deserialize_withConfiguredTopic_routesToTargets() {
+    final RoutingConfig ordersRouting =
+        RoutingConfig.newBuilder()
+            .setTypeUrl(ORDERS_VALUE_TYPE)
+            .addTargetFunctionTypes(ORDERS_TARGET)
+            .build();
+
+    final Map<String, RoutingConfig> routings = new HashMap<>();
+    routings.put(ORDERS_TOPIC, ordersRouting);
+
+    final RoutableKafkaIngressDeserializer deserializer =
+        new RoutableKafkaIngressDeserializer(routings);
+
+    final byte[] payload = "order-payload".getBytes(StandardCharsets.UTF_8);
+    final byte[] key = "pk-7".getBytes(StandardCharsets.UTF_8);
+    final ConsumerRecord<byte[], byte[]> record =
+        new ConsumerRecord<>(ORDERS_TOPIC, 0, 0L, key, payload);
+
+    final Message result = deserializer.deserialize(record);
+
+    assertThat(result).isInstanceOf(AutoRoutable.class);
+    final AutoRoutable routable = (AutoRoutable) result;
+    assertThat(routable.getId()).isEqualTo("pk-7");
+    assertThat(routable.getPayloadBytes().toByteArray()).isEqualTo(payload);
+    assertThat(routable.getConfig().getTypeUrl()).isEqualTo(ORDERS_VALUE_TYPE);
+    assertThat(routable.getConfig().getTargetFunctionTypesList()).containsExactly(ORDERS_TARGET);
+  }
+
+  @Test
+  void deserialize_withUnknownTopic_throwsRoutingMissError() {
+    final RoutingConfig ordersRouting =
+        RoutingConfig.newBuilder()
+            .setTypeUrl(ORDERS_VALUE_TYPE)
+            .addTargetFunctionTypes(ORDERS_TARGET)
+            .build();
+
+    final Map<String, RoutingConfig> routings = new HashMap<>();
+    routings.put(ORDERS_TOPIC, ordersRouting);
+
+    final RoutableKafkaIngressDeserializer deserializer =
+        new RoutableKafkaIngressDeserializer(routings);
+
+    final ConsumerRecord<byte[], byte[]> record =
+        new ConsumerRecord<>(
+            "unknown-topic",
+            0,
+            0L,
+            "pk".getBytes(StandardCharsets.UTF_8),
+            "x".getBytes(StandardCharsets.UTF_8));
+
+    assertThatThrownBy(() -> deserializer.deserialize(record))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("unknown-topic")
+        .hasMessageContaining("no routing config");
+  }
+}

--- a/statefun-flink/statefun-flink-io-bundle/src/test/java/org/apache/flink/statefun/flink/io/kinesis/binders/ingress/v1/RoutableKinesisIngressDeserializerTest.java
+++ b/statefun-flink/statefun-flink-io-bundle/src/test/java/org/apache/flink/statefun/flink/io/kinesis/binders/ingress/v1/RoutableKinesisIngressDeserializerTest.java
@@ -1,0 +1,232 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2014 The Apache Software Foundation
+
+package org.apache.flink.statefun.flink.io.kinesis.binders.ingress.v1;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.google.protobuf.Message;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.flink.statefun.flink.io.generated.AutoRoutable;
+import org.apache.flink.statefun.flink.io.generated.RoutingConfig;
+import org.apache.flink.statefun.flink.io.generated.TargetFunctionType;
+import org.apache.flink.statefun.sdk.kinesis.ingress.IngressRecord;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for {@link RoutableKinesisIngressDeserializer}.
+ *
+ * <p>Covers the ARN-keyed routing path that {@link RoutableKinesisIngressSpec} configures for the
+ * Flink 2.x {@code KinesisStreamsSource}: that source passes the stream <em>ARN</em> as the {@code
+ * stream} argument of {@code KinesisDeserializationSchema.deserialize(...)}, which is then
+ * surfaced as {@link IngressRecord#getStream()}. The deserializer must look up the routing config
+ * by that exact value. A silent regression in Flink upstream (or in our wrapper) that flipped the
+ * argument back to the short stream name would otherwise drop messages with no test failure.
+ */
+class RoutableKinesisIngressDeserializerTest {
+
+  private static final String ORDERS_ARN =
+      "arn:aws:kinesis:us-east-1:123456789012:stream/orders";
+  private static final String EVENTS_ARN =
+      "arn:aws:kinesis:us-east-1:123456789012:stream/events";
+
+  private static final String ORDERS_VALUE_TYPE = "com.googleapis/com.mycomp.foo.OrderMessage";
+  private static final String EVENTS_VALUE_TYPE = "com.googleapis/com.mycomp.foo.EventMessage";
+
+  private static final TargetFunctionType ORDERS_TARGET =
+      TargetFunctionType.newBuilder().setNamespace("com.mycomp.foo").setType("orders-fn").build();
+  private static final TargetFunctionType EVENTS_TARGET_A =
+      TargetFunctionType.newBuilder().setNamespace("com.mycomp.foo").setType("events-fn-a").build();
+  private static final TargetFunctionType EVENTS_TARGET_B =
+      TargetFunctionType.newBuilder().setNamespace("com.mycomp.foo").setType("events-fn-b").build();
+
+  @Test
+  void deserialize_withArnAsStream_routesToConfiguredTargets() {
+    final RoutingConfig ordersRouting = routingConfig(ORDERS_VALUE_TYPE, ORDERS_TARGET);
+    final RoutableKinesisIngressDeserializer deserializer =
+        new RoutableKinesisIngressDeserializer(singleton(ORDERS_ARN, ordersRouting));
+
+    final byte[] payload = "order-123".getBytes(StandardCharsets.UTF_8);
+    final IngressRecord record = ingressRecord(ORDERS_ARN, "pk-42", payload);
+
+    final Message result = deserializer.deserialize(record);
+
+    assertThat(result).isInstanceOf(AutoRoutable.class);
+    final AutoRoutable routable = (AutoRoutable) result;
+    assertThat(routable.getId()).isEqualTo("pk-42");
+    assertThat(routable.getPayloadBytes().toByteArray()).isEqualTo(payload);
+    assertThat(routable.getConfig().getTypeUrl()).isEqualTo(ORDERS_VALUE_TYPE);
+    assertThat(routable.getConfig().getTargetFunctionTypesList()).containsExactly(ORDERS_TARGET);
+  }
+
+  /**
+   * Regression guard: routing map is keyed by ARN (Flink 2.x contract). If the connector ever
+   * passed the short stream name instead, the lookup must fail loudly so the regression is
+   * detected, rather than silently dropping records.
+   */
+  @Test
+  void deserialize_withShortNameAsStream_throwsRoutingMissError() {
+    final RoutingConfig ordersRouting = routingConfig(ORDERS_VALUE_TYPE, ORDERS_TARGET);
+    final RoutableKinesisIngressDeserializer deserializer =
+        new RoutableKinesisIngressDeserializer(singleton(ORDERS_ARN, ordersRouting));
+
+    final IngressRecord record =
+        ingressRecord("orders", "pk-1", "x".getBytes(StandardCharsets.UTF_8));
+
+    assertThatThrownBy(() -> deserializer.deserialize(record))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("orders")
+        .hasMessageContaining("no routing config");
+  }
+
+  @Test
+  void deserialize_withUnknownArn_throwsRoutingMissError() {
+    final RoutingConfig ordersRouting = routingConfig(ORDERS_VALUE_TYPE, ORDERS_TARGET);
+    final RoutableKinesisIngressDeserializer deserializer =
+        new RoutableKinesisIngressDeserializer(singleton(ORDERS_ARN, ordersRouting));
+
+    final IngressRecord record =
+        ingressRecord(EVENTS_ARN, "pk-1", "x".getBytes(StandardCharsets.UTF_8));
+
+    assertThatThrownBy(() -> deserializer.deserialize(record))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining(EVENTS_ARN)
+        .hasMessageContaining("no routing config");
+  }
+
+  /**
+   * Empty Kinesis payloads are legal at the protocol level. The deserializer wraps the bytes in an
+   * {@link AutoRoutable} envelope without parsing the payload itself (parsing is downstream), so
+   * an empty payload should round-trip cleanly: success with zero-byte payload.
+   */
+  @Test
+  void deserialize_withEmptyPayload_handlesGracefully() {
+    final RoutingConfig ordersRouting = routingConfig(ORDERS_VALUE_TYPE, ORDERS_TARGET);
+    final RoutableKinesisIngressDeserializer deserializer =
+        new RoutableKinesisIngressDeserializer(singleton(ORDERS_ARN, ordersRouting));
+
+    final IngressRecord record = ingressRecord(ORDERS_ARN, "pk-empty", new byte[0]);
+
+    final Message result = deserializer.deserialize(record);
+
+    assertThat(result).isInstanceOf(AutoRoutable.class);
+    final AutoRoutable routable = (AutoRoutable) result;
+    assertThat(routable.getId()).isEqualTo("pk-empty");
+    assertThat(routable.getPayloadBytes().size()).isZero();
+    assertThat(routable.getConfig().getTypeUrl()).isEqualTo(ORDERS_VALUE_TYPE);
+  }
+
+  /**
+   * Kinesis records cap at 1 MiB. The deserializer must not truncate. Uses a deterministic byte
+   * pattern so we can verify exact bytes (including the boundary bytes) made it through.
+   */
+  @Test
+  void deserialize_withMaxSizePayload_succeeds() {
+    final RoutingConfig ordersRouting = routingConfig(ORDERS_VALUE_TYPE, ORDERS_TARGET);
+    final RoutableKinesisIngressDeserializer deserializer =
+        new RoutableKinesisIngressDeserializer(singleton(ORDERS_ARN, ordersRouting));
+
+    final int oneMiB = 1024 * 1024;
+    final byte[] payload = new byte[oneMiB];
+    for (int i = 0; i < oneMiB; i++) {
+      payload[i] = (byte) (i & 0xFF);
+    }
+
+    final IngressRecord record = ingressRecord(ORDERS_ARN, "pk-big", payload);
+
+    final Message result = deserializer.deserialize(record);
+
+    assertThat(result).isInstanceOf(AutoRoutable.class);
+    final AutoRoutable routable = (AutoRoutable) result;
+    assertThat(routable.getPayloadBytes().size()).isEqualTo(oneMiB);
+    assertThat(routable.getPayloadBytes().toByteArray()).isEqualTo(payload);
+  }
+
+  /**
+   * Catches accidental cross-stream state pollution: each ARN entry must dispatch independently to
+   * its own configured value type / targets, even when the same deserializer instance handles
+   * interleaved records from both streams.
+   */
+  @Test
+  void deserialize_multipleArnRoutingEntries_dispatchesIndependently() {
+    final RoutingConfig ordersRouting = routingConfig(ORDERS_VALUE_TYPE, ORDERS_TARGET);
+    final RoutingConfig eventsRouting =
+        routingConfig(EVENTS_VALUE_TYPE, EVENTS_TARGET_A, EVENTS_TARGET_B);
+
+    final Map<String, RoutingConfig> routings = new HashMap<>();
+    routings.put(ORDERS_ARN, ordersRouting);
+    routings.put(EVENTS_ARN, eventsRouting);
+
+    final RoutableKinesisIngressDeserializer deserializer =
+        new RoutableKinesisIngressDeserializer(routings);
+
+    final byte[] orderPayload = "order".getBytes(StandardCharsets.UTF_8);
+    final byte[] eventPayloadFirst = "event-1".getBytes(StandardCharsets.UTF_8);
+    final byte[] eventPayloadSecond = "event-2".getBytes(StandardCharsets.UTF_8);
+
+    // Interleave the records to exercise both lookups within the same instance.
+    final AutoRoutable orderResult =
+        (AutoRoutable) deserializer.deserialize(ingressRecord(ORDERS_ARN, "o-1", orderPayload));
+    final AutoRoutable eventResult1 =
+        (AutoRoutable)
+            deserializer.deserialize(ingressRecord(EVENTS_ARN, "e-1", eventPayloadFirst));
+    final AutoRoutable orderResult2 =
+        (AutoRoutable) deserializer.deserialize(ingressRecord(ORDERS_ARN, "o-2", orderPayload));
+    final AutoRoutable eventResult2 =
+        (AutoRoutable)
+            deserializer.deserialize(ingressRecord(EVENTS_ARN, "e-2", eventPayloadSecond));
+
+    // Orders side: orders value type and a single target.
+    assertThat(orderResult.getId()).isEqualTo("o-1");
+    assertThat(orderResult.getConfig().getTypeUrl()).isEqualTo(ORDERS_VALUE_TYPE);
+    assertThat(orderResult.getConfig().getTargetFunctionTypesList()).containsExactly(ORDERS_TARGET);
+
+    assertThat(orderResult2.getId()).isEqualTo("o-2");
+    assertThat(orderResult2.getConfig().getTypeUrl()).isEqualTo(ORDERS_VALUE_TYPE);
+    assertThat(orderResult2.getConfig().getTargetFunctionTypesList())
+        .containsExactly(ORDERS_TARGET);
+
+    // Events side: events value type and two distinct targets.
+    assertThat(eventResult1.getId()).isEqualTo("e-1");
+    assertThat(eventResult1.getConfig().getTypeUrl()).isEqualTo(EVENTS_VALUE_TYPE);
+    assertThat(eventResult1.getConfig().getTargetFunctionTypesList())
+        .containsExactly(EVENTS_TARGET_A, EVENTS_TARGET_B);
+    assertThat(eventResult1.getPayloadBytes().toByteArray()).isEqualTo(eventPayloadFirst);
+
+    assertThat(eventResult2.getId()).isEqualTo("e-2");
+    assertThat(eventResult2.getConfig().getTypeUrl()).isEqualTo(EVENTS_VALUE_TYPE);
+    assertThat(eventResult2.getConfig().getTargetFunctionTypesList())
+        .containsExactly(EVENTS_TARGET_A, EVENTS_TARGET_B);
+    assertThat(eventResult2.getPayloadBytes().toByteArray()).isEqualTo(eventPayloadSecond);
+  }
+
+  // --- helpers ---------------------------------------------------------------------------------
+
+  private static RoutingConfig routingConfig(String valueType, TargetFunctionType... targets) {
+    final RoutingConfig.Builder builder = RoutingConfig.newBuilder().setTypeUrl(valueType);
+    for (TargetFunctionType target : targets) {
+      builder.addTargetFunctionTypes(target);
+    }
+    return builder.build();
+  }
+
+  private static Map<String, RoutingConfig> singleton(String key, RoutingConfig value) {
+    final Map<String, RoutingConfig> map = new HashMap<>(1);
+    map.put(key, value);
+    return map;
+  }
+
+  private static IngressRecord ingressRecord(String stream, String partitionKey, byte[] data) {
+    return IngressRecord.newBuilder()
+        .withStream(stream)
+        .withShardId("shardId-000000000000")
+        .withPartitionKey(partitionKey)
+        .withSequenceNumber("seq-1")
+        .withData(data)
+        .withApproximateArrivalTimestamp(0L)
+        .build();
+  }
+}

--- a/statefun-flink/statefun-flink-io-bundle/src/test/java/org/apache/flink/statefun/flink/io/kinesis/binders/ingress/v1/RoutableKinesisIngressDeserializerTest.java
+++ b/statefun-flink/statefun-flink-io-bundle/src/test/java/org/apache/flink/statefun/flink/io/kinesis/binders/ingress/v1/RoutableKinesisIngressDeserializerTest.java
@@ -10,11 +10,17 @@ import com.google.protobuf.Message;
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.stream.Stream;
 import org.apache.flink.statefun.flink.io.generated.AutoRoutable;
 import org.apache.flink.statefun.flink.io.generated.RoutingConfig;
 import org.apache.flink.statefun.flink.io.generated.TargetFunctionType;
 import org.apache.flink.statefun.sdk.kinesis.ingress.IngressRecord;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 /**
  * Unit tests for {@link RoutableKinesisIngressDeserializer}.
@@ -43,12 +49,19 @@ class RoutableKinesisIngressDeserializerTest {
   private static final TargetFunctionType EVENTS_TARGET_B =
       TargetFunctionType.newBuilder().setNamespace("com.mycomp.foo").setType("events-fn-b").build();
 
+  private static final RoutingConfig ORDERS_ROUTING =
+      routingConfig(ORDERS_VALUE_TYPE, ORDERS_TARGET);
+
+  private RoutableKinesisIngressDeserializer deserializer;
+
+  @BeforeEach
+  void setUp() {
+    deserializer = new RoutableKinesisIngressDeserializer(routingMap(ORDERS_ARN, ORDERS_ROUTING));
+  }
+
+  @DisplayName("routes ARN-keyed records to configured value type and targets")
   @Test
   void deserialize_withArnAsStream_routesToConfiguredTargets() {
-    final RoutingConfig ordersRouting = routingConfig(ORDERS_VALUE_TYPE, ORDERS_TARGET);
-    final RoutableKinesisIngressDeserializer deserializer =
-        new RoutableKinesisIngressDeserializer(singleton(ORDERS_ARN, ordersRouting));
-
     final byte[] payload = "order-123".getBytes(StandardCharsets.UTF_8);
     final IngressRecord record = ingressRecord(ORDERS_ARN, "pk-42", payload);
 
@@ -63,38 +76,28 @@ class RoutableKinesisIngressDeserializerTest {
   }
 
   /**
-   * Regression guard: routing map is keyed by ARN (Flink 2.x contract). If the connector ever
-   * passed the short stream name instead, the lookup must fail loudly so the regression is
-   * detected, rather than silently dropping records.
+   * Regression guard: routing map is keyed by ARN (Flink 2.x contract). A short stream name or an
+   * unconfigured ARN must both fail loudly so the regression is detected, rather than silently
+   * dropping records.
    */
-  @Test
-  void deserialize_withShortNameAsStream_throwsRoutingMissError() {
-    final RoutingConfig ordersRouting = routingConfig(ORDERS_VALUE_TYPE, ORDERS_TARGET);
-    final RoutableKinesisIngressDeserializer deserializer =
-        new RoutableKinesisIngressDeserializer(singleton(ORDERS_ARN, ordersRouting));
-
+  @DisplayName("throws routing-miss error when stream key is not in the routing map")
+  @ParameterizedTest(name = "{1}")
+  @MethodSource("nonMatchingStreamKeys")
+  void deserialize_withNonMatchingStreamKey_throwsRoutingMissError(
+      String streamKey, String reason) {
     final IngressRecord record =
-        ingressRecord("orders", "pk-1", "x".getBytes(StandardCharsets.UTF_8));
+        ingressRecord(streamKey, "pk-1", "x".getBytes(StandardCharsets.UTF_8));
 
     assertThatThrownBy(() -> deserializer.deserialize(record))
         .isInstanceOf(IllegalStateException.class)
-        .hasMessageContaining("orders")
+        .hasMessageContaining(streamKey)
         .hasMessageContaining("no routing config");
   }
 
-  @Test
-  void deserialize_withUnknownArn_throwsRoutingMissError() {
-    final RoutingConfig ordersRouting = routingConfig(ORDERS_VALUE_TYPE, ORDERS_TARGET);
-    final RoutableKinesisIngressDeserializer deserializer =
-        new RoutableKinesisIngressDeserializer(singleton(ORDERS_ARN, ordersRouting));
-
-    final IngressRecord record =
-        ingressRecord(EVENTS_ARN, "pk-1", "x".getBytes(StandardCharsets.UTF_8));
-
-    assertThatThrownBy(() -> deserializer.deserialize(record))
-        .isInstanceOf(IllegalStateException.class)
-        .hasMessageContaining(EVENTS_ARN)
-        .hasMessageContaining("no routing config");
+  static Stream<Arguments> nonMatchingStreamKeys() {
+    return Stream.of(
+        Arguments.of("orders", "short name (Flink 2.x regression guard)"),
+        Arguments.of(EVENTS_ARN, "unconfigured ARN"));
   }
 
   /**
@@ -102,12 +105,9 @@ class RoutableKinesisIngressDeserializerTest {
    * {@link AutoRoutable} envelope without parsing the payload itself (parsing is downstream), so
    * an empty payload should round-trip cleanly: success with zero-byte payload.
    */
+  @DisplayName("round-trips empty payload as zero-byte AutoRoutable envelope")
   @Test
   void deserialize_withEmptyPayload_handlesGracefully() {
-    final RoutingConfig ordersRouting = routingConfig(ORDERS_VALUE_TYPE, ORDERS_TARGET);
-    final RoutableKinesisIngressDeserializer deserializer =
-        new RoutableKinesisIngressDeserializer(singleton(ORDERS_ARN, ordersRouting));
-
     final IngressRecord record = ingressRecord(ORDERS_ARN, "pk-empty", new byte[0]);
 
     final Message result = deserializer.deserialize(record);
@@ -123,12 +123,9 @@ class RoutableKinesisIngressDeserializerTest {
    * Kinesis records cap at 1 MiB. The deserializer must not truncate. Uses a deterministic byte
    * pattern so we can verify exact bytes (including the boundary bytes) made it through.
    */
+  @DisplayName("preserves full 1 MiB payload without truncation")
   @Test
   void deserialize_withMaxSizePayload_succeeds() {
-    final RoutingConfig ordersRouting = routingConfig(ORDERS_VALUE_TYPE, ORDERS_TARGET);
-    final RoutableKinesisIngressDeserializer deserializer =
-        new RoutableKinesisIngressDeserializer(singleton(ORDERS_ARN, ordersRouting));
-
     final int oneMiB = 1024 * 1024;
     final byte[] payload = new byte[oneMiB];
     for (int i = 0; i < oneMiB; i++) {
@@ -150,17 +147,17 @@ class RoutableKinesisIngressDeserializerTest {
    * its own configured value type / targets, even when the same deserializer instance handles
    * interleaved records from both streams.
    */
+  @DisplayName("dispatches interleaved records from multiple ARNs independently")
   @Test
   void deserialize_multipleArnRoutingEntries_dispatchesIndependently() {
-    final RoutingConfig ordersRouting = routingConfig(ORDERS_VALUE_TYPE, ORDERS_TARGET);
     final RoutingConfig eventsRouting =
         routingConfig(EVENTS_VALUE_TYPE, EVENTS_TARGET_A, EVENTS_TARGET_B);
 
     final Map<String, RoutingConfig> routings = new HashMap<>();
-    routings.put(ORDERS_ARN, ordersRouting);
+    routings.put(ORDERS_ARN, ORDERS_ROUTING);
     routings.put(EVENTS_ARN, eventsRouting);
 
-    final RoutableKinesisIngressDeserializer deserializer =
+    final RoutableKinesisIngressDeserializer multiDeserializer =
         new RoutableKinesisIngressDeserializer(routings);
 
     final byte[] orderPayload = "order".getBytes(StandardCharsets.UTF_8);
@@ -169,15 +166,17 @@ class RoutableKinesisIngressDeserializerTest {
 
     // Interleave the records to exercise both lookups within the same instance.
     final AutoRoutable orderResult =
-        (AutoRoutable) deserializer.deserialize(ingressRecord(ORDERS_ARN, "o-1", orderPayload));
+        (AutoRoutable)
+            multiDeserializer.deserialize(ingressRecord(ORDERS_ARN, "o-1", orderPayload));
     final AutoRoutable eventResult1 =
         (AutoRoutable)
-            deserializer.deserialize(ingressRecord(EVENTS_ARN, "e-1", eventPayloadFirst));
+            multiDeserializer.deserialize(ingressRecord(EVENTS_ARN, "e-1", eventPayloadFirst));
     final AutoRoutable orderResult2 =
-        (AutoRoutable) deserializer.deserialize(ingressRecord(ORDERS_ARN, "o-2", orderPayload));
+        (AutoRoutable)
+            multiDeserializer.deserialize(ingressRecord(ORDERS_ARN, "o-2", orderPayload));
     final AutoRoutable eventResult2 =
         (AutoRoutable)
-            deserializer.deserialize(ingressRecord(EVENTS_ARN, "e-2", eventPayloadSecond));
+            multiDeserializer.deserialize(ingressRecord(EVENTS_ARN, "e-2", eventPayloadSecond));
 
     // Orders side: orders value type and a single target.
     assertThat(orderResult.getId()).isEqualTo("o-1");
@@ -213,7 +212,7 @@ class RoutableKinesisIngressDeserializerTest {
     return builder.build();
   }
 
-  private static Map<String, RoutingConfig> singleton(String key, RoutingConfig value) {
+  private static Map<String, RoutingConfig> routingMap(String key, RoutingConfig value) {
     final Map<String, RoutingConfig> map = new HashMap<>(1);
     map.put(key, value);
     return map;


### PR DESCRIPTION
## Why

Highest-ROI test investment from the [#149 coverage analysis](https://github.com/kzmlabs/flink-statefun/issues/149) (top of the agent's ranked list).

`RoutableKinesisIngressDeserializer` was rewritten for Flink 2.x and depends on a critical invariant — Flink 2.x's `KinesisStreamsSource` passes the **stream ARN** (not short name) into the deserializer. A regression in Flink upstream OR in our wrapper would silently drop messages with no test failure. This was 0% tested.

## What's added

- `RoutableKinesisIngressDeserializerTest` — 6 test invocations (4 `@Test` + 1 `@ParameterizedTest` × 2 inputs):
  - happy path: ARN-keyed routing dispatches to configured value type + targets
  - **regression guard** (parameterized): non-matching stream key throws `IllegalStateException` with the missing key in the message — covers both 'short name passed instead of ARN' (the Flink 2.x trap) and 'unconfigured ARN'
  - empty-payload round-trip
  - 1 MiB max-size payload deterministic byte-by-byte verification
  - multi-entry routing dispatches independently across interleaved records (no cross-stream pollution)

- `RoutableKafkaIngressDeserializerTest` — bonus: lifts the Kafka deserializer off zero coverage with a happy-path + missing-topic regression guard.

Module `statefun-flink-io-bundle` test count: 30 → 38.

## Best-practice compliance

- AAA structure, single responsibility per test
- Test names follow `methodUnderTest_condition_expectedBehavior`
- AssertJ fluent assertions + JUnit 5 Jupiter
- `@BeforeEach` for shared setup (no per-test duplication)
- `@ParameterizedTest` with `@MethodSource` for the symmetric routing-miss property
- `@DisplayName` annotations on every test for readable CI/IDE output
- Real production types throughout — no over-mocking
- Doc-comments explain *why* each test matters

## What's NOT in this PR

- Zero production code changes (pure-test PR).
- The Flink-level `deserialize(record, stream, shardId, collector)` signature is in `KinesisDeserializationSchemaDelegate` (already covered by an existing test). These tests cover the SDK-level `deserialize(IngressRecord)` that delegate forwards into.
- Other coverage investments from #149 (RequestReplyFunction async-failure, savepoint-bootstrap union, PersistedTable concurrency, Netty timeouts) — separate PRs.

## Test plan

- [x] Tests compile + pass locally (`mvn test -pl :statefun-flink-io-bundle -Dtest=Routable*DeserializerTest` → 8 pass)
- [ ] CI green on this PR (Build & Test, K8s E2E, CodeQL, Scorecard)
- [ ] Codecov reports a small bump in `statefun-flink-io-bundle` line + branch coverage