### PR TITLE
docs: refresh CHANGELOG + RELEASE-GUIDE for 3.0 / 3.1 releases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,20 @@ All notable changes to **StateFun Actors by Kzmlabs** are documented in this fil
 
 > **Reading guide:** "KZM-x.y" releases are this fork's versions on Flink 2.x. Apache StateFun's last release was [3.4.0](https://github.com/apache/flink-statefun/releases/tag/release-3.4.0) (October 2024) on Flink 1.16. See [docs/upstream-vs-kzm.md](https://kzmlabs.github.io/flink-statefun/upstream-vs-kzm/) for the full migration matrix.
 
-## [3.4.0-KZM-3.0-RC1] - 2026-04-23
+## [3.4.0-KZM-3.1] - 2026-04-29
+
+Patch release on top of 3.4.0-KZM-3.0. Same Kinesis-restoration baseline as
+3.0; this entry exists for traceability so the changelog and Maven Central
+match.
+
+## [3.4.0-KZM-3.0] - 2026-04-29
+
+Stable promotion of `3.4.0-KZM-3.0-RC1` after the Kubernetes native E2E gate
+(both Kafka and Kinesis suites) ran green and Maven Central + GHCR publishing
+completed cleanly. No source changes vs RC1 — same Kinesis I/O restoration,
+same LocalStack-backed K8s E2E.
+
+## [3.4.0-KZM-3.0-RC1] - 2026-04-24
 
 ### Added — Kinesis ingress/egress end-to-end support
 
@@ -167,6 +180,8 @@ First stable release of the KZM-2.0 line, promoting RC7 after successful Maven C
 - Add Docker image publishing to GitHub Container Registry
 - Add release setup guide and release script
 
+[3.4.0-KZM-3.1]: https://github.com/kzmlabs/flink-statefun/releases/tag/v3.4.0-KZM-3.1
+[3.4.0-KZM-3.0]: https://github.com/kzmlabs/flink-statefun/releases/tag/v3.4.0-KZM-3.0
 [3.4.0-KZM-3.0-RC1]: https://github.com/kzmlabs/flink-statefun/releases/tag/v3.4.0-KZM-3.0-RC1
 [3.4.0-KZM-2.0]: https://github.com/kzmlabs/flink-statefun/releases/tag/v3.4.0-KZM-2.0
 [3.4.0-KZM-2.0-RC7]: https://github.com/kzmlabs/flink-statefun/releases/tag/v3.4.0-KZM-2.0-RC7

--- a/RELEASE-GUIDE.md
+++ b/RELEASE-GUIDE.md
@@ -4,11 +4,17 @@
 
 This guide documents the release process for publishing to Maven Central and GitHub Container Registry (GHCR).
 
-## Current Release: 3.4.0-KZM-3.0-RC1
+## Current Release: 3.4.0-KZM-3.1
 
 - **Maven Central**: Published
-- **Docker Image**: `ghcr.io/kzmlabs/flink-statefun:3.4.0-KZM-3.0-RC1`
-- **GitHub Release**: https://github.com/kzmlabs/flink-statefun/releases
+- **Docker Image**: `ghcr.io/kzmlabs/flink-statefun:3.4.0-KZM-3.1` (and `:latest`)
+- **GitHub Release**: https://github.com/kzmlabs/flink-statefun/releases/tag/v3.4.0-KZM-3.1
+
+Lineage:
+- **3.4.0-KZM-2.0** (2026-04-23) — stable; Kinesis broken (SDK-only, no runtime)
+- **3.4.0-KZM-3.0-RC1** (2026-04-24) — Kinesis runtime restored on Flink 2.x
+- **3.4.0-KZM-3.0** (2026-04-29) — stable promotion of RC1
+- **3.4.0-KZM-3.1** (2026-04-29, current) — patch on top of 3.0
 
 ---
 
@@ -20,14 +26,14 @@ Triggered automatically when pushing a tag starting with `v`:
 
 ```bash
 # Update version
-mvn versions:set -DnewVersion=3.4.0-KZM-3.0-RC2 -DgenerateBackupPoms=false
+mvn versions:set -DnewVersion=3.4.0-KZM-3.2 -DgenerateBackupPoms=false
 
 # Commit and tag
 git add -A
-git commit -m "Release 3.4.0-KZM-3.0-RC2"
+git commit -m "Release 3.4.0-KZM-3.2"
 git push origin release
-git tag v3.4.0-KZM-3.0-RC2
-git push origin v3.4.0-KZM-3.0-RC2
+git tag v3.4.0-KZM-3.2
+git push origin v3.4.0-KZM-3.2
 ```
 
 This runs `.github/workflows/release.yml` which:
@@ -43,11 +49,11 @@ but skips Maven Central deploy and GitHub Release creation.
 
 ```bash
 # Tag for Docker-only release
-git tag docker-3.4.0-KZM-3.0-RC1-test1
-git push origin docker-3.4.0-KZM-3.0-RC1-test1
+git tag docker-3.4.0-KZM-3.1-test1
+git push origin docker-3.4.0-KZM-3.1-test1
 ```
 
-This pushes the image as `ghcr.io/kzmlabs/flink-statefun:3.4.0-KZM-3.0-RC1-test1`.
+This pushes the image as `ghcr.io/kzmlabs/flink-statefun:3.4.0-KZM-3.1-test1`.
 
 There is also a `docker-release.yml` workflow with `workflow_dispatch` for manual triggers via the GitHub Actions UI.
 
@@ -168,12 +174,16 @@ Make package public: https://github.com/orgs/kzmlabs/packages/container/flink-st
 
 ## Version History
 
-| Version | Status | Notes |
-|---------|--------|-------|
-| RC20 | ✅ Published | Fixed all Maven Central validation issues |
-| RC19 | ❌ Failed | Missing javadoc for statefun-flink-distribution |
-| RC18 | ❌ Failed | Missing `<name>` in all modules |
-| RC17 | ❌ Failed | Missing javadoc for statefun-sdk-protos |
+| Version | Date | Status | Notes |
+|---------|------|--------|-------|
+| 3.4.0-KZM-3.1 | 2026-04-29 | ✅ Published | Patch on top of 3.0 (current) |
+| 3.4.0-KZM-3.0 | 2026-04-29 | ✅ Published | Stable promotion of 3.0-RC1 |
+| 3.4.0-KZM-3.0-RC1 | 2026-04-24 | ✅ Published | Kinesis runtime restored on Flink 2.x |
+| 3.4.0-KZM-2.0 | 2026-04-23 | ✅ Published | Stable; Kinesis broken (SDK-only, no runtime) |
+| RC20 | (early) | ✅ Published | Fixed all Maven Central validation issues |
+| RC19 | (early) | ❌ Failed | Missing javadoc for statefun-flink-distribution |
+| RC18 | (early) | ❌ Failed | Missing `<name>` in all modules |
+| RC17 | (early) | ❌ Failed | Missing javadoc for statefun-sdk-protos |
 
 ---
 
@@ -195,6 +205,6 @@ mvn clean install -Prelease -DskipTests -Dgpg.skip=true
 # Check workflow status
 gh run list --repo kzmlabs/flink-statefun
 
-# Pull Docker image
-docker pull ghcr.io/kzmlabs/flink-statefun:3.4.0-KZM-3.0-RC1
+# Pull Docker image (latest stable)
+docker pull ghcr.io/kzmlabs/flink-statefun:3.4.0-KZM-3.1
 ```


### PR DESCRIPTION
## Summary

Two stale documents flagged during the PR #173 review:

- **`CHANGELOG.md`** stopped at `3.4.0-KZM-3.0-RC1` (2026-04-23 in the file, actually 2026-04-24 per the git tag). Both `3.4.0-KZM-3.0` (2026-04-29 stable promotion) and `3.4.0-KZM-3.1` (2026-04-29 patch — current latest) shipped to Maven Central + GHCR but the changelog never recorded them.
- **`RELEASE-GUIDE.md`** still declared the current release as `3.4.0-KZM-3.0-RC1` and used RC1 / RC2 strings in its example tag commands.

## Changes

`CHANGELOG.md`:
- Add entries for `3.4.0-KZM-3.0` and `3.4.0-KZM-3.1` (both 2026-04-29, taken from `git log` of the actual tags).
- Fix the `3.4.0-KZM-3.0-RC1` date from 2026-04-23 → 2026-04-24 to match the tag.
- Add the two missing release-tag link references at the bottom.

`RELEASE-GUIDE.md`:
- 'Current Release' is now `3.4.0-KZM-3.1` with a lineage block (KZM-2.0 → 3.0-RC1 → 3.0 → 3.1).
- Example tag commands updated to current versions.
- 'Version History' restructured to a dated table sorted newest-first; early RC17–RC20 rows kept for historical context.
- 'Pull Docker image' quick command updated to `:3.4.0-KZM-3.1`.

## Test plan

Docs only — nothing to test in CI beyond rendering. The CHANGELOG link references resolve to existing tags (`v3.4.0-KZM-3.0`, `v3.4.0-KZM-3.1`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**Documentation**
- Updated changelog with new release entries for the 3.4.0-KZM series on Flink 2.x / Java 21
- Updated release guide with current version references and deployment examples

<!-- end of auto-generated comment: release notes by coderabbit.ai -->