### PR TITLE
docs: fix mermaid render error in README architecture diagram

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,11 +20,11 @@ You write a function keyed by a logical id. The runtime gives it per-key durable
 
 ```mermaid
 flowchart LR
-    KafkaIn[Kafka / Kinesis<br/>ingress] --> Dispatch[StateFun<br/>dispatcher]
-    Dispatch -->|state-keyed message| Func[Function instance]
-    Func -->|HTTP request-reply| Remote[Remote endpoint]
-    Func -->|emit| Egress[Kafka / Kinesis<br/>egress]
-    Func <-->|state I/O| State[(RocksDB keyed state<br/>checkpointed to S3)]
+    KafkaIn["Kafka / Kinesis<br/>ingress"] --> Dispatch["StateFun<br/>dispatcher"]
+    Dispatch -->|"state-keyed message"| Func["Function instance"]
+    Func -->|"HTTP request-reply"| Remote["Remote endpoint"]
+    Func -->|"emit"| Egress["Kafka / Kinesis<br/>egress"]
+    Func <-->|"state I/O"| State[("RocksDB keyed state<br/>checkpointed to S3")]
 ```
 
 **Use cases:** event-driven microservices, real-time fraud detection, IoT digital twins, payment orchestration, actor-style stateful compute, distributed sagas, serverless stream processing.


### PR DESCRIPTION
GitHub's mermaid renderer was failing the top-of-README architecture diagram with `Cannot read properties of undefined (reading 'render')`. The parser chokes on unquoted node labels containing forward slashes (`Kafka / Kinesis`), `<br/>` tags, `[(cylinder)]` shape syntax, and `<-->` bidirectional arrows in combination.

Fix: wrap all node + edge labels in double quotes (mermaid-supported escape). Same fix pattern applied to the coverage aggregator README diagrams in commit ebc3c354.

After merge, refresh https://github.com/kzmlabs/flink-statefun (hard refresh to bust browser cache) — the diagram should render.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the flowchart diagram in the README to improve formatting and readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->