### PR TITLE
test: align Routable*DeserializerTest with project naming convention

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,6 +41,45 @@ mvn spotless:apply
 
 CI will fail builds that do not conform.
 
+### Testing conventions
+
+The project uses **JUnit 5 Jupiter** with **AssertJ** for fluent assertions. Hamcrest is also available for legacy tests. Match the style of the surrounding tests in the module you are touching.
+
+**Test method naming**
+
+Use plain camelCase, no underscores. Make the name a short statement of the property under test. The class name (`SomethingTest`) already provides the subject; the method name describes the behavior:
+
+```java
+// Good — matches the project's existing 300+ tests
+@Test
+void routesArnKeyedRecordsToConfiguredTargets() { ... }
+
+@Test
+void throwsWhenStreamKeyIsNotInRoutingMap() { ... }
+
+// Avoid — snake_case is inconsistent with the rest of the codebase
+@Test
+void deserialize_withArnAsStream_routesToConfiguredTargets() { ... }
+```
+
+Do not use `@DisplayName`. The test method name is the documentation; relying on annotations splits the description from the code that defines it.
+
+**Test structure**
+
+- Arrange / Act / Assert separation visible in each test.
+- One concept per test (`@ParameterizedTest` for the same property across multiple inputs).
+- Use `@BeforeEach` to set up shared state; tests that need a different setup shadow with a local variable instead of mutating the shared field.
+- Real types over mocks where practical. Reach for mocks only when the dependency is genuinely external (network, filesystem) or has a complex lifecycle.
+- Helpers (record builders, config builders) as `private static` methods at the bottom of the test class.
+
+**Documentation**
+
+Use Javadoc on tests only when the *why* is non-obvious — e.g. "regression guard for the Flink 2.x ARN-vs-short-name contract", not "tests deserialization". The reader can see what the test does from the assertions; the comment should add context the assertions can't.
+
+**Coverage guidance**
+
+The project tracks coverage via JaCoCo + Codecov ([flags `unittests` and `e2e`](https://app.codecov.io/gh/kzmlabs/flink-statefun)). New behavior should be covered. Don't chase coverage percentages on glue/getter/builder code; prioritize critical-runtime paths (binders, state access, message dispatch) and error paths (boundary conditions, malformed input, transient failures). See [issue #149](https://github.com/kzmlabs/flink-statefun/issues/149) for the rolling investment plan.
+
 ## Pull Request Process
 
 1. Fork the repository and create a feature branch from `release`

--- a/statefun-flink/statefun-flink-io-bundle/src/test/java/org/apache/flink/statefun/flink/io/kafka/binders/ingress/v1/RoutableKafkaIngressDeserializerTest.java
+++ b/statefun-flink/statefun-flink-io-bundle/src/test/java/org/apache/flink/statefun/flink/io/kafka/binders/ingress/v1/RoutableKafkaIngressDeserializerTest.java
@@ -14,7 +14,6 @@ import org.apache.flink.statefun.flink.io.generated.RoutingConfig;
 import org.apache.flink.statefun.flink.io.generated.TargetFunctionType;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -43,9 +42,8 @@ class RoutableKafkaIngressDeserializerTest {
         new RoutableKafkaIngressDeserializer(routingMap(ORDERS_TOPIC, ORDERS_ROUTING));
   }
 
-  @DisplayName("routes records on a configured topic to the configured value type and targets")
   @Test
-  void deserialize_withConfiguredTopic_routesToTargets() {
+  void routesConfiguredTopicToTargets() {
     final byte[] payload = "order-payload".getBytes(StandardCharsets.UTF_8);
     final byte[] key = "pk-7".getBytes(StandardCharsets.UTF_8);
     final ConsumerRecord<byte[], byte[]> record = consumerRecord(ORDERS_TOPIC, key, payload);
@@ -60,9 +58,8 @@ class RoutableKafkaIngressDeserializerTest {
     assertThat(routable.getConfig().getTargetFunctionTypesList()).containsExactly(ORDERS_TARGET);
   }
 
-  @DisplayName("throws routing-miss error when topic is not in the routing map")
   @Test
-  void deserialize_withUnknownTopic_throwsRoutingMissError() {
+  void throwsWhenTopicIsNotInRoutingMap() {
     final ConsumerRecord<byte[], byte[]> record =
         consumerRecord(
             "unknown-topic",

--- a/statefun-flink/statefun-flink-io-bundle/src/test/java/org/apache/flink/statefun/flink/io/kinesis/binders/ingress/v1/RoutableKinesisIngressDeserializerTest.java
+++ b/statefun-flink/statefun-flink-io-bundle/src/test/java/org/apache/flink/statefun/flink/io/kinesis/binders/ingress/v1/RoutableKinesisIngressDeserializerTest.java
@@ -16,7 +16,6 @@ import org.apache.flink.statefun.flink.io.generated.RoutingConfig;
 import org.apache.flink.statefun.flink.io.generated.TargetFunctionType;
 import org.apache.flink.statefun.sdk.kinesis.ingress.IngressRecord;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -59,9 +58,8 @@ class RoutableKinesisIngressDeserializerTest {
     deserializer = new RoutableKinesisIngressDeserializer(routingMap(ORDERS_ARN, ORDERS_ROUTING));
   }
 
-  @DisplayName("routes ARN-keyed records to configured value type and targets")
   @Test
-  void deserialize_withArnAsStream_routesToConfiguredTargets() {
+  void routesArnKeyedRecordsToConfiguredTargets() {
     final byte[] payload = "order-123".getBytes(StandardCharsets.UTF_8);
     final IngressRecord record = ingressRecord(ORDERS_ARN, "pk-42", payload);
 
@@ -80,11 +78,9 @@ class RoutableKinesisIngressDeserializerTest {
    * unconfigured ARN must both fail loudly so the regression is detected, rather than silently
    * dropping records.
    */
-  @DisplayName("throws routing-miss error when stream key is not in the routing map")
   @ParameterizedTest(name = "{1}")
   @MethodSource("nonMatchingStreamKeys")
-  void deserialize_withNonMatchingStreamKey_throwsRoutingMissError(
-      String streamKey, String reason) {
+  void throwsWhenStreamKeyIsNotInRoutingMap(String streamKey, String reason) {
     final IngressRecord record =
         ingressRecord(streamKey, "pk-1", "x".getBytes(StandardCharsets.UTF_8));
 
@@ -105,9 +101,8 @@ class RoutableKinesisIngressDeserializerTest {
    * {@link AutoRoutable} envelope without parsing the payload itself (parsing is downstream), so
    * an empty payload should round-trip cleanly: success with zero-byte payload.
    */
-  @DisplayName("round-trips empty payload as zero-byte AutoRoutable envelope")
   @Test
-  void deserialize_withEmptyPayload_handlesGracefully() {
+  void wrapsEmptyPayloadInAutoRoutableEnvelope() {
     final IngressRecord record = ingressRecord(ORDERS_ARN, "pk-empty", new byte[0]);
 
     final Message result = deserializer.deserialize(record);
@@ -123,9 +118,8 @@ class RoutableKinesisIngressDeserializerTest {
    * Kinesis records cap at 1 MiB. The deserializer must not truncate. Uses a deterministic byte
    * pattern so we can verify exact bytes (including the boundary bytes) made it through.
    */
-  @DisplayName("preserves full 1 MiB payload without truncation")
   @Test
-  void deserialize_withMaxSizePayload_succeeds() {
+  void preservesMaxSizePayloadWithoutTruncation() {
     final int oneMiB = 1024 * 1024;
     final byte[] payload = new byte[oneMiB];
     for (int i = 0; i < oneMiB; i++) {
@@ -147,9 +141,8 @@ class RoutableKinesisIngressDeserializerTest {
    * its own configured value type / targets, even when the same deserializer instance handles
    * interleaved records from both streams.
    */
-  @DisplayName("dispatches interleaved records from multiple ARNs independently")
   @Test
-  void deserialize_multipleArnRoutingEntries_dispatchesIndependently() {
+  void dispatchesMultipleArnEntriesIndependently() {
     final RoutingConfig eventsRouting =
         routingConfig(EVENTS_VALUE_TYPE, EVENTS_TARGET_A, EVENTS_TARGET_B);
 


### PR DESCRIPTION
Follow-up to #163. Audit found that the 7 new tests use snake_case (`deserialize_withArnAsStream_...`) while the rest of the codebase uses plain camelCase (`buildsSourceFromSpecWithArn`, `legacySingleStreamThrowsHelpfulError`, etc. — 300+ tests checked).

## What changed

**Renames** (7 methods):

| Old | New |
|---|---|
| `deserialize_withArnAsStream_routesToConfiguredTargets` | `routesArnKeyedRecordsToConfiguredTargets` |
| `deserialize_withNonMatchingStreamKey_throwsRoutingMissError` | `throwsWhenStreamKeyIsNotInRoutingMap` |
| `deserialize_withEmptyPayload_handlesGracefully` | `wrapsEmptyPayloadInAutoRoutableEnvelope` |
| `deserialize_withMaxSizePayload_succeeds` | `preservesMaxSizePayloadWithoutTruncation` |
| `deserialize_multipleArnRoutingEntries_dispatchesIndependently` | `dispatchesMultipleArnEntriesIndependently` |
| `deserialize_withConfiguredTopic_routesToTargets` | `routesConfiguredTopicToTargets` |
| `deserialize_withUnknownTopic_throwsRoutingMissError` | `throwsWhenTopicIsNotInRoutingMap` |

**Stripped `@DisplayName`** — not used anywhere else in the codebase. Test method name is the documentation.

**New `Testing conventions` section in CONTRIBUTING.md** locking in the convention so future PRs don't drift:
- Naming (camelCase, no underscores, no `@DisplayName`)
- AAA structure, single concept per test
- AssertJ + JUnit 5 Jupiter
- Real types over mocks
- Helper placement
- When to use Javadoc on tests (only when *why* is non-obvious)
- Coverage guidance pointing at #149

## Test plan

- [x] `mvn test -Dtest='Routable*DeserializerTest'` → 8/8 pass locally
- [ ] CI green on this PR