### PR TITLE
test(coverage): exercise httpfn retry + jsonmodule legacy v3.0 paths

### DIFF
--- a/statefun-flink/statefun-flink-common/pom.xml
+++ b/statefun-flink/statefun-flink-common/pom.xml
@@ -59,6 +59,11 @@
             <artifactId>hamcrest</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.apache.flink</groupId>
             <artifactId>flink-core</artifactId>
             <version>${flink.version}</version>

--- a/statefun-flink/statefun-flink-common/src/test/java/org/apache/flink/statefun/flink/common/UnimplementedTypeSerializerTest.java
+++ b/statefun-flink/statefun-flink-common/src/test/java/org/apache/flink/statefun/flink/common/UnimplementedTypeSerializerTest.java
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Kzmlabs
+package org.apache.flink.statefun.flink.common;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+
+class UnimplementedTypeSerializerTest {
+
+  /**
+   * The serializer is intentionally a placeholder: every method except equals/hashCode/getLength
+   * must throw to make sure no caller silently exercises a half-implementation. Pin that
+   * behavior so a future contributor doesn't accidentally implement one method without the rest.
+   */
+  @Test
+  void allOperationalMethodsThrowUnsupported() {
+    UnimplementedTypeSerializer<String> s = new UnimplementedTypeSerializer<>();
+
+    assertThatThrownBy(() -> s.duplicate()).isInstanceOf(UnsupportedOperationException.class);
+    assertThatThrownBy(() -> s.createInstance()).isInstanceOf(UnsupportedOperationException.class);
+    assertThatThrownBy(() -> s.copy("a")).isInstanceOf(UnsupportedOperationException.class);
+    assertThatThrownBy(() -> s.copy("a", "b")).isInstanceOf(UnsupportedOperationException.class);
+    assertThatThrownBy(() -> s.serialize("a", null))
+        .isInstanceOf(UnsupportedOperationException.class);
+    assertThatThrownBy(() -> s.deserialize((org.apache.flink.core.memory.DataInputView) null))
+        .isInstanceOf(UnsupportedOperationException.class);
+    assertThatThrownBy(() -> s.deserialize("a", null))
+        .isInstanceOf(UnsupportedOperationException.class);
+    assertThatThrownBy(
+            () ->
+                s.copy(
+                    (org.apache.flink.core.memory.DataInputView) null,
+                    (org.apache.flink.core.memory.DataOutputView) null))
+        .isInstanceOf(UnsupportedOperationException.class);
+    assertThatThrownBy(() -> s.snapshotConfiguration())
+        .isInstanceOf(UnsupportedOperationException.class);
+  }
+
+  @Test
+  void shapeAccessorsReturnConstants() {
+    UnimplementedTypeSerializer<String> s = new UnimplementedTypeSerializer<>();
+
+    // The serializer claims a fixed length of 0 (sentinel for "I'm a stub") and not-immutable.
+    assertThat(s.getLength()).isZero();
+    assertThat(s.isImmutableType()).isFalse();
+  }
+
+  @Test
+  void equalsIsIdentityNotValueBased() {
+    UnimplementedTypeSerializer<String> a = new UnimplementedTypeSerializer<>();
+    UnimplementedTypeSerializer<String> b = new UnimplementedTypeSerializer<>();
+
+    // Two instances are NOT equal — the contract is reference equality, otherwise Flink would
+    // try to merge two unrelated stub serializers.
+    assertThat(a).isEqualTo(a);
+    assertThat(a).isNotEqualTo(b);
+    assertThat(a).isNotEqualTo("not a serializer");
+    assertThat(a).isNotEqualTo(null);
+  }
+
+  @Test
+  void hashCodeIsConstantSeven() {
+    // Pin this — `7` is documented as the placeholder hash. Any change to a real hash would
+    // imply someone is treating this as a real serializer.
+    assertThat(new UnimplementedTypeSerializer<String>().hashCode()).isEqualTo(7);
+  }
+}

--- a/statefun-flink/statefun-flink-common/src/test/java/org/apache/flink/statefun/flink/common/protobuf/InputStreamViewTest.java
+++ b/statefun-flink/statefun-flink-common/src/test/java/org/apache/flink/statefun/flink/common/protobuf/InputStreamViewTest.java
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Kzmlabs
+package org.apache.flink.statefun.flink.common.protobuf;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.io.ByteArrayInputStream;
+import java.io.DataInputStream;
+import org.apache.flink.core.memory.DataInputViewStreamWrapper;
+import org.junit.jupiter.api.Test;
+
+class InputStreamViewTest {
+
+  @Test
+  void singleByteReadHonorsLimit() throws Exception {
+    InputStreamView view = new InputStreamView();
+    view.set(viewOver(new byte[] {1, 2, 3, 4, 5}), 3);
+
+    assertThat(view.read()).isEqualTo(1);
+    assertThat(view.read()).isEqualTo(2);
+    assertThat(view.read()).isEqualTo(3);
+    // Limit reached even though there are more bytes in the underlying stream.
+    assertThat(view.read()).isEqualTo(-1);
+  }
+
+  @Test
+  void readIntoBufferStopsAtLimit() throws Exception {
+    InputStreamView view = new InputStreamView();
+    view.set(viewOver(new byte[] {10, 20, 30, 40, 50}), 3);
+
+    byte[] buf = new byte[10];
+    int n = view.read(buf, 0, 10);
+
+    assertThat(n).isEqualTo(3);
+    assertThat(buf[0]).isEqualTo((byte) 10);
+    assertThat(buf[1]).isEqualTo((byte) 20);
+    assertThat(buf[2]).isEqualTo((byte) 30);
+    // After hitting the limit, subsequent reads return -1.
+    assertThat(view.read(buf, 0, 10)).isEqualTo(-1);
+  }
+
+  @Test
+  void readIntoBufferAccountsForPartialReads() throws Exception {
+    InputStreamView view = new InputStreamView();
+    view.set(viewOver(new byte[] {1, 2, 3, 4, 5}), 5);
+
+    byte[] buf = new byte[2];
+    assertThat(view.read(buf, 0, 2)).isEqualTo(2);
+    assertThat(view.read(buf, 0, 2)).isEqualTo(2);
+    // 1 byte left under the limit.
+    assertThat(view.read(buf, 0, 2)).isEqualTo(1);
+    // Limit exhausted.
+    assertThat(view.read(buf, 0, 2)).isEqualTo(-1);
+  }
+
+  @Test
+  void skipDecrementsLimit() throws Exception {
+    InputStreamView view = new InputStreamView();
+    view.set(viewOver(new byte[] {1, 2, 3, 4, 5}), 5);
+
+    long skipped = view.skip(3);
+
+    assertThat(skipped).isEqualTo(3);
+    assertThat(view.read()).isEqualTo(4);
+    assertThat(view.read()).isEqualTo(5);
+    assertThat(view.read()).isEqualTo(-1);
+  }
+
+  @Test
+  void skipIsBoundedByLimit() throws Exception {
+    InputStreamView view = new InputStreamView();
+    view.set(viewOver(new byte[] {1, 2, 3, 4, 5, 6, 7, 8}), 4);
+
+    long skipped = view.skip(100);
+
+    assertThat(skipped).isEqualTo(4);
+    assertThat(view.read()).isEqualTo(-1);
+  }
+
+  @Test
+  void doneResetsForReuse() throws Exception {
+    InputStreamView view = new InputStreamView();
+    view.set(viewOver(new byte[] {1, 2, 3}), 3);
+
+    view.done();
+
+    // After done, no more bytes are readable. The view is now ready to be reused with a
+    // fresh `set(...)` call — this is the InputStreamView's contract for being pooled.
+    assertThat(view.read()).isEqualTo(-1);
+  }
+
+  @Test
+  void markAndResetAreUnsupported() {
+    InputStreamView view = new InputStreamView();
+
+    assertThatThrownBy(() -> view.mark(0)).isInstanceOf(UnsupportedOperationException.class);
+    assertThatThrownBy(view::reset).isInstanceOf(UnsupportedOperationException.class);
+  }
+
+  private static org.apache.flink.core.memory.DataInputView viewOver(byte[] bytes) {
+    return new DataInputViewStreamWrapper(new DataInputStream(new ByteArrayInputStream(bytes)));
+  }
+}

--- a/statefun-flink/statefun-flink-common/src/test/java/org/apache/flink/statefun/flink/common/protobuf/OutputStreamViewTest.java
+++ b/statefun-flink/statefun-flink-common/src/test/java/org/apache/flink/statefun/flink/common/protobuf/OutputStreamViewTest.java
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Kzmlabs
+package org.apache.flink.statefun.flink.common.protobuf;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.ByteArrayOutputStream;
+import java.io.DataOutputStream;
+import org.apache.flink.core.memory.DataOutputViewStreamWrapper;
+import org.junit.jupiter.api.Test;
+
+class OutputStreamViewTest {
+
+  @Test
+  void singleByteWriteIsForwardedToUnderlyingDataOutput() throws Exception {
+    ByteArrayOutputStream sink = new ByteArrayOutputStream();
+    OutputStreamView view = new OutputStreamView();
+    view.set(new DataOutputViewStreamWrapper(new DataOutputStream(sink)));
+
+    view.write(0x42);
+
+    assertThat(sink.toByteArray()).containsExactly(0x42);
+  }
+
+  @Test
+  void byteArrayWriteIsForwarded() throws Exception {
+    ByteArrayOutputStream sink = new ByteArrayOutputStream();
+    OutputStreamView view = new OutputStreamView();
+    view.set(new DataOutputViewStreamWrapper(new DataOutputStream(sink)));
+
+    view.write(new byte[] {1, 2, 3, 4});
+
+    assertThat(sink.toByteArray()).containsExactly(1, 2, 3, 4);
+  }
+
+  @Test
+  void byteArrayOffsetLenWriteIsForwarded() throws Exception {
+    ByteArrayOutputStream sink = new ByteArrayOutputStream();
+    OutputStreamView view = new OutputStreamView();
+    view.set(new DataOutputViewStreamWrapper(new DataOutputStream(sink)));
+
+    view.write(new byte[] {1, 2, 3, 4, 5}, 1, 3);
+
+    // Mid-buffer slice — bytes 2,3,4.
+    assertThat(sink.toByteArray()).containsExactly(2, 3, 4);
+  }
+
+  @Test
+  void flushAndCloseAreNoOps() throws Exception {
+    OutputStreamView view = new OutputStreamView();
+    // No target set — flush/close must not NPE; the stream is allowed to be reused.
+    view.flush();
+    view.close();
+    // No exception means pass.
+    assertThat(view).isNotNull();
+  }
+
+  @Test
+  void doneDetachesTarget() {
+    OutputStreamView view = new OutputStreamView();
+    view.set(new DataOutputViewStreamWrapper(new DataOutputStream(new ByteArrayOutputStream())));
+
+    view.done();
+
+    // After done, no target — write would NPE. The contract is that done() releases the
+    // underlying view so the OutputStreamView can be cached/pooled without holding a stale
+    // reference to last-job's serialization buffer.
+    org.assertj.core.api.Assertions.assertThatThrownBy(() -> view.write(0))
+        .isInstanceOf(NullPointerException.class);
+  }
+}

--- a/statefun-flink/statefun-flink-common/src/test/java/org/apache/flink/statefun/flink/common/types/TypedValueUtilTest.java
+++ b/statefun-flink/statefun-flink-common/src/test/java/org/apache/flink/statefun/flink/common/types/TypedValueUtilTest.java
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Kzmlabs
+package org.apache.flink.statefun.flink.common.types;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.google.protobuf.ByteString;
+import org.apache.flink.statefun.sdk.reqreply.generated.TypedValue;
+import org.junit.jupiter.api.Test;
+
+class TypedValueUtilTest {
+
+  @Test
+  void packProtobufMessageProducesTypeUrlPrefixedByTypeGoogleapisCom() {
+    TypedValue input = TypedValue.newBuilder().setTypename("foo/bar").setHasValue(true).build();
+
+    TypedValue packed = TypedValueUtil.packProtobufMessage(input);
+
+    assertThat(packed.getTypename())
+        .isEqualTo("type.googleapis.com/" + TypedValue.getDescriptor().getFullName());
+    assertThat(packed.getHasValue()).isTrue();
+    assertThat(packed.getValue()).isEqualTo(input.toByteString());
+  }
+
+  @Test
+  void isProtobufTypeOfMatchesPackedDescriptor() {
+    TypedValue input = TypedValue.newBuilder().setTypename("anything").build();
+    TypedValue packed = TypedValueUtil.packProtobufMessage(input);
+
+    assertThat(TypedValueUtil.isProtobufTypeOf(packed, TypedValue.getDescriptor())).isTrue();
+  }
+
+  @Test
+  void isProtobufTypeOfRejectsMismatchedTypeName() {
+    TypedValue notPacked =
+        TypedValue.newBuilder().setTypename("type.googleapis.com/some.Other").build();
+
+    assertThat(TypedValueUtil.isProtobufTypeOf(notPacked, TypedValue.getDescriptor())).isFalse();
+  }
+
+  @Test
+  void unpackProtobufMessageRoundtripsValue() {
+    TypedValue original = TypedValue.newBuilder().setTypename("io.test/x").setHasValue(true).build();
+    TypedValue packed = TypedValueUtil.packProtobufMessage(original);
+
+    TypedValue unpacked = TypedValueUtil.unpackProtobufMessage(packed, TypedValue.parser());
+
+    assertThat(unpacked).isEqualTo(original);
+  }
+
+  @Test
+  void unpackProtobufMessageRaisesIllegalStateOnCorruptedBytes() {
+    TypedValue corrupted =
+        TypedValue.newBuilder()
+            .setTypename("type.googleapis.com/" + TypedValue.getDescriptor().getFullName())
+            .setHasValue(true)
+            .setValue(ByteString.copyFrom(new byte[] {(byte) 0xFF, (byte) 0xFF}))
+            .build();
+
+    assertThatThrownBy(() -> TypedValueUtil.unpackProtobufMessage(corrupted, TypedValue.parser()))
+        .isInstanceOf(IllegalStateException.class)
+        .hasCauseInstanceOf(com.google.protobuf.InvalidProtocolBufferException.class);
+  }
+}

--- a/statefun-flink/statefun-flink-core/src/test/java/org/apache/flink/statefun/flink/core/FlinkConfigExtractorTest.java
+++ b/statefun-flink/statefun-flink-core/src/test/java/org/apache/flink/statefun/flink/core/FlinkConfigExtractorTest.java
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Kzmlabs
+package org.apache.flink.statefun.flink.core;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Pins the reflective contract that {@link FlinkConfigExtractor#reflectivelyExtractFromEnv} relies
+ * on: {@code StreamExecutionEnvironment#getConfiguration} exists, is reflectively accessible, and
+ * returns the same Configuration the SDK feeds back into binders / Modules.
+ *
+ * <p>The class uses reflection because {@code getConfiguration()} is package-private upstream.
+ * If Flink ever renames or removes that method, this test fails immediately rather than silently
+ * skipping StateFun config extraction at job-graph build time.
+ */
+class FlinkConfigExtractorTest {
+
+  @Test
+  void extractsConfigurationFromLocalStreamExecutionEnvironment() {
+    Configuration sentinel = new Configuration();
+    sentinel.setString("statefun.test.sentinel", "match-me");
+
+    StreamExecutionEnvironment env =
+        StreamExecutionEnvironment.createLocalEnvironment(1, sentinel);
+
+    Configuration extracted = FlinkConfigExtractor.reflectivelyExtractFromEnv(env);
+
+    assertThat(extracted).isNotNull();
+    // The extracted config must reflect the values we supplied to createLocalEnvironment —
+    // proves the reflection lands on the right field, not a fresh empty Configuration.
+    assertThat(extracted.getString("statefun.test.sentinel", null)).isEqualTo("match-me");
+  }
+
+  @Test
+  void extractedConfigIsReadableForFurtherStateFunsLookups() {
+    StreamExecutionEnvironment env = StreamExecutionEnvironment.createLocalEnvironment(1);
+
+    Configuration extracted = FlinkConfigExtractor.reflectivelyExtractFromEnv(env);
+
+    // Empty config is fine — the API contract is "return a Configuration, never throw on
+    // missing keys". Pin that callers can read defaults safely.
+    assertThat(extracted.getString("any.missing.key", "fallback")).isEqualTo("fallback");
+  }
+}

--- a/statefun-flink/statefun-flink-core/src/test/java/org/apache/flink/statefun/flink/core/StatefulFunctionsConfigSettersTest.java
+++ b/statefun-flink/statefun-flink-core/src/test/java/org/apache/flink/statefun/flink/core/StatefulFunctionsConfigSettersTest.java
@@ -1,0 +1,170 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Kzmlabs
+package org.apache.flink.statefun.flink.core;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.io.Serializable;
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.MemorySize;
+import org.apache.flink.statefun.flink.core.message.MessageFactoryType;
+import org.apache.flink.statefun.sdk.spi.StatefulFunctionModule;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Covers the {@link StatefulFunctionsConfig} setter / accessor surface that
+ * StatefulFunctionsConfigTest doesn't reach: setFactoryType / setEmbedded / setProvider /
+ * getRemoteModuleName / addAllGlobalConfigurations / fromEnvironment.
+ */
+class StatefulFunctionsConfigSettersTest {
+
+  @Test
+  void fromFlinkConfigurationWithDefaultsReturnsDocumentedDefaults() {
+    StatefulFunctionsConfig cfg =
+        StatefulFunctionsConfig.fromFlinkConfiguration(new Configuration());
+
+    assertThat(cfg.getFlinkJobName()).isEqualTo("StatefulFunctions");
+    assertThat(cfg.getFactoryType()).isEqualTo(MessageFactoryType.WITH_PROTOBUF_PAYLOADS);
+    assertThat(cfg.getFeedbackBufferSize()).isEqualTo(MemorySize.ofMebiBytes(32));
+    assertThat(cfg.getMaxAsyncOperationsPerTask()).isEqualTo(32 * 1024);
+    assertThat(cfg.getRemoteModuleName()).isEqualTo("classpath:module.yaml");
+    assertThat(cfg.isEmbedded()).isFalse();
+    assertThat(cfg.getCustomPayloadSerializerClassName()).isNull();
+    assertThat(cfg.getGlobalConfigurations()).isEmpty();
+  }
+
+  @Test
+  void fromEnvironmentReadsFromStreamExecutionEnvironmentConfiguration() {
+    Configuration sentinel = new Configuration();
+    sentinel.set(StatefulFunctionsConfig.FLINK_JOB_NAME, "from-env-job");
+    StreamExecutionEnvironment env =
+        StreamExecutionEnvironment.createLocalEnvironment(1, sentinel);
+
+    StatefulFunctionsConfig cfg = StatefulFunctionsConfig.fromEnvironment(env);
+
+    assertThat(cfg.getFlinkJobName()).isEqualTo("from-env-job");
+  }
+
+  @Test
+  void settersOverrideValuesAfterFromFlinkConfiguration() {
+    StatefulFunctionsConfig cfg =
+        StatefulFunctionsConfig.fromFlinkConfiguration(new Configuration());
+
+    cfg.setFlinkJobName("renamed");
+    cfg.setFactoryType(MessageFactoryType.WITH_KRYO_PAYLOADS);
+    cfg.setCustomPayloadSerializerClassName("com.foo.Serializer");
+    cfg.setFeedbackBufferSize(MemorySize.ofMebiBytes(64));
+    cfg.setMaxAsyncOperationsPerTask(2048);
+    cfg.setRemoteModuleName("file:///tmp/module.yaml");
+    cfg.setEmbedded(true);
+
+    assertThat(cfg.getFlinkJobName()).isEqualTo("renamed");
+    assertThat(cfg.getFactoryType()).isEqualTo(MessageFactoryType.WITH_KRYO_PAYLOADS);
+    assertThat(cfg.getCustomPayloadSerializerClassName()).isEqualTo("com.foo.Serializer");
+    assertThat(cfg.getFeedbackBufferSize()).isEqualTo(MemorySize.ofMebiBytes(64));
+    assertThat(cfg.getMaxAsyncOperationsPerTask()).isEqualTo(2048);
+    assertThat(cfg.getRemoteModuleName()).isEqualTo("file:///tmp/module.yaml");
+    assertThat(cfg.isEmbedded()).isTrue();
+  }
+
+  @Test
+  void settersRejectNullForRequiredFields() {
+    StatefulFunctionsConfig cfg =
+        StatefulFunctionsConfig.fromFlinkConfiguration(new Configuration());
+
+    assertThatThrownBy(() -> cfg.setFactoryType(null)).isInstanceOf(NullPointerException.class);
+    assertThatThrownBy(() -> cfg.setFlinkJobName(null)).isInstanceOf(NullPointerException.class);
+    assertThatThrownBy(() -> cfg.setFeedbackBufferSize(null))
+        .isInstanceOf(NullPointerException.class);
+    assertThatThrownBy(() -> cfg.setRemoteModuleName(null))
+        .isInstanceOf(NullPointerException.class);
+  }
+
+  @Test
+  void getFactoryKeyReflectsCurrentTypeAndCustomSerializerName() {
+    StatefulFunctionsConfig cfg =
+        StatefulFunctionsConfig.fromFlinkConfiguration(new Configuration());
+    cfg.setFactoryType(MessageFactoryType.WITH_CUSTOM_PAYLOADS);
+    cfg.setCustomPayloadSerializerClassName("com.foo.Bar");
+
+    assertThat(cfg.getFactoryKey().getType()).isEqualTo(MessageFactoryType.WITH_CUSTOM_PAYLOADS);
+    assertThat(cfg.getFactoryKey().getCustomPayloadSerializerClassName()).hasValue("com.foo.Bar");
+  }
+
+  @Test
+  void addAllGlobalConfigurationsMergesIntoExistingMap() {
+    Configuration cfg = new Configuration();
+    cfg.setString("statefun.module.global-config.preexisting", "from-flink-conf");
+    StatefulFunctionsConfig stateFunCfg = StatefulFunctionsConfig.fromFlinkConfiguration(cfg);
+
+    Map<String, String> additions = new HashMap<>();
+    additions.put("added", "from-runtime");
+    additions.put("preexisting", "overwritten");
+    stateFunCfg.addAllGlobalConfigurations(additions);
+
+    Map<String, String> resolved = stateFunCfg.getGlobalConfigurations();
+    assertThat(resolved).containsEntry("added", "from-runtime");
+    // addAllGlobalConfigurations uses putAll — pinned to overwrite-on-conflict semantics.
+    assertThat(resolved).containsEntry("preexisting", "overwritten");
+  }
+
+  @Test
+  void getGlobalConfigurationsIsImmutable() {
+    StatefulFunctionsConfig cfg =
+        StatefulFunctionsConfig.fromFlinkConfiguration(new Configuration());
+
+    assertThatThrownBy(() -> cfg.getGlobalConfigurations().put("k", "v"))
+        .isInstanceOf(UnsupportedOperationException.class);
+  }
+
+  @Test
+  void universeProviderRoundtripsThroughByteSerialization() {
+    StatefulFunctionsConfig cfg =
+        StatefulFunctionsConfig.fromFlinkConfiguration(new Configuration());
+
+    SerializableProvider provider = new SerializableProvider("payload");
+    cfg.setProvider(provider);
+    StatefulFunctionsUniverseProvider restored = cfg.getProvider(getClass().getClassLoader());
+
+    assertThat(restored).isInstanceOf(SerializableProvider.class);
+    assertThat(((SerializableProvider) restored).payload).isEqualTo("payload");
+  }
+
+  @Test
+  void getProviderBeforeSetThrows() {
+    StatefulFunctionsConfig cfg =
+        StatefulFunctionsConfig.fromFlinkConfiguration(new Configuration());
+
+    // Pin: calling getProvider before setProvider is misuse. Implementation deserializes a
+    // null byte array which surfaces as NPE through Flink's InstantiationUtil — either NPE or
+    // IllegalStateException is a loud failure, but it must not silently return null.
+    assertThatThrownBy(() -> cfg.getProvider(getClass().getClassLoader()))
+        .isInstanceOf(RuntimeException.class);
+  }
+
+  /** Minimal StatefulFunctionsUniverseProvider that survives serialize → deserialize. */
+  private static final class SerializableProvider
+      implements StatefulFunctionsUniverseProvider, Serializable {
+    private static final long serialVersionUID = 1L;
+    final String payload;
+
+    SerializableProvider(String payload) {
+      this.payload = payload;
+    }
+
+    @Override
+    public StatefulFunctionsUniverse get(
+        ClassLoader classLoader, StatefulFunctionsConfig configuration) {
+      throw new UnsupportedOperationException("Test double — never invoked.");
+    }
+
+    // Used implicitly by the contract — keep here so reflection-based discovery works.
+    @SuppressWarnings("unused")
+    static final Class<? extends StatefulFunctionModule> MODULE_INTERFACE_REF =
+        StatefulFunctionModule.class;
+  }
+}

--- a/statefun-flink/statefun-flink-core/src/test/java/org/apache/flink/statefun/flink/core/StatefulFunctionsUniverseBindersTest.java
+++ b/statefun-flink/statefun-flink-core/src/test/java/org/apache/flink/statefun/flink/core/StatefulFunctionsUniverseBindersTest.java
@@ -1,0 +1,188 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Kzmlabs
+package org.apache.flink.statefun.flink.core;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.apache.flink.statefun.flink.core.message.MessageFactoryKey;
+import org.apache.flink.statefun.flink.core.message.MessageFactoryType;
+import org.apache.flink.statefun.flink.io.spi.SinkProvider;
+import org.apache.flink.statefun.flink.io.spi.SourceProvider;
+import org.apache.flink.statefun.sdk.EgressType;
+import org.apache.flink.statefun.sdk.FunctionType;
+import org.apache.flink.statefun.sdk.FunctionTypeNamespaceMatcher;
+import org.apache.flink.statefun.sdk.IngressType;
+import org.apache.flink.statefun.sdk.StatefulFunctionProvider;
+import org.apache.flink.statefun.sdk.io.EgressIdentifier;
+import org.apache.flink.statefun.sdk.io.EgressSpec;
+import org.apache.flink.statefun.sdk.io.IngressIdentifier;
+import org.apache.flink.statefun.sdk.io.IngressSpec;
+import org.apache.flink.statefun.sdk.io.Router;
+import org.junit.jupiter.api.Test;
+
+class StatefulFunctionsUniverseBindersTest {
+
+  @Test
+  void bindIngressRecordsSpecKeyedById() {
+    StatefulFunctionsUniverse u = newUniverse();
+    IngressIdentifier<String> id = new IngressIdentifier<>(String.class, "ns", "in");
+    IngressSpec<String> spec = ingressSpec(id);
+
+    u.bindIngress(spec);
+
+    assertThat(u.ingress()).containsEntry(id, spec);
+  }
+
+  @Test
+  void bindIngressRejectsDuplicateId() {
+    StatefulFunctionsUniverse u = newUniverse();
+    IngressIdentifier<String> id = new IngressIdentifier<>(String.class, "ns", "in");
+    u.bindIngress(ingressSpec(id));
+
+    assertThatThrownBy(() -> u.bindIngress(ingressSpec(id)))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("previously defined");
+  }
+
+  @Test
+  void bindEgressRecordsSpecKeyedById() {
+    StatefulFunctionsUniverse u = newUniverse();
+    EgressIdentifier<String> id = new EgressIdentifier<>("ns", "out", String.class);
+    EgressSpec<String> spec = egressSpec(id);
+
+    u.bindEgress(spec);
+
+    assertThat(u.egress()).containsEntry(id, spec);
+  }
+
+  @Test
+  void bindRouterAccumulatesPerIngress() {
+    StatefulFunctionsUniverse u = newUniverse();
+    IngressIdentifier<String> id = new IngressIdentifier<>(String.class, "ns", "in");
+    Router<String> r1 = (msg, sink) -> {};
+    Router<String> r2 = (msg, sink) -> {};
+
+    u.bindIngressRouter(id, r1);
+    u.bindIngressRouter(id, r2);
+
+    assertThat(u.routers().get(id)).containsExactly(r1, r2);
+  }
+
+  @Test
+  void bindFunctionProviderByTypeRejectsDuplicate() {
+    StatefulFunctionsUniverse u = newUniverse();
+    FunctionType ft = new FunctionType("ns", "fn");
+    StatefulFunctionProvider provider = ignored -> null;
+
+    u.bindFunctionProvider(ft, provider);
+
+    assertThatThrownBy(() -> u.bindFunctionProvider(ft, provider))
+        .isInstanceOf(IllegalStateException.class);
+    assertThat(u.functions()).containsEntry(ft, provider);
+  }
+
+  @Test
+  void bindFunctionProviderByNamespaceMatcherRecordsByNamespace() {
+    StatefulFunctionsUniverse u = newUniverse();
+    StatefulFunctionProvider provider = ignored -> null;
+
+    u.bindFunctionProvider(FunctionTypeNamespaceMatcher.targetNamespace("ns"), provider);
+
+    assertThat(u.namespaceFunctions()).containsEntry("ns", provider);
+  }
+
+  @Test
+  void bindSourceProviderRejectsDuplicate() {
+    StatefulFunctionsUniverse u = newUniverse();
+    IngressType type = new IngressType("ns", "kafka");
+    SourceProvider source =
+        new SourceProvider() {
+          @Override
+          public <T, SplitT extends org.apache.flink.api.connector.source.SourceSplit, EnumChckT>
+              org.apache.flink.api.connector.source.Source<T, SplitT, EnumChckT> forSpec(
+                  org.apache.flink.statefun.sdk.io.IngressSpec<T> spec) {
+            return null;
+          }
+        };
+
+    u.bindSourceProvider(type, source);
+
+    assertThatThrownBy(() -> u.bindSourceProvider(type, source))
+        .isInstanceOf(IllegalStateException.class);
+    assertThat(u.sources()).containsEntry(type, source);
+  }
+
+  @Test
+  void bindSinkProviderRecordsBinding() {
+    StatefulFunctionsUniverse u = newUniverse();
+    EgressType type = new EgressType("ns", "kafka");
+    SinkProvider sink =
+        new SinkProvider() {
+          @Override
+          public <T> org.apache.flink.api.connector.sink2.Sink<T> forSpec(EgressSpec<T> spec) {
+            return null;
+          }
+        };
+
+    u.bindSinkProvider(type, sink);
+
+    assertThat(u.sinks()).containsEntry(type, sink);
+  }
+
+  @Test
+  void universeExposesMessageFactoryKey() {
+    MessageFactoryKey key =
+        MessageFactoryKey.forType(MessageFactoryType.WITH_PROTOBUF_PAYLOADS, null);
+    StatefulFunctionsUniverse u = new StatefulFunctionsUniverse(key);
+
+    assertThat(u.messageFactoryKey()).isSameAs(key);
+    assertThat(u.types()).isNotNull();
+  }
+
+  @Test
+  void resolveExtensionThrowsForMissingTypeName() {
+    StatefulFunctionsUniverse u = newUniverse();
+
+    assertThatThrownBy(
+            () ->
+                u.resolveExtension(
+                    org.apache.flink.statefun.sdk.TypeName.parseFrom("a/b"), Object.class))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("does not exist");
+  }
+
+  private static StatefulFunctionsUniverse newUniverse() {
+    return new StatefulFunctionsUniverse(
+        MessageFactoryKey.forType(MessageFactoryType.WITH_PROTOBUF_PAYLOADS, null));
+  }
+
+  private static <T> IngressSpec<T> ingressSpec(IngressIdentifier<T> id) {
+    return new IngressSpec<T>() {
+      @Override
+      public IngressIdentifier<T> id() {
+        return id;
+      }
+
+      @Override
+      public IngressType type() {
+        return new IngressType("ns", "test");
+      }
+    };
+  }
+
+  private static <T> EgressSpec<T> egressSpec(EgressIdentifier<T> id) {
+    return new EgressSpec<T>() {
+      @Override
+      public EgressIdentifier<T> id() {
+        return id;
+      }
+
+      @Override
+      public EgressType type() {
+        return new EgressType("ns", "test");
+      }
+    };
+  }
+
+}

--- a/statefun-flink/statefun-flink-core/src/test/java/org/apache/flink/statefun/flink/core/StatefulFunctionsUniverseValidatorTest.java
+++ b/statefun-flink/statefun-flink-core/src/test/java/org/apache/flink/statefun/flink/core/StatefulFunctionsUniverseValidatorTest.java
@@ -1,0 +1,162 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Kzmlabs
+package org.apache.flink.statefun.flink.core;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.apache.flink.statefun.flink.core.message.MessageFactoryKey;
+import org.apache.flink.statefun.flink.core.message.MessageFactoryType;
+import org.apache.flink.statefun.flink.io.spi.SourceProvider;
+import org.apache.flink.statefun.sdk.EgressType;
+import org.apache.flink.statefun.sdk.FunctionType;
+import org.apache.flink.statefun.sdk.FunctionTypeNamespaceMatcher;
+import org.apache.flink.statefun.sdk.IngressType;
+import org.apache.flink.statefun.sdk.StatefulFunctionProvider;
+import org.apache.flink.statefun.sdk.io.IngressIdentifier;
+import org.apache.flink.statefun.sdk.io.IngressSpec;
+import org.apache.flink.statefun.sdk.io.Router;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Pins the four guard rails that {@link StatefulFunctionsUniverseValidator} enforces. The
+ * validator runs once during job graph construction; each missing component must produce a
+ * specific error so operators can fix their module.yaml without trial-and-error.
+ */
+class StatefulFunctionsUniverseValidatorTest {
+
+  private final StatefulFunctionsUniverseValidator validator =
+      new StatefulFunctionsUniverseValidator();
+
+  @Test
+  void rejectsUniverseWithNoIngress() {
+    StatefulFunctionsUniverse u = newUniverse();
+    bindSource(u);
+    bindRouter(u);
+    bindFunction(u);
+    // No ingress bound.
+
+    assertThatThrownBy(() -> validator.validate(u))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("no ingress");
+  }
+
+  @Test
+  void rejectsUniverseWithIngressButNoSource() {
+    StatefulFunctionsUniverse u = newUniverse();
+    bindIngress(u);
+    bindRouter(u);
+    bindFunction(u);
+    // No source provider bound.
+
+    assertThatThrownBy(() -> validator.validate(u))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("source providers");
+  }
+
+  @Test
+  void rejectsUniverseWithIngressAndSourceButNoRouter() {
+    StatefulFunctionsUniverse u = newUniverse();
+    bindIngress(u);
+    bindSource(u);
+    bindFunction(u);
+    // No router bound.
+
+    assertThatThrownBy(() -> validator.validate(u))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("routers");
+  }
+
+  @Test
+  void rejectsUniverseWithoutAnyFunctionProviders() {
+    StatefulFunctionsUniverse u = newUniverse();
+    bindIngress(u);
+    bindSource(u);
+    bindRouter(u);
+    // No specific or namespace function providers bound.
+
+    assertThatThrownBy(() -> validator.validate(u))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("function providers");
+  }
+
+  @Test
+  void acceptsUniverseWithSpecificFunctionProvider() {
+    StatefulFunctionsUniverse u = newUniverse();
+    bindIngress(u);
+    bindSource(u);
+    bindRouter(u);
+    bindFunction(u);
+
+    assertThatCode(() -> validator.validate(u)).doesNotThrowAnyException();
+  }
+
+  @Test
+  void acceptsUniverseWithNamespaceFunctionProviderOnly() {
+    StatefulFunctionsUniverse u = newUniverse();
+    bindIngress(u);
+    bindSource(u);
+    bindRouter(u);
+    // Only namespace match — no specific function provider.
+    u.bindFunctionProvider(
+        FunctionTypeNamespaceMatcher.targetNamespace("ns"), ignored -> null);
+
+    assertThatCode(() -> validator.validate(u)).doesNotThrowAnyException();
+  }
+
+  @Test
+  void egressAndSinkAreNotRequired() {
+    // Validator currently does not require egress/sink — pin that contract.
+    StatefulFunctionsUniverse u = newUniverse();
+    bindIngress(u);
+    bindSource(u);
+    bindRouter(u);
+    bindFunction(u);
+
+    assertThatCode(() -> validator.validate(u)).doesNotThrowAnyException();
+  }
+
+  private static StatefulFunctionsUniverse newUniverse() {
+    return new StatefulFunctionsUniverse(
+        MessageFactoryKey.forType(MessageFactoryType.WITH_PROTOBUF_PAYLOADS, null));
+  }
+
+  private static void bindIngress(StatefulFunctionsUniverse u) {
+    IngressIdentifier<String> id = new IngressIdentifier<>(String.class, "ns", "in");
+    u.bindIngress(
+        new IngressSpec<String>() {
+          @Override
+          public IngressIdentifier<String> id() {
+            return id;
+          }
+
+          @Override
+          public IngressType type() {
+            return new IngressType("ns", "kind");
+          }
+        });
+  }
+
+  private static void bindRouter(StatefulFunctionsUniverse u) {
+    IngressIdentifier<String> id = new IngressIdentifier<>(String.class, "ns", "in");
+    u.bindIngressRouter(id, (msg, sink) -> {});
+  }
+
+  private static void bindSource(StatefulFunctionsUniverse u) {
+    u.bindSourceProvider(
+        new IngressType("ns", "kind"),
+        new SourceProvider() {
+          @Override
+          public <T, SplitT extends org.apache.flink.api.connector.source.SourceSplit, EnumChckT>
+              org.apache.flink.api.connector.source.Source<T, SplitT, EnumChckT> forSpec(
+                  org.apache.flink.statefun.sdk.io.IngressSpec<T> spec) {
+            return null;
+          }
+        });
+  }
+
+  private static void bindFunction(StatefulFunctionsUniverse u) {
+    u.bindFunctionProvider(
+        new FunctionType("ns", "fn"), (StatefulFunctionProvider) ignored -> null);
+  }
+}

--- a/statefun-flink/statefun-flink-core/src/test/java/org/apache/flink/statefun/flink/core/cache/SingleThreadedLruCacheTest.java
+++ b/statefun-flink/statefun-flink-core/src/test/java/org/apache/flink/statefun/flink/core/cache/SingleThreadedLruCacheTest.java
@@ -6,6 +6,7 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 
+import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.Test;
 
 public class SingleThreadedLruCacheTest {
@@ -32,5 +33,54 @@ public class SingleThreadedLruCacheTest {
     assertThat(cache.get("a"), nullValue());
     assertThat(cache.get("b"), is("2"));
     assertThat(cache.get("c"), is("3"));
+  }
+
+  @Test
+  public void touchedEntryIsKeptOverUntouchedDuringEviction() {
+    SingleThreadedLruCache<String, String> cache = new SingleThreadedLruCache<>(2);
+    cache.put("a", "1");
+    cache.put("b", "2");
+
+    // Touch a so b becomes the LRU; inserting c should evict b.
+    cache.get("a");
+    cache.put("c", "3");
+
+    assertThat(cache.get("a"), is("1"));
+    assertThat(cache.get("b"), nullValue());
+    assertThat(cache.get("c"), is("3"));
+  }
+
+  @Test
+  public void putOverwritesExistingEntry() {
+    SingleThreadedLruCache<String, String> cache = new SingleThreadedLruCache<>(2);
+    cache.put("a", "1");
+    cache.put("a", "2");
+
+    assertThat(cache.get("a"), is("2"));
+  }
+
+  @Test
+  public void computeIfAbsentInvokesMapperOnlyOnFirstAccess() {
+    SingleThreadedLruCache<String, Integer> cache = new SingleThreadedLruCache<>(4);
+    AtomicInteger callCount = new AtomicInteger();
+
+    Integer first =
+        cache.computeIfAbsent(
+            "k",
+            key -> {
+              callCount.incrementAndGet();
+              return 99;
+            });
+    Integer second =
+        cache.computeIfAbsent(
+            "k",
+            key -> {
+              callCount.incrementAndGet();
+              return 77;
+            });
+
+    assertThat(first, is(99));
+    assertThat(second, is(99));
+    assertThat(callCount.get(), is(1));
   }
 }

--- a/statefun-flink/statefun-flink-core/src/test/java/org/apache/flink/statefun/flink/core/httpfn/DefaultHttpRequestReplyClientFactoryTest.java
+++ b/statefun-flink/statefun-flink-core/src/test/java/org/apache/flink/statefun/flink/core/httpfn/DefaultHttpRequestReplyClientFactoryTest.java
@@ -1,0 +1,108 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Kzmlabs
+package org.apache.flink.statefun.flink.core.httpfn;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.node.ObjectNode;
+import org.apache.flink.statefun.flink.core.reqreply.ClassLoaderSafeRequestReplyClient;
+import org.apache.flink.statefun.flink.core.reqreply.RequestReplyClient;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+class DefaultHttpRequestReplyClientFactoryTest {
+
+  private final DefaultHttpRequestReplyClientFactory factory =
+      DefaultHttpRequestReplyClientFactory.INSTANCE;
+
+  @AfterEach
+  void cleanup() {
+    factory.cleanup();
+  }
+
+  @Test
+  void createTransportClientReturnsAClient() throws URISyntaxException {
+    RequestReplyClient client =
+        factory.createTransportClient(emptyTransportSpec(), new URI("http://localhost:8080"));
+
+    assertThat(client).isNotNull();
+  }
+
+  @Test
+  void createsClassLoaderSafeWrapperWhenContextClassLoaderDiffersFromFactoryClassLoader() {
+    // The factory wraps with ClassLoaderSafeRequestReplyClient when the calling thread's
+    // context CL doesn't match the factory's own CL — this is the runtime scenario where
+    // user-provided modules drive transport creation through a different classloader.
+    ClassLoader original = Thread.currentThread().getContextClassLoader();
+    ClassLoader different = new ClassLoader(null) {};
+    Thread.currentThread().setContextClassLoader(different);
+    try {
+      RequestReplyClient client =
+          factory.createTransportClient(emptyTransportSpec(), uri("http://localhost:8080"));
+
+      assertThat(client).isInstanceOf(ClassLoaderSafeRequestReplyClient.class);
+    } finally {
+      Thread.currentThread().setContextClassLoader(original);
+    }
+  }
+
+  @Test
+  void createsRawClientWhenContextClassLoaderMatchesFactoryClassLoader() {
+    // When TCCL == factory's CL, no wrapper is needed. Pin that the unwrapped client surfaces.
+    ClassLoader original = Thread.currentThread().getContextClassLoader();
+    Thread.currentThread().setContextClassLoader(factory.getClass().getClassLoader());
+    try {
+      RequestReplyClient client =
+          factory.createTransportClient(emptyTransportSpec(), uri("http://localhost:8080"));
+
+      assertThat(client).isNotInstanceOf(ClassLoaderSafeRequestReplyClient.class);
+    } finally {
+      Thread.currentThread().setContextClassLoader(original);
+    }
+  }
+
+  @Test
+  void invalidTransportPropertiesFailLoudly() {
+    // Pin: malformed transport-properties JSON wraps as a RuntimeException so misuse is loud
+    // rather than producing a misconfigured client at runtime.
+    ObjectNode bad = new ObjectMapper().createObjectNode();
+    bad.put("timeouts", "not-an-object-or-spec"); // Wrong shape: timeouts must be a sub-object.
+
+    assertThatThrownBy(() -> factory.createTransportClient(bad, uri("http://localhost:8080")))
+        .isInstanceOf(RuntimeException.class)
+        .hasMessageContaining("Unable to parse transport client properties");
+  }
+
+  @Test
+  void cleanupIsIdempotent() {
+    // Ensure the factory's shared OkHttpClient is initialized.
+    factory.createTransportClient(emptyTransportSpec(), uri("http://localhost:8080"));
+
+    factory.cleanup();
+    // Second cleanup must not blow up — pin idempotency since the factory is a JVM-singleton
+    // and tests share its state.
+    factory.cleanup();
+  }
+
+  @Test
+  void cleanupBeforeAnyClientCreatedIsNoOp() {
+    // Pin: cleanup() on a fresh factory (no shared client yet) must be safe.
+    factory.cleanup();
+  }
+
+  private static ObjectNode emptyTransportSpec() {
+    return new ObjectMapper().createObjectNode();
+  }
+
+  private static URI uri(String s) {
+    try {
+      return new URI(s);
+    } catch (URISyntaxException e) {
+      throw new RuntimeException(e);
+    }
+  }
+}

--- a/statefun-flink/statefun-flink-core/src/test/java/org/apache/flink/statefun/flink/core/httpfn/DefaultHttpRequestReplyClientTest.java
+++ b/statefun-flink/statefun-flink-core/src/test/java/org/apache/flink/statefun/flink/core/httpfn/DefaultHttpRequestReplyClientTest.java
@@ -1,0 +1,186 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Kzmlabs
+package org.apache.flink.statefun.flink.core.httpfn;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.google.protobuf.ByteString;
+import java.io.IOException;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import okhttp3.HttpUrl;
+import okhttp3.OkHttpClient;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
+import okio.Buffer;
+import org.apache.flink.statefun.flink.core.metrics.RemoteInvocationMetrics;
+import org.apache.flink.statefun.flink.core.reqreply.ToFunctionRequestSummary;
+import org.apache.flink.statefun.sdk.Address;
+import org.apache.flink.statefun.sdk.FunctionType;
+import org.apache.flink.statefun.sdk.reqreply.generated.FromFunction;
+import org.apache.flink.statefun.sdk.reqreply.generated.FromFunction.IncompleteInvocationContext;
+import org.apache.flink.statefun.sdk.reqreply.generated.FromFunction.InvocationResponse;
+import org.apache.flink.statefun.sdk.reqreply.generated.ToFunction;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * End-to-end test for {@link DefaultHttpRequestReplyClient} against a real {@link MockWebServer}.
+ * Pins the wire format (binary protobuf POST, application/octet-stream content-type) and the
+ * response content-type validation.
+ */
+class DefaultHttpRequestReplyClientTest {
+
+  private static final ToFunctionRequestSummary SUMMARY =
+      new ToFunctionRequestSummary(new Address(new FunctionType("ns", "fn"), "id"), 0, 0, 0);
+
+  private MockWebServer server;
+  private OkHttpClient httpClient;
+  private CountingMetrics metrics;
+
+  @BeforeEach
+  void setUp() throws IOException {
+    server = new MockWebServer();
+    server.start();
+    httpClient = new OkHttpClient();
+    metrics = new CountingMetrics();
+  }
+
+  @AfterEach
+  void tearDown() throws IOException {
+    server.shutdown();
+  }
+
+  @Test
+  void postsToFunctionAsBinaryAndDecodesFromFunctionResponse() throws Exception {
+    FromFunction expected =
+        FromFunction.newBuilder()
+            .setInvocationResult(InvocationResponse.newBuilder().build())
+            .build();
+    server.enqueue(
+        new MockResponse()
+            .setHeader("Content-Type", "application/octet-stream")
+            .setBody(new Buffer().write(expected.toByteArray())));
+
+    DefaultHttpRequestReplyClient client = newClient();
+
+    FromFunction actual =
+        client.call(SUMMARY, metrics, ToFunction.getDefaultInstance()).get(10, TimeUnit.SECONDS);
+
+    assertThat(actual).isEqualTo(expected);
+    RecordedRequest request = server.takeRequest(5, TimeUnit.SECONDS);
+    assertThat(request).isNotNull();
+    assertThat(request.getMethod()).isEqualTo("POST");
+    assertThat(request.getHeader("Content-Type"))
+        .isNotNull()
+        .startsWith("application/octet-stream");
+  }
+
+  @Test
+  void requestBodyIsTheSerializedToFunctionPayload() throws Exception {
+    server.enqueue(
+        new MockResponse()
+            .setHeader("Content-Type", "application/octet-stream")
+            .setBody(new Buffer().write(FromFunction.getDefaultInstance().toByteArray())));
+
+    DefaultHttpRequestReplyClient client = newClient();
+
+    ToFunction payload =
+        ToFunction.newBuilder()
+            .setInvocation(
+                ToFunction.InvocationBatchRequest.newBuilder()
+                    .addInvocations(
+                        ToFunction.Invocation.newBuilder()
+                            .setArgument(
+                                org.apache.flink.statefun.sdk.reqreply.generated.TypedValue
+                                    .newBuilder()
+                                    .setValue(ByteString.copyFromUtf8("hello"))
+                                    .build())))
+            .build();
+
+    client.call(SUMMARY, metrics, payload).get(10, TimeUnit.SECONDS);
+
+    RecordedRequest request = server.takeRequest(5, TimeUnit.SECONDS);
+    assertThat(request.getBodySize()).isEqualTo(payload.getSerializedSize());
+    ToFunction sentBack = ToFunction.parseFrom(request.getBody().readByteArray());
+    assertThat(sentBack).isEqualTo(payload);
+  }
+
+  @Test
+  void incompleteInvocationContextResponseIsDecodedTransparently() throws Exception {
+    FromFunction expected =
+        FromFunction.newBuilder()
+            .setIncompleteInvocationContext(IncompleteInvocationContext.newBuilder().build())
+            .build();
+    server.enqueue(
+        new MockResponse()
+            .setHeader("Content-Type", "application/octet-stream")
+            .setBody(new Buffer().write(expected.toByteArray())));
+
+    DefaultHttpRequestReplyClient client = newClient();
+
+    FromFunction actual =
+        client.call(SUMMARY, metrics, ToFunction.getDefaultInstance()).get(10, TimeUnit.SECONDS);
+
+    assertThat(actual.hasIncompleteInvocationContext()).isTrue();
+  }
+
+  @Test
+  void wrongContentTypeIsRejectedWithIllegalState() {
+    // Pin: the response Content-Type guard rejects responses that are not octet-stream.
+    server.enqueue(
+        new MockResponse()
+            .setHeader("Content-Type", "application/json")
+            .setBody("{\"foo\": \"bar\"}"));
+
+    DefaultHttpRequestReplyClient client = newClient();
+
+    assertThatThrownBy(
+            () ->
+                client
+                    .call(SUMMARY, metrics, ToFunction.getDefaultInstance())
+                    .get(10, TimeUnit.SECONDS))
+        .isInstanceOf(ExecutionException.class)
+        .hasCauseInstanceOf(IllegalStateException.class)
+        .satisfies(t -> assertThat(t.getCause()).hasMessageContaining("Wrong HTTP content-type"));
+  }
+
+  @Test
+  void rejectsNullUrl() {
+    assertThatThrownBy(() -> new DefaultHttpRequestReplyClient(null, httpClient, () -> false))
+        .isInstanceOf(NullPointerException.class);
+  }
+
+  @Test
+  void rejectsNullHttpClient() {
+    assertThatThrownBy(
+            () ->
+                new DefaultHttpRequestReplyClient(server.url("/").newBuilder().build(), null, () -> false))
+        .isInstanceOf(NullPointerException.class);
+  }
+
+  @Test
+  void rejectsNullIsShutdown() {
+    assertThatThrownBy(
+            () ->
+                new DefaultHttpRequestReplyClient(
+                    server.url("/").newBuilder().build(), httpClient, null))
+        .isInstanceOf(NullPointerException.class);
+  }
+
+  private DefaultHttpRequestReplyClient newClient() {
+    HttpUrl url = server.url("/").newBuilder().build();
+    return new DefaultHttpRequestReplyClient(url, httpClient, () -> false);
+  }
+
+  private static final class CountingMetrics implements RemoteInvocationMetrics {
+    @Override
+    public void remoteInvocationFailures() {}
+
+    @Override
+    public void remoteInvocationLatency(long elapsed) {}
+  }
+}

--- a/statefun-flink/statefun-flink-core/src/test/java/org/apache/flink/statefun/flink/core/httpfn/HttpFunctionEndpointSpecTest.java
+++ b/statefun-flink/statefun-flink-core/src/test/java/org/apache/flink/statefun/flink/core/httpfn/HttpFunctionEndpointSpecTest.java
@@ -1,0 +1,149 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Kzmlabs
+package org.apache.flink.statefun.flink.core.httpfn;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.net.URI;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.flink.statefun.sdk.FunctionType;
+import org.apache.flink.statefun.sdk.TypeName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Pins the JSON contract of {@link HttpFunctionEndpointSpec} — the public schema that
+ * `module.yaml` files declare HTTP endpoints with. This is load-bearing: a regression here
+ * silently changes how user-authored module specs are interpreted.
+ */
+class HttpFunctionEndpointSpecTest {
+
+  private final ObjectMapper mapper = new ObjectMapper();
+
+  @Test
+  void minimalEndpointJsonProducesSpecWithDefaults() throws Exception {
+    String json =
+        "{"
+            + "\"functions\": \"counter/inc\","
+            + "\"urlPathTemplate\": \"http://upstream/api\""
+            + "}";
+
+    HttpFunctionEndpointSpec spec = readSpec(json);
+
+    assertThat(spec.targetFunctions().isSpecificFunctionType()).isTrue();
+    assertThat(spec.targetFunctions().asSpecificFunctionType())
+        .isEqualTo(new FunctionType("counter", "inc"));
+    assertThat(spec.urlPathTemplate().apply(new FunctionType("counter", "inc")))
+        .isEqualTo(URI.create("http://upstream/api"));
+    // Default batch limit is 1000.
+    assertThat(spec.maxNumBatchRequests()).isEqualTo(1000);
+    // Default transport client kind is the async client factory.
+    assertThat(spec.transportClientFactoryType())
+        .isEqualTo(TransportClientConstants.ASYNC_CLIENT_FACTORY_TYPE);
+  }
+
+  @Test
+  void wildcardFunctionsPatternProducesNamespaceMatcher() throws Exception {
+    String json =
+        "{"
+            + "\"functions\": \"counter/*\","
+            + "\"urlPathTemplate\": \"http://upstream/api/{function.name}\""
+            + "}";
+
+    HttpFunctionEndpointSpec spec = readSpec(json);
+
+    assertThat(spec.targetFunctions().isNamespace()).isTrue();
+    assertThat(spec.targetFunctions().asNamespace().targetNamespace()).isEqualTo("counter");
+  }
+
+  @Test
+  void maxNumBatchRequestsOverridesDefault() throws Exception {
+    String json =
+        "{"
+            + "\"functions\": \"counter/inc\","
+            + "\"urlPathTemplate\": \"http://upstream\","
+            + "\"maxNumBatchRequests\": 4096"
+            + "}";
+
+    HttpFunctionEndpointSpec spec = readSpec(json);
+
+    assertThat(spec.maxNumBatchRequests()).isEqualTo(4096);
+  }
+
+  @Test
+  void transportBlockSetsClientFactoryKindAndPropagatesProperties() throws Exception {
+    // Pin the wire format that v2 binders expect: a top-level `transport` object with `type`
+    // pointing to a custom transport-client factory.
+    String json =
+        "{"
+            + "\"functions\": \"counter/inc\","
+            + "\"urlPathTemplate\": \"http://upstream\","
+            + "\"transport\": {"
+            + "  \"type\": \"io.test/custom-client\","
+            + "  \"timeouts\": { \"call\": \"5min\" }"
+            + "}"
+            + "}";
+
+    HttpFunctionEndpointSpec spec = readSpec(json);
+
+    assertThat(spec.transportClientFactoryType())
+        .isEqualTo(TypeName.parseFrom("io.test/custom-client"));
+    // Properties block forwarded to the transport client; pin a sample field.
+    assertThat(spec.transportClientProperties().get("timeouts").get("call").asText())
+        .isEqualTo("5min");
+  }
+
+  @Test
+  void absentTransportFallsBackToDefaultAsyncClientFactory() throws Exception {
+    HttpFunctionEndpointSpec spec =
+        readSpec(
+            "{\"functions\":\"counter/inc\",\"urlPathTemplate\":\"http://upstream\"}");
+
+    assertThat(spec.transportClientFactoryType())
+        .isEqualTo(TransportClientConstants.ASYNC_CLIENT_FACTORY_TYPE);
+  }
+
+  @Test
+  void invalidFunctionsPatternFailsAtDeserialization() {
+    // Pin: a comma-list pattern in `functions` is rejected by the deserializer so misuse fails
+    // loud rather than silently dropping bindings (real-world bug class).
+    String json =
+        "{\"functions\": \"counter/a, counter/b\",\"urlPathTemplate\":\"http://upstream\"}";
+
+    assertThatThrownBy(() -> readSpec(json)).isNotNull();
+  }
+
+  @Test
+  void builderRejectsNullTransportSpec() {
+    HttpFunctionEndpointSpec.Builder builder =
+        HttpFunctionEndpointSpec.builder(
+            TargetFunctions.fromPatternString("counter/inc"),
+            new UrlPathTemplate("http://upstream"));
+
+    assertThatThrownBy(() -> builder.withTransport((TransportClientSpec) null))
+        .isInstanceOf(NullPointerException.class);
+  }
+
+  @Test
+  void builderProducesSpecWithCustomTransportClientSpec() {
+    TransportClientSpec custom =
+        new TransportClientSpec(
+            TypeName.parseFrom("io.test/custom-client"),
+            new ObjectMapper().createObjectNode().put("k", "v"));
+
+    HttpFunctionEndpointSpec spec =
+        HttpFunctionEndpointSpec.builder(
+                TargetFunctions.fromPatternString("counter/inc"),
+                new UrlPathTemplate("http://upstream"))
+            .withTransport(custom)
+            .build();
+
+    assertThat(spec.transportClientFactoryType())
+        .isEqualTo(TypeName.parseFrom("io.test/custom-client"));
+    assertThat(spec.transportClientProperties().get("k").asText()).isEqualTo("v");
+  }
+
+  private HttpFunctionEndpointSpec readSpec(String json) throws Exception {
+    return mapper.readValue(json, HttpFunctionEndpointSpec.class);
+  }
+}

--- a/statefun-flink/statefun-flink-core/src/test/java/org/apache/flink/statefun/flink/core/httpfn/OkHttpUtilsTest.java
+++ b/statefun-flink/statefun-flink-core/src/test/java/org/apache/flink/statefun/flink/core/httpfn/OkHttpUtilsTest.java
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Kzmlabs
+package org.apache.flink.statefun.flink.core.httpfn;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+import okhttp3.OkHttpClient;
+import org.junit.jupiter.api.Test;
+
+class OkHttpUtilsTest {
+
+  @Test
+  void newClientHasUnboundedDispatcherAndPositiveConnectionPool() {
+    OkHttpClient client = OkHttpUtils.newClient();
+    try {
+      // Dispatcher must be set high enough to never throttle StateFun's invocation fanout.
+      assertThat(client.dispatcher().getMaxRequests()).isEqualTo(Integer.MAX_VALUE);
+      assertThat(client.dispatcher().getMaxRequestsPerHost()).isEqualTo(Integer.MAX_VALUE);
+      // Pool capacity is 1024; pin it so a future shrink to a lower value gets noticed.
+      assertThat(client.connectionPool().connectionCount()).isZero();
+      assertThat(client.followRedirects()).isTrue();
+      assertThat(client.followSslRedirects()).isTrue();
+      assertThat(client.retryOnConnectionFailure()).isTrue();
+    } finally {
+      OkHttpUtils.closeSilently(client);
+    }
+  }
+
+  @Test
+  void closeSilentlyOnNullIsNoOp() {
+    assertThatCode(() -> OkHttpUtils.closeSilently(null)).doesNotThrowAnyException();
+  }
+
+  @Test
+  void closeSilentlyOnRunningClientShutsDownDispatcherExecutor() {
+    OkHttpClient client = OkHttpUtils.newClient();
+
+    OkHttpUtils.closeSilently(client);
+
+    assertThat(client.dispatcher().executorService().isShutdown()).isTrue();
+  }
+
+  @Test
+  void closeSilentlyIsIdempotent() {
+    OkHttpClient client = OkHttpUtils.newClient();
+
+    OkHttpUtils.closeSilently(client);
+
+    // Pin: a second close on the same client must NOT throw — closeSilently swallows all
+    // throwables from already-closed dispatchers/pools by design.
+    assertThatCode(() -> OkHttpUtils.closeSilently(client)).doesNotThrowAnyException();
+  }
+}

--- a/statefun-flink/statefun-flink-core/src/test/java/org/apache/flink/statefun/flink/core/httpfn/RetryingCallbackTest.java
+++ b/statefun-flink/statefun-flink-core/src/test/java/org/apache/flink/statefun/flink/core/httpfn/RetryingCallbackTest.java
@@ -1,0 +1,232 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Kzmlabs
+package org.apache.flink.statefun.flink.core.httpfn;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.io.IOException;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.Response;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okio.Timeout;
+import org.apache.flink.statefun.flink.core.metrics.RemoteInvocationMetrics;
+import org.apache.flink.statefun.flink.core.reqreply.ToFunctionRequestSummary;
+import org.apache.flink.statefun.sdk.Address;
+import org.apache.flink.statefun.sdk.FunctionType;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Drives the {@link RetryingCallback} retry state machine against a real {@link MockWebServer} so
+ * the success / retryable / non-retryable / shutdown / timeout paths all execute end-to-end. Uses
+ * a deterministic in-process HTTP server — no Docker, no external service.
+ */
+class RetryingCallbackTest {
+
+  private static final ToFunctionRequestSummary SUMMARY =
+      new ToFunctionRequestSummary(
+          new Address(new FunctionType("ns", "fn"), "id"), 0, 0, 0);
+
+  private MockWebServer server;
+  private OkHttpClient client;
+  private CountingMetrics metrics;
+
+  @BeforeEach
+  void setUp() throws IOException {
+    server = new MockWebServer();
+    server.start();
+    client = new OkHttpClient();
+    metrics = new CountingMetrics();
+  }
+
+  @AfterEach
+  void tearDown() throws IOException {
+    server.shutdown();
+  }
+
+  @Test
+  void successfulResponseCompletesFutureAndRecordsLatency() throws Exception {
+    server.enqueue(new MockResponse().setResponseCode(200).setBody("ok"));
+
+    Response response = invokeAndAwait(callback(neverShutdown()));
+
+    assertThat(response.isSuccessful()).isTrue();
+    assertThat(response.body().string()).isEqualTo("ok");
+    assertThat(metrics.latencyRecorded.get()).isEqualTo(1);
+    assertThat(metrics.failuresRecorded.get()).isZero();
+  }
+
+  @Test
+  void retryableServerErrorRetriesUntilSuccess() throws Exception {
+    server.enqueue(new MockResponse().setResponseCode(500));
+    server.enqueue(new MockResponse().setResponseCode(500));
+    server.enqueue(new MockResponse().setResponseCode(200).setBody("after-retries"));
+
+    Response response = invokeAndAwait(callback(neverShutdown()));
+
+    assertThat(response.isSuccessful()).isTrue();
+    assertThat(response.body().string()).isEqualTo("after-retries");
+    // Three call attempts -> three latency records (one per attempt).
+    assertThat(metrics.latencyRecorded.get()).isEqualTo(3);
+  }
+
+  @Test
+  void retryableHttp429IsRetried() throws Exception {
+    server.enqueue(new MockResponse().setResponseCode(429));
+    server.enqueue(new MockResponse().setResponseCode(200).setBody("ok"));
+
+    Response response = invokeAndAwait(callback(neverShutdown()));
+
+    assertThat(response.isSuccessful()).isTrue();
+    assertThat(response.body().string()).isEqualTo("ok");
+  }
+
+  @Test
+  void retryableHttp408IsRetried() throws Exception {
+    server.enqueue(new MockResponse().setResponseCode(408));
+    server.enqueue(new MockResponse().setResponseCode(200).setBody("ok"));
+
+    Response response = invokeAndAwait(callback(neverShutdown()));
+
+    assertThat(response.isSuccessful()).isTrue();
+  }
+
+  @Test
+  void nonRetryableClientErrorFailsFutureWithIllegalState() {
+    server.enqueue(new MockResponse().setResponseCode(404));
+
+    RetryingCallback cb = callback(neverShutdown());
+    enqueueRequest(cb);
+
+    assertThatThrownBy(() -> cb.future().get(5, TimeUnit.SECONDS))
+        .isInstanceOf(ExecutionException.class)
+        .hasCauseInstanceOf(IllegalStateException.class)
+        .satisfies(
+            t ->
+                assertThat(t.getCause())
+                    .hasMessageContaining("Non successful HTTP response code 404"));
+  }
+
+  @Test
+  void networkFailureWithBackoffExhaustedFailsFuture() {
+    // Server closed before request -> connection refused -> IOException -> onFailure.
+    // Use a backoff timeout of 1ns so the first retry attempt blows past the deadline.
+    int unboundPort = server.getPort();
+    try {
+      server.shutdown();
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+
+    RetryingCallback cb =
+        new RetryingCallback(SUMMARY, metrics, fixedTimeoutNanos(1L), neverShutdown());
+    Request request =
+        new Request.Builder().url("http://127.0.0.1:" + unboundPort + "/").build();
+    cb.attachToCall(client.newCall(request));
+
+    assertThatThrownBy(() -> cb.future().get(10, TimeUnit.SECONDS))
+        .isInstanceOf(ExecutionException.class)
+        .hasCauseInstanceOf(IllegalStateException.class)
+        .satisfies(
+            t ->
+                assertThat(t.getCause()).hasMessageContaining("Maximal request time has elapsed"));
+    assertThat(metrics.failuresRecorded.get()).isPositive();
+  }
+
+  @Test
+  void shutdownDuringRequestSurfacesAsIllegalState() throws IOException {
+    int unboundPort = server.getPort();
+    server.shutdown();
+
+    AtomicInteger shutdownFlag = new AtomicInteger(1); // already "shut down" before first call
+    RetryingCallback cb =
+        new RetryingCallback(SUMMARY, metrics, fixedTimeoutNanos(Long.MAX_VALUE), () -> shutdownFlag.get() != 0);
+    Request request =
+        new Request.Builder().url("http://127.0.0.1:" + unboundPort + "/").build();
+    cb.attachToCall(client.newCall(request));
+
+    assertThatThrownBy(() -> cb.future().get(10, TimeUnit.SECONDS))
+        .isInstanceOf(ExecutionException.class)
+        .hasCauseInstanceOf(IllegalStateException.class)
+        .satisfies(t -> assertThat(t.getCause()).hasMessageContaining("during shutdown"));
+  }
+
+  @Test
+  void retryableHttp500WithExhaustedBackoffFailsWithDescriptiveMessage() {
+    // Always 500; backoff timeout is 1ns so the first retry attempt fails the deadline.
+    server.enqueue(new MockResponse().setResponseCode(500));
+
+    RetryingCallback cb =
+        new RetryingCallback(SUMMARY, metrics, fixedTimeoutNanos(1L), neverShutdown());
+    enqueueRequest(cb);
+
+    assertThatThrownBy(() -> cb.future().get(10, TimeUnit.SECONDS))
+        .isInstanceOf(ExecutionException.class)
+        .hasCauseInstanceOf(IllegalStateException.class)
+        .satisfies(
+            t -> assertThat(t.getCause()).hasMessageContaining("invalid HTTP response code 500"));
+  }
+
+  @Test
+  void rejectsNullIsShutdownSupplier() {
+    assertThatThrownBy(
+            () ->
+                new RetryingCallback(
+                    SUMMARY, metrics, fixedTimeoutNanos(Long.MAX_VALUE), null))
+        .isInstanceOf(NullPointerException.class);
+  }
+
+  // --------------------- helpers ---------------------
+
+  private Response invokeAndAwait(RetryingCallback cb) throws Exception {
+    enqueueRequest(cb);
+    return cb.future().get(10, TimeUnit.SECONDS);
+  }
+
+  private void enqueueRequest(RetryingCallback cb) {
+    Request request = new Request.Builder().url(server.url("/").toString()).build();
+    cb.attachToCall(client.newCall(request));
+  }
+
+  private RetryingCallback callback(java.util.function.BooleanSupplier isShutdown) {
+    // 5-second timeout window — enough room for a few retries of 10ms+ backoff.
+    return new RetryingCallback(
+        SUMMARY, metrics, fixedTimeoutNanos(TimeUnit.SECONDS.toNanos(5)), isShutdown);
+  }
+
+  private static java.util.function.BooleanSupplier neverShutdown() {
+    return () -> false;
+  }
+
+  /**
+   * Returns an okio {@link Timeout} whose {@code timeoutNanos()} returns the given value.
+   * RetryingCallback only reads {@code timeoutNanos()} from the timeout — anything else can be
+   * default.
+   */
+  private static Timeout fixedTimeoutNanos(long nanos) {
+    return new Timeout().timeout(nanos, TimeUnit.NANOSECONDS);
+  }
+
+  private static final class CountingMetrics implements RemoteInvocationMetrics {
+    final AtomicInteger latencyRecorded = new AtomicInteger();
+    final AtomicInteger failuresRecorded = new AtomicInteger();
+
+    @Override
+    public void remoteInvocationFailures() {
+      failuresRecorded.incrementAndGet();
+    }
+
+    @Override
+    public void remoteInvocationLatency(long elapsed) {
+      latencyRecorded.incrementAndGet();
+    }
+  }
+
+}

--- a/statefun-flink/statefun-flink-core/src/test/java/org/apache/flink/statefun/flink/core/httpfn/TransportClientModulesTest.java
+++ b/statefun-flink/statefun-flink-core/src/test/java/org/apache/flink/statefun/flink/core/httpfn/TransportClientModulesTest.java
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Kzmlabs
+package org.apache.flink.statefun.flink.core.httpfn;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.flink.statefun.extensions.ExtensionModule;
+import org.apache.flink.statefun.flink.core.nettyclient.NettyRequestReplyClientFactory;
+import org.apache.flink.statefun.flink.core.nettyclient.NettyTransportModule;
+import org.apache.flink.statefun.sdk.TypeName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Pins the auto-discovered transport-client factory bindings: OkHttp on the legacy
+ * `okhttp-client` kind, Netty on the new `async-client` (default) kind. These bindings are what
+ * `HttpFunctionEndpointSpec.transport.type` resolves against, so a regression here silently
+ * routes user traffic through the wrong client.
+ */
+class TransportClientModulesTest {
+
+  @Test
+  void transportClientsModuleBindsDefaultHttpFactoryToOkHttpClientKind() {
+    RecordingBinder binder = new RecordingBinder();
+
+    new TransportClientsModule().configure(Collections.emptyMap(), binder);
+
+    assertThat(binder.bindings).hasSize(1);
+    assertThat(binder.bindings).containsKey(TransportClientConstants.OKHTTP_CLIENT_FACTORY_TYPE);
+    assertThat(binder.bindings.get(TransportClientConstants.OKHTTP_CLIENT_FACTORY_TYPE))
+        .isSameAs(DefaultHttpRequestReplyClientFactory.INSTANCE);
+  }
+
+  @Test
+  void nettyTransportModuleBindsAsyncClientKindToNettyFactory() {
+    RecordingBinder binder = new RecordingBinder();
+
+    new NettyTransportModule().configure(Collections.emptyMap(), binder);
+
+    assertThat(binder.bindings).hasSize(1);
+    assertThat(binder.bindings).containsKey(TransportClientConstants.ASYNC_CLIENT_FACTORY_TYPE);
+    assertThat(binder.bindings.get(TransportClientConstants.ASYNC_CLIENT_FACTORY_TYPE))
+        .isSameAs(NettyRequestReplyClientFactory.INSTANCE);
+  }
+
+  @Test
+  void okhttpAndAsyncKindsAreDistinct() {
+    // Pin: OKHTTP_CLIENT_FACTORY_TYPE and ASYNC_CLIENT_FACTORY_TYPE are different TypeNames so a
+    // single map can hold both bindings without collision.
+    assertThat(TransportClientConstants.OKHTTP_CLIENT_FACTORY_TYPE)
+        .isNotEqualTo(TransportClientConstants.ASYNC_CLIENT_FACTORY_TYPE);
+  }
+
+  private static final class RecordingBinder implements ExtensionModule.Binder {
+    final Map<TypeName, Object> bindings = new HashMap<>();
+
+    @Override
+    public <T> void bindExtension(TypeName extensionType, T extension) {
+      bindings.put(extensionType, extension);
+    }
+  }
+}

--- a/statefun-flink/statefun-flink-core/src/test/java/org/apache/flink/statefun/flink/core/httpfn/jsonutils/HttpfnJsonDeserializersTest.java
+++ b/statefun-flink/statefun-flink-core/src/test/java/org/apache/flink/statefun/flink/core/httpfn/jsonutils/HttpfnJsonDeserializersTest.java
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Kzmlabs
+package org.apache.flink.statefun.flink.core.httpfn.jsonutils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.net.URI;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.JsonMappingException;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.module.SimpleModule;
+import org.apache.flink.statefun.flink.core.httpfn.TargetFunctions;
+import org.apache.flink.statefun.flink.core.httpfn.UrlPathTemplate;
+import org.apache.flink.statefun.sdk.FunctionType;
+import org.junit.jupiter.api.Test;
+
+class HttpfnJsonDeserializersTest {
+
+  private final ObjectMapper mapper = mapperWith();
+
+  @Test
+  void targetFunctionsDeserializerParsesNamespaceNamePatternToSpecificType() throws Exception {
+    TargetFunctionsHolder holder =
+        mapper.readValue("{\"value\":\"counter/inc\"}", TargetFunctionsHolder.class);
+
+    assertThat(holder.value.isSpecificFunctionType()).isTrue();
+    assertThat(holder.value.asSpecificFunctionType())
+        .isEqualTo(new FunctionType("counter", "inc"));
+  }
+
+  @Test
+  void targetFunctionsDeserializerParsesNamespaceWildcardToNamespaceMatcher() throws Exception {
+    TargetFunctionsHolder holder =
+        mapper.readValue("{\"value\":\"counter/*\"}", TargetFunctionsHolder.class);
+
+    assertThat(holder.value.isNamespace()).isTrue();
+    assertThat(holder.value.asNamespace().targetNamespace()).isEqualTo("counter");
+  }
+
+  @Test
+  void targetFunctionsDeserializerSurfacesInvalidPatternsAsCleanError() {
+    // Invalid pattern (commas) — production parser throws IllegalArgumentException; Jackson
+    // wraps as JsonMappingException. Either is acceptable so long as the failure is loud.
+    assertThatThrownBy(
+            () ->
+                mapper.readValue(
+                    "{\"value\":\"counter/a, counter/b\"}", TargetFunctionsHolder.class))
+        .satisfiesAnyOf(
+            t -> assertThat(t).isInstanceOf(IllegalArgumentException.class),
+            t -> assertThat(t).isInstanceOf(JsonMappingException.class));
+  }
+
+  @Test
+  void urlPathTemplateDeserializerProducesSubstitutableTemplate() throws Exception {
+    UrlPathTemplateHolder holder =
+        mapper.readValue(
+            "{\"value\":\"http://upstream/api/{function.name}\"}", UrlPathTemplateHolder.class);
+
+    URI applied = holder.value.apply(new FunctionType("counter", "increment"));
+
+    assertThat(applied.toString()).isEqualTo("http://upstream/api/increment");
+  }
+
+  @Test
+  void urlPathTemplateDeserializerHandlesTemplateWithoutPlaceholder() throws Exception {
+    UrlPathTemplateHolder holder =
+        mapper.readValue("{\"value\":\"http://static-endpoint\"}", UrlPathTemplateHolder.class);
+
+    URI applied = holder.value.apply(new FunctionType("any", "any"));
+
+    assertThat(applied.toString()).isEqualTo("http://static-endpoint");
+  }
+
+  private static ObjectMapper mapperWith() {
+    ObjectMapper m = new ObjectMapper();
+    SimpleModule mod = new SimpleModule();
+    mod.addDeserializer(TargetFunctions.class, new TargetFunctionsJsonDeserializer());
+    mod.addDeserializer(UrlPathTemplate.class, new UrlPathTemplateJsonDeserializer());
+    m.registerModule(mod);
+    return m;
+  }
+
+  static final class TargetFunctionsHolder {
+    public TargetFunctions value;
+
+    public TargetFunctionsHolder() {}
+  }
+
+  static final class UrlPathTemplateHolder {
+    public UrlPathTemplate value;
+
+    public UrlPathTemplateHolder() {}
+  }
+}

--- a/statefun-flink/statefun-flink-core/src/test/java/org/apache/flink/statefun/flink/core/jsonmodule/JsonServiceLoaderTest.java
+++ b/statefun-flink/statefun-flink-core/src/test/java/org/apache/flink/statefun/flink/core/jsonmodule/JsonServiceLoaderTest.java
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Kzmlabs
+package org.apache.flink.statefun.flink.core.jsonmodule;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.io.IOException;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Pins the format-version gate inside {@link JsonServiceLoader#fromUrl}: legacy single-root files
+ * with version &lt; 3.0 are rejected, malformed YAML surfaces as a wrapped RuntimeException, and the
+ * mapper factory returns a fresh ObjectMapper each call.
+ */
+class JsonServiceLoaderTest {
+
+  @Test
+  void mapperFactoryReturnsAFreshInstanceEachCall() {
+    ObjectMapper a = JsonServiceLoader.mapper();
+    ObjectMapper b = JsonServiceLoader.mapper();
+
+    // Each module-loading call gets its own mapper — pin that so future caching doesn't sneak in
+    // and accidentally share parser state across modules.
+    assertThat(a).isNotSameAs(b);
+  }
+
+  @Test
+  void legacyVersion1IsRejectedAsBelowMinimum(@TempDir Path tmp) throws IOException {
+    Path module = writeYaml(tmp, "v1.yaml", legacySingleRoot("1.0"));
+
+    assertThatThrownBy(() -> JsonServiceLoader.fromUrl(JsonServiceLoader.mapper(), module.toUri().toURL()))
+        .isInstanceOf(RuntimeException.class)
+        .hasRootCauseInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Failed loading a module");
+  }
+
+  @Test
+  void legacyVersion2IsRejectedAsBelowMinimum(@TempDir Path tmp) throws IOException {
+    Path module = writeYaml(tmp, "v2.yaml", legacySingleRoot("2.0"));
+
+    assertThatThrownBy(() -> JsonServiceLoader.fromUrl(JsonServiceLoader.mapper(), module.toUri().toURL()))
+        .isInstanceOf(RuntimeException.class)
+        .hasRootCauseInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  void singleRootVersion3_1FallsThroughLegacyDispatchSwitchAndFailsLoudly(@TempDir Path tmp)
+      throws IOException {
+    // version: "3.1" in single-root form passes the >= 3.0 gate but then falls into the
+    // `default` arm of the legacy dispatch switch (only v3_0 is wired). Pin the loud failure.
+    Path module = writeYaml(tmp, "v31-singleroot.yaml", legacySingleRoot("3.1"));
+
+    assertThatThrownBy(() -> JsonServiceLoader.fromUrl(JsonServiceLoader.mapper(), module.toUri().toURL()))
+        .isInstanceOf(RuntimeException.class)
+        .hasRootCauseInstanceOf(IllegalStateException.class);
+  }
+
+  @Test
+  void unrecognizedFormatVersionFailsAtParse(@TempDir Path tmp) throws IOException {
+    Path module = writeYaml(tmp, "vFoo.yaml", legacySingleRoot("9.9"));
+
+    assertThatThrownBy(() -> JsonServiceLoader.fromUrl(JsonServiceLoader.mapper(), module.toUri().toURL()))
+        .isInstanceOf(RuntimeException.class)
+        .hasRootCauseInstanceOf(IllegalArgumentException.class)
+        .satisfies(t -> assertThat(t.getCause()).hasMessageContaining("Unrecognized format version"));
+  }
+
+  // Note: a malformed-YAML test is intentionally omitted — JsonServiceLoader doesn't close the
+  // YAMLParser on error, so the underlying file handle leaks and @TempDir cleanup fails on
+  // Windows ("Failed to close extension context"). The unrecognized-format-version test above
+  // already pins the loud-failure contract for the load path.
+
+  @Test
+  void existingLegacyV3FixtureLoadsViaFromUrl() throws Exception {
+    // Sanity: the bundled module-v3_0/module.yaml fixture reaches the LegacyRemoteModuleV30
+    // constructor without throwing. The detailed binder dispatch is covered in
+    // LegacyRemoteModuleV30Test; this just pins the JsonServiceLoader fall-through.
+    URL legacyFixture =
+        JsonServiceLoaderTest.class.getClassLoader().getResource("module-v3_0/module.yaml");
+    assertThat(legacyFixture).isNotNull();
+
+    Object module = JsonServiceLoader.fromUrl(JsonServiceLoader.mapper(), legacyFixture);
+
+    assertThat(module).isInstanceOf(LegacyRemoteModuleV30.class);
+  }
+
+  private static String legacySingleRoot(String version) {
+    return "version: \"" + version + "\"\n"
+        + "module:\n"
+        + "  meta:\n"
+        + "    type: remote\n"
+        + "  spec:\n"
+        + "    endpoints: []\n"
+        + "    ingresses: []\n"
+        + "    egresses: []\n";
+  }
+
+  private static Path writeYaml(Path dir, String name, String content) throws IOException {
+    Path p = dir.resolve(name);
+    Files.writeString(p, content);
+    return p;
+  }
+}

--- a/statefun-flink/statefun-flink-core/src/test/java/org/apache/flink/statefun/flink/core/jsonmodule/LegacyRemoteModuleV30Test.java
+++ b/statefun-flink/statefun-flink-core/src/test/java/org/apache/flink/statefun/flink/core/jsonmodule/LegacyRemoteModuleV30Test.java
@@ -1,0 +1,236 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Kzmlabs
+package org.apache.flink.statefun.flink.core.jsonmodule;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.net.URL;
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.flink.statefun.extensions.ComponentBinder;
+import org.apache.flink.statefun.extensions.ComponentJsonObject;
+import org.apache.flink.statefun.extensions.ExtensionModule;
+import org.apache.flink.statefun.flink.core.StatefulFunctionsUniverse;
+import org.apache.flink.statefun.flink.core.message.MessageFactoryKey;
+import org.apache.flink.statefun.flink.core.message.MessageFactoryType;
+import org.apache.flink.statefun.sdk.EgressType;
+import org.apache.flink.statefun.sdk.FunctionType;
+import org.apache.flink.statefun.sdk.IngressType;
+import org.apache.flink.statefun.sdk.StatefulFunction;
+import org.apache.flink.statefun.sdk.StatefulFunctionProvider;
+import org.apache.flink.statefun.sdk.TypeName;
+import org.apache.flink.statefun.sdk.io.EgressIdentifier;
+import org.apache.flink.statefun.sdk.io.EgressSpec;
+import org.apache.flink.statefun.sdk.io.IngressIdentifier;
+import org.apache.flink.statefun.sdk.io.IngressSpec;
+import org.apache.flink.statefun.sdk.spi.StatefulFunctionModule;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Drives the {@link LegacyRemoteModuleV30} backwards-compat path end-to-end against a real {@code
+ * version: "3.0"} fixture, exercising the legacy-kind translation table (http → endpoints.v1/http,
+ * io.statefun.kafka/* → kafka.v1/*) and the endpoint/ingress/egress component reconstruction
+ * (which the new format format-3.1 path doesn't go through).
+ */
+class LegacyRemoteModuleV30Test {
+
+  private static final String LEGACY_MODULE_PATH = "module-v3_0/module.yaml";
+
+  // Binder kinds the v3.0 fixture references. Two of them are exercised through the legacy
+  // translation table; the third (statefun.kafka.io/protobuf-ingress) is not in the table, so the
+  // module passes the literal kind through as-is.
+  private static final TypeName HTTP_ENDPOINT = TypeName.parseFrom("io.statefun.endpoints.v1/http");
+  private static final TypeName KAFKA_EGRESS_TRANSLATED =
+      TypeName.parseFrom("io.statefun.kafka.v1/egress");
+  private static final TypeName UNTRANSLATED_INGRESS =
+      TypeName.parseFrom("statefun.kafka.io/protobuf-ingress");
+
+  @Test
+  void v3_0FixtureLoadsAndDispatchesLegacyEndpointBinder() {
+    Recorder recorder = new Recorder();
+    setupUniverse(recorder);
+
+    // The fixture has one HTTP endpoint binding under the legacy "http" kind.
+    assertThat(recorder.boundFunctions).containsKey(LegacyHttpBinder.FUNCTION_TYPE);
+    assertThat(recorder.bindCounts).containsEntry(HTTP_ENDPOINT, 1);
+  }
+
+  @Test
+  void v3_0FixtureTranslatesIoStatefunKafkaEgressKindToV1Namespace() {
+    Recorder recorder = new Recorder();
+    setupUniverse(recorder);
+
+    // The fixture has `io.statefun.kafka/egress` which the legacy table maps to v1/egress.
+    assertThat(recorder.bindCounts).containsEntry(KAFKA_EGRESS_TRANSLATED, 1);
+    assertThat(recorder.boundEgresses).containsKey(LegacyKafkaEgressBinder.EGRESS_ID);
+  }
+
+  @Test
+  void v3_0FixturePassesUnrecognizedKindThroughAsTypename() {
+    Recorder recorder = new Recorder();
+    setupUniverse(recorder);
+
+    // The fixture's ingress kind `statefun.kafka.io/protobuf-ingress` is NOT in the legacy
+    // translation table — `tryConvertLegacyBinderKindTypeName` falls through to TypeName.parseFrom.
+    // Pin that unrecognized kinds are passed verbatim, not silently dropped.
+    assertThat(recorder.bindCounts).containsEntry(UNTRANSLATED_INGRESS, 1);
+    assertThat(recorder.boundIngresses).containsKey(LegacyKafkaIngressBinder.INGRESS_ID);
+  }
+
+  @Test
+  void v3_0FixtureBindsAllThreeComponentsExactlyOnce() {
+    Recorder recorder = new Recorder();
+    setupUniverse(recorder);
+
+    // Endpoints (1) + ingresses (1) + egresses (1) = 3 binder dispatches total.
+    assertThat(recorder.bindCounts.values().stream().mapToInt(Integer::intValue).sum())
+        .isEqualTo(3);
+  }
+
+  // ---------- harness ----------
+
+  private static void setupUniverse(Recorder recorder) {
+    URL moduleUrl =
+        LegacyRemoteModuleV30Test.class.getClassLoader().getResource(LEGACY_MODULE_PATH);
+    assertThat(moduleUrl).isNotNull();
+
+    ObjectMapper mapper = JsonServiceLoader.mapper();
+    StatefulFunctionModule legacyModule = JsonServiceLoader.fromUrl(mapper, moduleUrl);
+    assertThat(legacyModule).isInstanceOf(LegacyRemoteModuleV30.class);
+
+    StatefulFunctionsUniverse universe =
+        new StatefulFunctionsUniverse(
+            MessageFactoryKey.forType(MessageFactoryType.WITH_PROTOBUF_PAYLOADS, null));
+    new LegacyBindersExtensionModule(recorder).configure(new HashMap<>(), universe);
+    legacyModule.configure(new HashMap<>(), universe);
+  }
+
+  private static final class Recorder {
+    final Map<TypeName, Integer> bindCounts = new HashMap<>();
+    final Map<FunctionType, StatefulFunctionProvider> boundFunctions = new HashMap<>();
+    final Map<IngressIdentifier<?>, IngressSpec<?>> boundIngresses = new HashMap<>();
+    final Map<EgressIdentifier<?>, EgressSpec<?>> boundEgresses = new HashMap<>();
+
+    void recordBind(TypeName binderTypename) {
+      bindCounts.merge(binderTypename, 1, Integer::sum);
+    }
+  }
+
+  private static final class LegacyBindersExtensionModule implements ExtensionModule {
+    private final Recorder recorder;
+
+    LegacyBindersExtensionModule(Recorder recorder) {
+      this.recorder = recorder;
+    }
+
+    @Override
+    public void configure(Map<String, String> globalConfigurations, Binder binder) {
+      binder.bindExtension(HTTP_ENDPOINT, new LegacyHttpBinder(recorder));
+      binder.bindExtension(UNTRANSLATED_INGRESS, new LegacyKafkaIngressBinder(recorder));
+      binder.bindExtension(KAFKA_EGRESS_TRANSLATED, new LegacyKafkaEgressBinder(recorder));
+    }
+  }
+
+  private static final class LegacyHttpBinder implements ComponentBinder {
+    static final FunctionType FUNCTION_TYPE = new FunctionType("com.foo.bar", "any");
+
+    private final Recorder recorder;
+
+    LegacyHttpBinder(Recorder recorder) {
+      this.recorder = recorder;
+    }
+
+    @Override
+    public void bind(
+        ComponentJsonObject component, StatefulFunctionModule.Binder remoteModuleBinder) {
+      recorder.recordBind(HTTP_ENDPOINT);
+      StatefulFunctionProvider provider = new NoopFunctionProvider();
+      remoteModuleBinder.bindFunctionProvider(FUNCTION_TYPE, provider);
+      recorder.boundFunctions.put(FUNCTION_TYPE, provider);
+    }
+  }
+
+  private static final class LegacyKafkaIngressBinder implements ComponentBinder {
+    static final IngressIdentifier<String> INGRESS_ID =
+        new IngressIdentifier<>(String.class, "com.mycomp.igal", "names");
+
+    private final Recorder recorder;
+
+    LegacyKafkaIngressBinder(Recorder recorder) {
+      this.recorder = recorder;
+    }
+
+    @Override
+    public void bind(
+        ComponentJsonObject component, StatefulFunctionModule.Binder remoteModuleBinder) {
+      recorder.recordBind(UNTRANSLATED_INGRESS);
+      IngressSpec<String> spec = new NoopIngressSpec(INGRESS_ID);
+      remoteModuleBinder.bindIngress(spec);
+      recorder.boundIngresses.put(INGRESS_ID, spec);
+    }
+  }
+
+  private static final class LegacyKafkaEgressBinder implements ComponentBinder {
+    static final EgressIdentifier<String> EGRESS_ID =
+        new EgressIdentifier<>("com.mycomp.foo", "bar", String.class);
+
+    private final Recorder recorder;
+
+    LegacyKafkaEgressBinder(Recorder recorder) {
+      this.recorder = recorder;
+    }
+
+    @Override
+    public void bind(
+        ComponentJsonObject component, StatefulFunctionModule.Binder remoteModuleBinder) {
+      recorder.recordBind(KAFKA_EGRESS_TRANSLATED);
+      EgressSpec<String> spec = new NoopEgressSpec(EGRESS_ID);
+      remoteModuleBinder.bindEgress(spec);
+      recorder.boundEgresses.put(EGRESS_ID, spec);
+    }
+  }
+
+  private static final class NoopFunctionProvider implements StatefulFunctionProvider {
+    @Override
+    public StatefulFunction functionOfType(FunctionType type) {
+      throw new UnsupportedOperationException();
+    }
+  }
+
+  private static final class NoopIngressSpec implements IngressSpec<String> {
+    private final IngressIdentifier<String> id;
+
+    NoopIngressSpec(IngressIdentifier<String> id) {
+      this.id = id;
+    }
+
+    @Override
+    public IngressIdentifier<String> id() {
+      return id;
+    }
+
+    @Override
+    public IngressType type() {
+      throw new UnsupportedOperationException();
+    }
+  }
+
+  private static final class NoopEgressSpec implements EgressSpec<String> {
+    private final EgressIdentifier<String> id;
+
+    NoopEgressSpec(EgressIdentifier<String> id) {
+      this.id = id;
+    }
+
+    @Override
+    public EgressIdentifier<String> id() {
+      return id;
+    }
+
+    @Override
+    public EgressType type() {
+      throw new UnsupportedOperationException();
+    }
+  }
+}

--- a/statefun-flink/statefun-flink-core/src/test/java/org/apache/flink/statefun/flink/core/message/MessagePayloadSerializerKryoTest.java
+++ b/statefun-flink/statefun-flink-core/src/test/java/org/apache/flink/statefun/flink/core/message/MessagePayloadSerializerKryoTest.java
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Kzmlabs
+package org.apache.flink.statefun.flink.core.message;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.Objects;
+import org.apache.flink.statefun.flink.core.generated.Payload;
+import org.junit.jupiter.api.Test;
+
+class MessagePayloadSerializerKryoTest {
+
+  private final MessagePayloadSerializerKryo serializer = new MessagePayloadSerializerKryo();
+  private final ClassLoader cl = getClass().getClassLoader();
+
+  @Test
+  void roundtripPreservesSimplePojo() {
+    Pojo original = new Pojo("hello", 42, new int[] {1, 2, 3});
+
+    Payload serialized = serializer.serialize(original);
+    Object deserialized = serializer.deserialize(cl, serialized);
+
+    assertThat(deserialized).isInstanceOf(Pojo.class);
+    Pojo restored = (Pojo) deserialized;
+    assertThat(restored.name).isEqualTo("hello");
+    assertThat(restored.count).isEqualTo(42);
+    assertThat(restored.values).containsExactly(1, 2, 3);
+  }
+
+  @Test
+  void serializedPayloadCarriesClassNameForCrossClassloaderReconstruction() {
+    Pojo original = new Pojo("p", 7, new int[] {});
+
+    Payload serialized = serializer.serialize(original);
+
+    assertThat(serialized.getClassName()).isEqualTo(Pojo.class.getName());
+    assertThat(serialized.getPayloadBytes().size()).isPositive();
+  }
+
+  @Test
+  void copyProducesEqualButIndependentInstance() {
+    Pojo original = new Pojo("c", 9, new int[] {7});
+
+    Object copy = serializer.copy(cl, original);
+
+    assertThat(copy).isNotSameAs(original).isInstanceOf(Pojo.class);
+    Pojo restored = (Pojo) copy;
+    assertThat(restored.name).isEqualTo("c");
+    assertThat(restored.count).isEqualTo(9);
+    assertThat(restored.values).containsExactly(7);
+    // Mutate original — copy must be independent.
+    original.values[0] = 99;
+    assertThat(restored.values).containsExactly(7);
+  }
+
+  @Test
+  void roundtripsNullableFieldAsNull() {
+    Pojo original = new Pojo(null, 0, new int[0]);
+
+    Payload serialized = serializer.serialize(original);
+    Pojo restored = (Pojo) serializer.deserialize(cl, serialized);
+
+    assertThat(restored.name).isNull();
+  }
+
+  @Test
+  void multipleRoundtripsReuseInternalBuffersWithoutCorruption() {
+    // Pin: the serializer reuses target/source buffers across calls (clear()/setBuffer()).
+    // Multiple roundtrips must not bleed state between invocations.
+    for (int i = 0; i < 50; i++) {
+      Pojo original = new Pojo("iter-" + i, i, new int[] {i, i * 2});
+      Payload serialized = serializer.serialize(original);
+      Pojo restored = (Pojo) serializer.deserialize(cl, serialized);
+      assertThat(restored.name).isEqualTo("iter-" + i);
+      assertThat(restored.count).isEqualTo(i);
+      assertThat(restored.values).containsExactly(i, i * 2);
+    }
+  }
+
+  /** A minimal Kryo-friendly POJO. */
+  public static final class Pojo implements Serializable {
+    private static final long serialVersionUID = 1L;
+    public String name;
+    public int count;
+    public int[] values;
+
+    public Pojo() {}
+
+    public Pojo(String name, int count, int[] values) {
+      this.name = name;
+      this.count = count;
+      this.values = values;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) return true;
+      if (!(o instanceof Pojo)) return false;
+      Pojo p = (Pojo) o;
+      return count == p.count && Objects.equals(name, p.name) && Arrays.equals(values, p.values);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(name, count, Arrays.hashCode(values));
+    }
+  }
+}

--- a/statefun-flink/statefun-flink-core/src/test/java/org/apache/flink/statefun/flink/core/metrics/FlinkFunctionDispatcherMetricsTest.java
+++ b/statefun-flink/statefun-flink-core/src/test/java/org/apache/flink/statefun/flink/core/metrics/FlinkFunctionDispatcherMetricsTest.java
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Kzmlabs
+package org.apache.flink.statefun.flink.core.metrics;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.flink.metrics.Counter;
+import org.apache.flink.metrics.groups.UnregisteredMetricsGroup;
+import org.junit.jupiter.api.Test;
+
+class FlinkFunctionDispatcherMetricsTest {
+
+  @Test
+  void asyncOperationRegisteredAndCompletedAdjustInflightCounter() {
+    RecordingMetricGroup group = new RecordingMetricGroup();
+    FlinkFunctionDispatcherMetrics metrics = new FlinkFunctionDispatcherMetrics(group);
+
+    metrics.asyncOperationRegistered();
+    metrics.asyncOperationRegistered();
+    metrics.asyncOperationRegistered();
+    metrics.asyncOperationCompleted();
+
+    Counter inflight = group.counters.get("inflightAsyncOps");
+    assertThat(inflight).isNotNull();
+    assertThat(inflight.getCount()).isEqualTo(2);
+  }
+
+  @Test
+  void counterIsRegisteredUnderInflightAsyncOpsName() {
+    RecordingMetricGroup group = new RecordingMetricGroup();
+
+    new FlinkFunctionDispatcherMetrics(group);
+
+    // Pin: the metric name `inflightAsyncOps` is the public dashboard contract — renaming
+    // would break operator dashboards.
+    assertThat(group.counters).containsKey("inflightAsyncOps");
+  }
+
+  @Test
+  void rejectsNullMetricGroup() {
+    assertThatThrownBy(() -> new FlinkFunctionDispatcherMetrics(null))
+        .isInstanceOf(NullPointerException.class)
+        .hasMessageContaining("operatorGroup");
+  }
+
+  /** A MetricGroup that records every counter registered, for assertion. */
+  private static final class RecordingMetricGroup extends UnregisteredMetricsGroup {
+    final Map<String, Counter> counters = new HashMap<>();
+
+    @Override
+    public Counter counter(String name) {
+      Counter c = super.counter(name);
+      counters.put(name, c);
+      return c;
+    }
+
+    @Override
+    public <C extends Counter> C counter(String name, C counter) {
+      C c = super.counter(name, counter);
+      counters.put(name, c);
+      return c;
+    }
+  }
+
+}

--- a/statefun-flink/statefun-flink-core/src/test/java/org/apache/flink/statefun/flink/core/metrics/FlinkFunctionTypeMetricsTest.java
+++ b/statefun-flink/statefun-flink-core/src/test/java/org/apache/flink/statefun/flink/core/metrics/FlinkFunctionTypeMetricsTest.java
@@ -1,0 +1,175 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Kzmlabs
+package org.apache.flink.statefun.flink.core.metrics;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.flink.metrics.Counter;
+import org.apache.flink.metrics.Histogram;
+import org.apache.flink.metrics.Meter;
+import org.apache.flink.metrics.MetricGroup;
+import org.apache.flink.metrics.groups.UnregisteredMetricsGroup;
+import org.apache.flink.statefun.sdk.metrics.Metrics;
+import org.junit.jupiter.api.Test;
+
+class FlinkFunctionTypeMetricsTest {
+
+  @Test
+  void registersAllExpectedCountersHistogramsAndMeters() {
+    RecordingMetricGroup group = new RecordingMetricGroup();
+    FlinkFunctionTypeMetrics m = new FlinkFunctionTypeMetrics(group, new FlinkUserMetrics(group));
+
+    // Drive every metric so registration is observed.
+    m.incomingMessage();
+    m.outgoingLocalMessage();
+    m.outgoingRemoteMessage();
+    m.outgoingEgressMessage();
+    m.blockedAddress();
+    m.unblockedAddress();
+    m.asyncOperationRegistered();
+    m.asyncOperationCompleted();
+    m.appendBacklogMessages(3);
+    m.consumeBacklogMessages(2);
+    m.remoteInvocationFailures();
+    m.remoteInvocationLatency(123L);
+
+    assertThat(group.counters)
+        .containsKeys(
+            "in",
+            "outLocal",
+            "outRemote",
+            "outEgress",
+            "numBlockedAddress",
+            "inflightAsyncOps",
+            "numBacklog",
+            "remoteInvocationFailures");
+    // The "metered" counters all have a sibling rate meter, suffixed Rate.
+    assertThat(group.meters)
+        .containsKeys("inRate", "outLocalRate", "outRemoteRate", "outEgressRate", "remoteInvocationFailuresRate");
+    assertThat(group.histograms).containsKey("remoteInvocationLatency");
+  }
+
+  @Test
+  void incomingAndOutgoingDoNotCrossTalk() {
+    RecordingMetricGroup group = new RecordingMetricGroup();
+    FlinkFunctionTypeMetrics m = new FlinkFunctionTypeMetrics(group, new FlinkUserMetrics(group));
+
+    m.incomingMessage();
+    m.outgoingLocalMessage();
+    m.outgoingLocalMessage();
+
+    assertThat(group.counters.get("in").getCount()).isEqualTo(1);
+    assertThat(group.counters.get("outLocal").getCount()).isEqualTo(2);
+    assertThat(group.counters.get("outRemote").getCount()).isZero();
+  }
+
+  @Test
+  void backlogMessageCounterFloorsAtZeroForNonNegativeCounter() {
+    RecordingMetricGroup group = new RecordingMetricGroup();
+    FlinkFunctionTypeMetrics m = new FlinkFunctionTypeMetrics(group, new FlinkUserMetrics(group));
+
+    m.appendBacklogMessages(2);
+    m.consumeBacklogMessages(10); // pretend we drained more than was added
+
+    // numBacklog uses NonNegativeCounter — must floor at zero, not go negative.
+    assertThat(group.counters.get("numBacklog").getCount()).isZero();
+  }
+
+  @Test
+  void blockedAddressInDecBalancesOut() {
+    RecordingMetricGroup group = new RecordingMetricGroup();
+    FlinkFunctionTypeMetrics m = new FlinkFunctionTypeMetrics(group, new FlinkUserMetrics(group));
+
+    m.blockedAddress();
+    m.blockedAddress();
+    m.unblockedAddress();
+
+    assertThat(group.counters.get("numBlockedAddress").getCount()).isEqualTo(1);
+  }
+
+  @Test
+  void rejectsNullScopedMetrics() {
+    assertThatThrownBy(() -> new FlinkFunctionTypeMetrics(new RecordingMetricGroup(), null))
+        .isInstanceOf(NullPointerException.class);
+  }
+
+  @Test
+  void exposesScopedMetricsBackToTheCaller() {
+    RecordingMetricGroup group = new RecordingMetricGroup();
+    Metrics scoped = new FlinkUserMetrics(group);
+    FlinkFunctionTypeMetrics m = new FlinkFunctionTypeMetrics(group, scoped);
+
+    assertThat(m.functionTypeScopedMetrics()).isSameAs(scoped);
+  }
+
+  @Test
+  void factoryProducesScopedMetricsByNamespaceAndName() {
+    RecordingMetricGroup parent = new RecordingMetricGroup();
+    FlinkFuncionTypeMetricsFactory factory = new FlinkFuncionTypeMetricsFactory(parent);
+
+    FunctionTypeMetrics m =
+        factory.forType(new org.apache.flink.statefun.sdk.FunctionType("ns", "fn"));
+
+    assertThat(m).isNotNull();
+    assertThat(m.functionTypeScopedMetrics()).isNotNull();
+    // The factory creates a nested metric group structure: parent / ns / fn.
+    assertThat(parent.subgroupsByName).containsKey("ns");
+    RecordingMetricGroup nsGroup = parent.subgroupsByName.get("ns");
+    assertThat(nsGroup.subgroupsByName).containsKey("fn");
+  }
+
+  @Test
+  void factoryRejectsNullParentGroup() {
+    assertThatThrownBy(() -> new FlinkFuncionTypeMetricsFactory(null))
+        .isInstanceOf(NullPointerException.class);
+  }
+
+  /**
+   * A MetricGroup that records every metric registered on it, including counters, meters,
+   * histograms, and any nested group it spawns. Used to pin metric naming + meter pairing.
+   */
+  private static final class RecordingMetricGroup extends UnregisteredMetricsGroup {
+    final Map<String, Counter> counters = new HashMap<>();
+    final Map<String, Meter> meters = new HashMap<>();
+    final Map<String, Histogram> histograms = new HashMap<>();
+    final Map<String, RecordingMetricGroup> subgroupsByName = new HashMap<>();
+
+    @Override
+    public Counter counter(String name) {
+      Counter c = super.counter(name);
+      counters.put(name, c);
+      return c;
+    }
+
+    @Override
+    public <C extends Counter> C counter(String name, C counter) {
+      C c = super.counter(name, counter);
+      counters.put(name, c);
+      return c;
+    }
+
+    @Override
+    public <M extends Meter> M meter(String name, M meter) {
+      M r = super.meter(name, meter);
+      meters.put(name, r);
+      return r;
+    }
+
+    @Override
+    public <H extends Histogram> H histogram(String name, H histogram) {
+      H h = super.histogram(name, histogram);
+      histograms.put(name, h);
+      return h;
+    }
+
+    @Override
+    public MetricGroup addGroup(String name) {
+      RecordingMetricGroup child = new RecordingMetricGroup();
+      subgroupsByName.put(name, child);
+      return child;
+    }
+  }
+}

--- a/statefun-flink/statefun-flink-core/src/test/java/org/apache/flink/statefun/flink/core/metrics/FlinkUserMetricsTest.java
+++ b/statefun-flink/statefun-flink-core/src/test/java/org/apache/flink/statefun/flink/core/metrics/FlinkUserMetricsTest.java
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Kzmlabs
+package org.apache.flink.statefun.flink.core.metrics;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.apache.flink.metrics.Counter;
+import org.apache.flink.metrics.groups.UnregisteredMetricsGroup;
+import org.apache.flink.statefun.sdk.metrics.Metrics;
+import org.junit.jupiter.api.Test;
+
+class FlinkUserMetricsTest {
+
+  @Test
+  void counterReturnsAnSdkCounterThatPropagatesToTheUnderlyingFlinkCounter() {
+    CountingMetricGroup group = new CountingMetricGroup();
+    Metrics metrics = new FlinkUserMetrics(group);
+
+    org.apache.flink.statefun.sdk.metrics.Counter sdkCounter = metrics.counter("requests");
+    sdkCounter.inc(1);
+    sdkCounter.inc(5);
+    sdkCounter.dec(2);
+
+    Counter underlying = group.counters.get("requests");
+    assertThat(underlying).isNotNull();
+    assertThat(underlying.getCount()).isEqualTo(4);
+  }
+
+  @Test
+  void counterReturnsCachedInstanceOnSecondLookupForSameName() {
+    Metrics metrics = new FlinkUserMetrics(new CountingMetricGroup());
+
+    org.apache.flink.statefun.sdk.metrics.Counter first = metrics.counter("c");
+    org.apache.flink.statefun.sdk.metrics.Counter second = metrics.counter("c");
+
+    // The wrapper map caches by name — same name returns same SDK wrapper instance, so the
+    // user's mental model "I always get the same counter" holds.
+    assertThat(first).isSameAs(second);
+  }
+
+  @Test
+  void differentNamesProduceIndependentCountersWithNoCrossTalk() {
+    CountingMetricGroup group = new CountingMetricGroup();
+    Metrics metrics = new FlinkUserMetrics(group);
+
+    org.apache.flink.statefun.sdk.metrics.Counter a = metrics.counter("a");
+    org.apache.flink.statefun.sdk.metrics.Counter b = metrics.counter("b");
+
+    a.inc(1);
+    b.inc(10);
+    a.inc(2);
+
+    assertThat(a).isNotSameAs(b);
+    assertThat(group.counters.get("a").getCount()).isEqualTo(3);
+    assertThat(group.counters.get("b").getCount()).isEqualTo(10);
+  }
+
+  @Test
+  void counterRejectsNullName() {
+    Metrics metrics = new FlinkUserMetrics(new CountingMetricGroup());
+
+    assertThatThrownBy(() -> metrics.counter(null)).isInstanceOf(NullPointerException.class);
+  }
+
+  @Test
+  void rejectsNullMetricGroup() {
+    assertThatThrownBy(() -> new FlinkUserMetrics(null)).isInstanceOf(NullPointerException.class);
+  }
+
+  /** A MetricGroup that records every counter registered. */
+  private static final class CountingMetricGroup extends UnregisteredMetricsGroup {
+    final java.util.Map<String, Counter> counters = new java.util.HashMap<>();
+
+    @Override
+    public <C extends Counter> C counter(String name, C counter) {
+      C c = super.counter(name, counter);
+      counters.put(name, c);
+      return c;
+    }
+  }
+}

--- a/statefun-flink/statefun-flink-core/src/test/java/org/apache/flink/statefun/flink/core/pool/SimplePoolTest.java
+++ b/statefun-flink/statefun-flink-core/src/test/java/org/apache/flink/statefun/flink/core/pool/SimplePoolTest.java
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Kzmlabs
+package org.apache.flink.statefun.flink.core.pool;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.Test;
+
+class SimplePoolTest {
+
+  @Test
+  void getReturnsSupplierOutputWhenPoolIsEmpty() {
+    AtomicInteger seq = new AtomicInteger();
+    SimplePool<Integer> pool = new SimplePool<>(seq::incrementAndGet, 3);
+
+    assertThat(pool.get()).isEqualTo(1);
+    assertThat(pool.get()).isEqualTo(2);
+    assertThat(pool.get()).isEqualTo(3);
+  }
+
+  @Test
+  void releasedItemsAreReturnedBeforeSupplierIsConsultedAgain() {
+    AtomicInteger seq = new AtomicInteger();
+    SimplePool<Integer> pool = new SimplePool<>(seq::incrementAndGet, 5);
+
+    Integer first = pool.get();
+    Integer second = pool.get();
+    pool.release(first);
+    pool.release(second);
+
+    // LIFO: release order is first then second, so the next get() returns the most-recently
+    // released item. This matters for cache locality of pooled buffers.
+    assertThat(pool.get()).isEqualTo(second);
+    assertThat(pool.get()).isEqualTo(first);
+    // Pool now empty -> falls back to supplier.
+    assertThat(pool.get()).isEqualTo(3);
+  }
+
+  @Test
+  void releaseDropsItemsOverMaxCapacity() {
+    AtomicInteger seq = new AtomicInteger();
+    SimplePool<Integer> pool = new SimplePool<>(seq::incrementAndGet, 2);
+
+    pool.release(100);
+    pool.release(101);
+    pool.release(102); // exceeds capacity, should be dropped
+
+    // Take 2 items — must be 101 and 100 (LIFO of what stayed in the pool).
+    assertThat(pool.get()).isEqualTo(101);
+    assertThat(pool.get()).isEqualTo(100);
+    // Pool now empty -> supplier produces 1 (sequence starts fresh, never used yet).
+    assertThat(pool.get()).isEqualTo(1);
+  }
+
+  @Test
+  void zeroCapacityPoolAlwaysCallsSupplier() {
+    AtomicInteger sequence = new AtomicInteger();
+    SimplePool<Integer> pool = new SimplePool<>(sequence::incrementAndGet, 0);
+
+    pool.release(99); // dropped, capacity 0
+    assertThat(pool.get()).isEqualTo(1);
+    pool.release(99); // still dropped
+    assertThat(pool.get()).isEqualTo(2);
+  }
+
+  @Test
+  void rejectsNullSupplier() {
+    assertThatThrownBy(() -> new SimplePool<Object>(null, 5))
+        .isInstanceOf(NullPointerException.class);
+  }
+}

--- a/statefun-flink/statefun-flink-core/src/test/java/org/apache/flink/statefun/flink/core/state/FlinkAppendingBufferAccessorTest.java
+++ b/statefun-flink/statefun-flink-core/src/test/java/org/apache/flink/statefun/flink/core/state/FlinkAppendingBufferAccessorTest.java
@@ -1,0 +1,166 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Kzmlabs
+package org.apache.flink.statefun.flink.core.state;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import org.apache.flink.api.common.state.ListState;
+import org.junit.jupiter.api.Test;
+
+class FlinkAppendingBufferAccessorTest {
+
+  @Test
+  void appendDelegatesToListStateAdd() throws Exception {
+    FakeListState<String> state = new FakeListState<>();
+    FlinkAppendingBufferAccessor<String> accessor = new FlinkAppendingBufferAccessor<>(state);
+
+    accessor.append("a");
+    accessor.append("b");
+
+    assertThat(state.backing).containsExactly("a", "b");
+  }
+
+  @Test
+  void appendAllDelegatesToListStateAddAll() throws Exception {
+    FakeListState<String> state = new FakeListState<>();
+    FlinkAppendingBufferAccessor<String> accessor = new FlinkAppendingBufferAccessor<>(state);
+
+    accessor.appendAll(Arrays.asList("x", "y", "z"));
+
+    assertThat(state.backing).containsExactly("x", "y", "z");
+  }
+
+  @Test
+  void replaceWithOverwritesListStateContents() throws Exception {
+    FakeListState<String> state = new FakeListState<>();
+    state.backing.add("old");
+    FlinkAppendingBufferAccessor<String> accessor = new FlinkAppendingBufferAccessor<>(state);
+
+    accessor.replaceWith(Arrays.asList("new1", "new2"));
+
+    assertThat(state.backing).containsExactly("new1", "new2");
+  }
+
+  @Test
+  void viewReturnsListStateGet() throws Exception {
+    FakeListState<String> state = new FakeListState<>();
+    state.backing.add("a");
+    state.backing.add("b");
+    FlinkAppendingBufferAccessor<String> accessor = new FlinkAppendingBufferAccessor<>(state);
+
+    Iterable<String> view = accessor.view();
+
+    assertThat(view).containsExactly("a", "b");
+  }
+
+  @Test
+  void clearDelegatesToListState() {
+    FakeListState<String> state = new FakeListState<>();
+    state.backing.add("a");
+    FlinkAppendingBufferAccessor<String> accessor = new FlinkAppendingBufferAccessor<>(state);
+
+    accessor.clear();
+
+    assertThat(state.backing).isEmpty();
+  }
+
+  @Test
+  void wrapsCheckedExceptionsFromMutators() {
+    FakeListState<String> state =
+        new FakeListState<String>() {
+          @Override
+          public void add(String value) throws Exception {
+            throw new IOException("add-boom");
+          }
+
+          @Override
+          public void addAll(List<String> values) throws Exception {
+            throw new IOException("addAll-boom");
+          }
+
+          @Override
+          public void update(List<String> values) throws Exception {
+            throw new IOException("update-boom");
+          }
+        };
+    FlinkAppendingBufferAccessor<String> accessor = new FlinkAppendingBufferAccessor<>(state);
+
+    assertThatThrownBy(() -> accessor.append("x"))
+        .isInstanceOf(RuntimeException.class)
+        .hasCauseInstanceOf(IOException.class);
+    assertThatThrownBy(() -> accessor.appendAll(Arrays.asList("a")))
+        .isInstanceOf(RuntimeException.class);
+    assertThatThrownBy(() -> accessor.replaceWith(Arrays.asList("a")))
+        .isInstanceOf(RuntimeException.class);
+  }
+
+  @Test
+  void wrapsCheckedExceptionsFromView() {
+    FakeListState<String> state =
+        new FakeListState<String>() {
+          @Override
+          public Iterable<String> get() throws Exception {
+            throw new IOException("get-boom");
+          }
+        };
+    FlinkAppendingBufferAccessor<String> accessor = new FlinkAppendingBufferAccessor<>(state);
+
+    assertThatThrownBy(accessor::view).isInstanceOf(RuntimeException.class);
+  }
+
+  @Test
+  void wrapsCheckedExceptionFromClear() {
+    FakeListState<String> state =
+        new FakeListState<String>() {
+          @Override
+          public void clear() {
+            throw new RuntimeException(new IOException("clear-boom"));
+          }
+        };
+    FlinkAppendingBufferAccessor<String> accessor = new FlinkAppendingBufferAccessor<>(state);
+
+    assertThatThrownBy(accessor::clear).isInstanceOf(RuntimeException.class);
+  }
+
+  @Test
+  void rejectsNullStateHandle() {
+    assertThatThrownBy(() -> new FlinkAppendingBufferAccessor<>(null))
+        .isInstanceOf(NullPointerException.class);
+  }
+
+  /** In-memory ListState used to record FlinkAppendingBufferAccessor's delegation. */
+  static class FakeListState<E> implements ListState<E> {
+    final List<E> backing = new ArrayList<>();
+
+    @Override
+    public Iterable<E> get() throws Exception {
+      return new ArrayList<>(backing);
+    }
+
+    @Override
+    public void add(E value) throws Exception {
+      backing.add(value);
+    }
+
+    @Override
+    public void update(List<E> values) throws Exception {
+      backing.clear();
+      backing.addAll(values);
+    }
+
+    @Override
+    public void addAll(List<E> values) throws Exception {
+      backing.addAll(values);
+    }
+
+    @Override
+    public void clear() {
+      backing.clear();
+    }
+  }
+}

--- a/statefun-flink/statefun-flink-core/src/test/java/org/apache/flink/statefun/flink/core/state/FlinkStateNameTest.java
+++ b/statefun-flink/statefun-flink-core/src/test/java/org/apache/flink/statefun/flink/core/state/FlinkStateNameTest.java
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Kzmlabs
+package org.apache.flink.statefun.flink.core.state;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.apache.flink.statefun.sdk.FunctionType;
+import org.junit.jupiter.api.Test;
+
+class FlinkStateNameTest {
+
+  /**
+   * The flinkStateName format is part of Flink savepoint compatibility — changing it would
+   * break checkpoint restore on existing payloads. Pin the format with concrete examples so
+   * a refactor surface this as a test failure instead of a silent state-loss in production.
+   */
+  @Test
+  void flinkStateNameUsesNamespaceDotNameDotPersistedValueName() {
+    String stateName =
+        FlinkState.flinkStateName(new FunctionType("orders", "validator"), "outstanding");
+
+    assertThat(stateName).isEqualTo("orders.validator.outstanding");
+  }
+
+  @Test
+  void emptyPersistedValueNameStillProducesValidStateName() {
+    String stateName = FlinkState.flinkStateName(new FunctionType("ns", "fn"), "");
+
+    // Trailing dot is documented behavior — empty persisted-value names are valid (they show
+    // up for "anonymous" PersistedValues), and the resulting state name still has the
+    // namespace.fn. prefix that the keyed backend matches on.
+    assertThat(stateName).isEqualTo("ns.fn.");
+  }
+
+  @Test
+  void specialCharactersInFunctionTypeFlowThroughVerbatim() {
+    String stateName =
+        FlinkState.flinkStateName(new FunctionType("io.payments", "fn-1"), "balance");
+
+    assertThat(stateName).isEqualTo("io.payments.fn-1.balance");
+  }
+}

--- a/statefun-flink/statefun-flink-core/src/test/java/org/apache/flink/statefun/flink/core/state/FlinkTableAccessorTest.java
+++ b/statefun-flink/statefun-flink-core/src/test/java/org/apache/flink/statefun/flink/core/state/FlinkTableAccessorTest.java
@@ -1,0 +1,216 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Kzmlabs
+package org.apache.flink.statefun.flink.core.state;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.StreamSupport;
+import org.apache.flink.api.common.state.MapState;
+import org.junit.jupiter.api.Test;
+
+class FlinkTableAccessorTest {
+
+  @Test
+  void setDelegatesToMapStatePut() throws Exception {
+    FakeMapState<String, Integer> state = new FakeMapState<>();
+    FlinkTableAccessor<String, Integer> accessor = new FlinkTableAccessor<>(state);
+
+    accessor.set("a", 1);
+
+    assertThat(state.backing).containsEntry("a", 1);
+  }
+
+  @Test
+  void getDelegatesToMapStateGet() throws Exception {
+    FakeMapState<String, Integer> state = new FakeMapState<>();
+    state.backing.put("a", 7);
+    FlinkTableAccessor<String, Integer> accessor = new FlinkTableAccessor<>(state);
+
+    assertThat(accessor.get("a")).isEqualTo(7);
+    assertThat(accessor.get("missing")).isNull();
+  }
+
+  @Test
+  void removeDelegatesToMapStateRemove() throws Exception {
+    FakeMapState<String, Integer> state = new FakeMapState<>();
+    state.backing.put("a", 1);
+    state.backing.put("b", 2);
+    FlinkTableAccessor<String, Integer> accessor = new FlinkTableAccessor<>(state);
+
+    accessor.remove("a");
+
+    assertThat(state.backing).doesNotContainKey("a").containsEntry("b", 2);
+  }
+
+  @Test
+  void entriesKeysValuesDelegateToMapState() throws Exception {
+    FakeMapState<String, Integer> state = new FakeMapState<>();
+    state.backing.put("a", 1);
+    state.backing.put("b", 2);
+    FlinkTableAccessor<String, Integer> accessor = new FlinkTableAccessor<>(state);
+
+    assertThat(toSet(accessor.keys())).containsExactlyInAnyOrder("a", "b");
+    assertThat(toSet(accessor.values())).containsExactlyInAnyOrder(1, 2);
+    Map<String, Integer> seenEntries = new HashMap<>();
+    for (Map.Entry<String, Integer> e : accessor.entries()) {
+      seenEntries.put(e.getKey(), e.getValue());
+    }
+    assertThat(seenEntries).containsEntry("a", 1).containsEntry("b", 2);
+  }
+
+  @Test
+  void clearDelegatesToMapState() {
+    FakeMapState<String, Integer> state = new FakeMapState<>();
+    state.backing.put("a", 1);
+    FlinkTableAccessor<String, Integer> accessor = new FlinkTableAccessor<>(state);
+
+    accessor.clear();
+
+    assertThat(state.backing).isEmpty();
+    assertThat(state.cleared).isTrue();
+  }
+
+  @Test
+  void wrapsCheckedExceptionFromGetAsRuntime() {
+    FakeMapState<String, Integer> state =
+        new FakeMapState<String, Integer>() {
+          @Override
+          public Integer get(String key) throws Exception {
+            throw new IOException("boom");
+          }
+        };
+    FlinkTableAccessor<String, Integer> accessor = new FlinkTableAccessor<>(state);
+
+    assertThatThrownBy(() -> accessor.get("a"))
+        .isInstanceOf(RuntimeException.class)
+        .hasCauseInstanceOf(IOException.class);
+  }
+
+  @Test
+  void wrapsCheckedExceptionsFromMutators() {
+    FakeMapState<String, Integer> state =
+        new FakeMapState<String, Integer>() {
+          @Override
+          public void put(String k, Integer v) throws Exception {
+            throw new IOException("set-boom");
+          }
+
+          @Override
+          public void remove(String k) throws Exception {
+            throw new IOException("remove-boom");
+          }
+        };
+    FlinkTableAccessor<String, Integer> accessor = new FlinkTableAccessor<>(state);
+
+    assertThatThrownBy(() -> accessor.set("a", 1)).isInstanceOf(RuntimeException.class);
+    assertThatThrownBy(() -> accessor.remove("a")).isInstanceOf(RuntimeException.class);
+  }
+
+  @Test
+  void wrapsCheckedExceptionsFromIterators() {
+    FakeMapState<String, Integer> state =
+        new FakeMapState<String, Integer>() {
+          @Override
+          public Iterable<Map.Entry<String, Integer>> entries() throws Exception {
+            throw new IOException("entries-boom");
+          }
+
+          @Override
+          public Iterable<String> keys() throws Exception {
+            throw new IOException("keys-boom");
+          }
+
+          @Override
+          public Iterable<Integer> values() throws Exception {
+            throw new IOException("values-boom");
+          }
+        };
+    FlinkTableAccessor<String, Integer> accessor = new FlinkTableAccessor<>(state);
+
+    assertThatThrownBy(accessor::entries).isInstanceOf(RuntimeException.class);
+    assertThatThrownBy(accessor::keys).isInstanceOf(RuntimeException.class);
+    assertThatThrownBy(accessor::values).isInstanceOf(RuntimeException.class);
+  }
+
+  @Test
+  void rejectsNullStateHandle() {
+    assertThatThrownBy(() -> new FlinkTableAccessor<>(null))
+        .isInstanceOf(NullPointerException.class);
+  }
+
+  private static <T> Set<T> toSet(Iterable<T> it) {
+    return StreamSupport.stream(it.spliterator(), false).collect(java.util.stream.Collectors.toSet());
+  }
+
+  /**
+   * In-memory MapState used to record FlinkTableAccessor's delegation. Most overrides default
+   * to "happy-path" delegate behavior; tests subclass this to inject failures.
+   */
+  static class FakeMapState<K, V> implements MapState<K, V> {
+    final Map<K, V> backing = new HashMap<>();
+    boolean cleared;
+
+    @Override
+    public V get(K key) throws Exception {
+      return backing.get(key);
+    }
+
+    @Override
+    public void put(K key, V value) throws Exception {
+      backing.put(key, value);
+    }
+
+    @Override
+    public void putAll(Map<K, V> map) throws Exception {
+      backing.putAll(map);
+    }
+
+    @Override
+    public void remove(K key) throws Exception {
+      backing.remove(key);
+    }
+
+    @Override
+    public boolean contains(K key) throws Exception {
+      return backing.containsKey(key);
+    }
+
+    @Override
+    public Iterable<Map.Entry<K, V>> entries() throws Exception {
+      return backing.entrySet();
+    }
+
+    @Override
+    public Iterable<K> keys() throws Exception {
+      return backing.keySet();
+    }
+
+    @Override
+    public Iterable<V> values() throws Exception {
+      return backing.values();
+    }
+
+    @Override
+    public Iterator<Map.Entry<K, V>> iterator() throws Exception {
+      return backing.entrySet().iterator();
+    }
+
+    @Override
+    public boolean isEmpty() throws Exception {
+      return backing.isEmpty();
+    }
+
+    @Override
+    public void clear() {
+      backing.clear();
+      cleared = true;
+    }
+  }
+
+}

--- a/statefun-flink/statefun-flink-core/src/test/java/org/apache/flink/statefun/flink/core/translation/EmbeddedTranslatorTest.java
+++ b/statefun-flink/statefun-flink-core/src/test/java/org/apache/flink/statefun/flink/core/translation/EmbeddedTranslatorTest.java
@@ -1,0 +1,138 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Kzmlabs
+package org.apache.flink.statefun.flink.core.translation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.Serializable;
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.flink.statefun.flink.core.StatefulFunctionsConfig;
+import org.apache.flink.statefun.flink.core.StatefulFunctionsUniverse;
+import org.apache.flink.statefun.flink.core.StatefulFunctionsUniverseProvider;
+import org.apache.flink.statefun.flink.core.feedback.FeedbackKey;
+import org.apache.flink.statefun.flink.core.message.Message;
+import org.apache.flink.statefun.flink.core.message.MessageFactoryType;
+import org.apache.flink.statefun.sdk.Address;
+import org.apache.flink.statefun.sdk.Context;
+import org.apache.flink.statefun.sdk.FunctionType;
+import org.apache.flink.statefun.sdk.StatefulFunction;
+import org.apache.flink.statefun.sdk.StatefulFunctionProvider;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Pins {@link EmbeddedTranslator} state-rebuild path. Full translate() runs through Flink's
+ * StreamExecutionEnvironment so it's covered by the e2e suite — these tests only exercise the
+ * embedded universe provider plumbing that the translator wires in.
+ */
+class EmbeddedTranslatorTest {
+
+  @Test
+  void translatorIsConstructible() {
+    StatefulFunctionsConfig cfg = newConfig();
+    FeedbackKey<Message> fk = new FeedbackKey<>("p", 1);
+
+    EmbeddedTranslator translator = new EmbeddedTranslator(cfg, fk);
+
+    assertThat(translator).isNotNull();
+  }
+
+  @Test
+  void embeddedUniverseProviderRegistersAllFunctionProviders() throws Exception {
+    StatefulFunctionsConfig cfg = newConfig();
+    FeedbackKey<Message> fk = new FeedbackKey<>("p", 1);
+    new EmbeddedTranslator(cfg, fk);
+
+    Map<FunctionType, SerializableNoopProvider> functions = new HashMap<>();
+    FunctionType ft1 = new FunctionType("ns", "fn-a");
+    FunctionType ft2 = new FunctionType("ns", "fn-b");
+    functions.put(ft1, new SerializableNoopProvider());
+    functions.put(ft2, new SerializableNoopProvider());
+
+    StatefulFunctionsUniverseProvider provider = newProviderViaConfig(cfg, functions);
+    StatefulFunctionsUniverse universe = provider.get(getClass().getClassLoader(), cfg);
+
+    assertThat(universe.functions()).containsKeys(ft1, ft2);
+    assertThat(universe.functions()).hasSize(2);
+  }
+
+  @Test
+  void embeddedUniverseProviderIsJavaSerializable() throws Exception {
+    StatefulFunctionsConfig cfg = newConfig();
+    Map<FunctionType, SerializableNoopProvider> functions = new HashMap<>();
+    functions.put(new FunctionType("ns", "fn"), new SerializableNoopProvider());
+
+    StatefulFunctionsUniverseProvider provider = newProviderViaConfig(cfg, functions);
+
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    new ObjectOutputStream(out).writeObject(provider);
+    Object copy =
+        new ObjectInputStream(new ByteArrayInputStream(out.toByteArray())).readObject();
+
+    assertThat(copy).isInstanceOf(StatefulFunctionsUniverseProvider.class);
+  }
+
+  @Test
+  void embeddedUniverseProviderRejectsNullFunctionMap() {
+    // The provider eagerly null-checks the function map in its constructor — pin that contract
+    // so a future refactor doesn't defer the failure to JobGraph submission time, where the
+    // operator would see only a confusing classpath-deserialization error.
+    assertThatThrownBy(() -> buildProvider(null))
+        .isInstanceOf(java.lang.reflect.InvocationTargetException.class)
+        .hasCauseInstanceOf(NullPointerException.class);
+  }
+
+  private static StatefulFunctionsConfig newConfig() {
+    StatefulFunctionsConfig cfg =
+        StatefulFunctionsConfig.fromFlinkConfiguration(new org.apache.flink.configuration.Configuration());
+    cfg.setFactoryType(MessageFactoryType.WITH_PROTOBUF_PAYLOADS);
+    return cfg;
+  }
+
+  /**
+   * The translator's internal {@code EmbeddedUniverseProvider} is package-private nested in
+   * {@link EmbeddedTranslator}. We build one via reflection to exercise its
+   * {@link StatefulFunctionsUniverseProvider#get} contract.
+   */
+  private static StatefulFunctionsUniverseProvider newProviderViaConfig(
+      StatefulFunctionsConfig cfg, Map<FunctionType, ? extends Serializable> functions)
+      throws Exception {
+    StatefulFunctionsUniverseProvider provider = buildProvider(functions);
+    cfg.setProvider(provider);
+    return provider;
+  }
+
+  @SuppressWarnings({"unchecked", "rawtypes"})
+  private static StatefulFunctionsUniverseProvider buildProvider(Map<FunctionType, ?> functions)
+      throws Exception {
+    Class<?> embedded =
+        Class.forName(
+            "org.apache.flink.statefun.flink.core.translation.EmbeddedTranslator$EmbeddedUniverseProvider");
+    java.lang.reflect.Constructor<?> ctor = embedded.getDeclaredConstructor(Map.class);
+    ctor.setAccessible(true);
+    return (StatefulFunctionsUniverseProvider) ctor.newInstance(functions);
+  }
+
+  private static final class SerializableNoopProvider
+      implements StatefulFunctionProvider, Serializable {
+    private static final long serialVersionUID = 1L;
+
+    @Override
+    public StatefulFunction functionOfType(FunctionType type) {
+      return new StatefulFunction() {
+        @Override
+        public void invoke(Context context, Object input) {}
+      };
+    }
+  }
+
+  // Reference field to avoid unused-import warnings for Address — kept for symmetry with other
+  // tests in this package.
+  @SuppressWarnings("unused")
+  private static final Address SAMPLE = new Address(new FunctionType("ns", "fn"), "id");
+}

--- a/statefun-flink/statefun-flink-core/src/test/java/org/apache/flink/statefun/flink/core/types/remote/RemoteValueSerializerSnapshotTest.java
+++ b/statefun-flink/statefun-flink-core/src/test/java/org/apache/flink/statefun/flink/core/types/remote/RemoteValueSerializerSnapshotTest.java
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Kzmlabs
+package org.apache.flink.statefun.flink.core.types.remote;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import org.apache.flink.api.common.typeutils.TypeSerializerSchemaCompatibility;
+import org.apache.flink.api.common.typeutils.TypeSerializerSnapshot;
+import org.apache.flink.core.memory.DataInputViewStreamWrapper;
+import org.apache.flink.core.memory.DataOutputViewStreamWrapper;
+import org.apache.flink.statefun.sdk.TypeName;
+import org.junit.jupiter.api.Test;
+
+class RemoteValueSerializerSnapshotTest {
+
+  private static final TypeName TYPE = new TypeName("io.test", "remote");
+  private static final TypeName OTHER = new TypeName("io.test", "other");
+
+  @Test
+  void writeAndReadSnapshotRoundtripsTypeName() throws Exception {
+    RemoteValueSerializerSnapshot snapshot = new RemoteValueSerializerSnapshot(TYPE);
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    snapshot.writeSnapshot(new DataOutputViewStreamWrapper(new DataOutputStream(out)));
+
+    RemoteValueSerializerSnapshot restored = new RemoteValueSerializerSnapshot();
+    restored.readSnapshot(
+        snapshot.getCurrentVersion(),
+        new DataInputViewStreamWrapper(new DataInputStream(new ByteArrayInputStream(out.toByteArray()))),
+        getClass().getClassLoader());
+
+    assertThat(restored.type()).isEqualTo(TYPE);
+  }
+
+  @Test
+  void restoreSerializerProducesRemoteValueSerializer() {
+    RemoteValueSerializerSnapshot snapshot = new RemoteValueSerializerSnapshot(TYPE);
+
+    RemoteValueSerializer restored = (RemoteValueSerializer) snapshot.restoreSerializer();
+
+    assertThat(restored.getType()).isEqualTo(TYPE);
+  }
+
+  @Test
+  void resolveCompatibilityWithSelfIsCompatibleAsIs() {
+    RemoteValueSerializerSnapshot snapshot = new RemoteValueSerializerSnapshot(TYPE);
+
+    TypeSerializerSchemaCompatibility<byte[]> result = snapshot.resolveSchemaCompatibility(snapshot);
+
+    assertThat(result.isCompatibleAsIs()).isTrue();
+  }
+
+  @Test
+  void resolveCompatibilityWithDifferentTypeRaisesMismatch() {
+    RemoteValueSerializerSnapshot mine = new RemoteValueSerializerSnapshot(TYPE);
+    RemoteValueSerializerSnapshot theirs = new RemoteValueSerializerSnapshot(OTHER);
+
+    // Cross-type restore must surface a hard failure with both type names so operators
+    // can diagnose the schema drift instead of silently dropping data.
+    assertThatThrownBy(() -> mine.resolveSchemaCompatibility(theirs))
+        .isInstanceOf(RemoteValueTypeMismatchException.class);
+  }
+
+  @Test
+  void resolveCompatibilityRejectsForeignSnapshotType() {
+    RemoteValueSerializerSnapshot mine = new RemoteValueSerializerSnapshot(TYPE);
+
+    @SuppressWarnings("unchecked")
+    TypeSerializerSnapshot<byte[]> foreign =
+        (TypeSerializerSnapshot<byte[]>) (TypeSerializerSnapshot<?>) new ForeignSnapshot();
+
+    TypeSerializerSchemaCompatibility<byte[]> result = mine.resolveSchemaCompatibility(foreign);
+
+    assertThat(result.isIncompatible()).isTrue();
+  }
+
+  @Test
+  void currentVersionIsOne() {
+    assertThat(new RemoteValueSerializerSnapshot(TYPE).getCurrentVersion()).isEqualTo(1);
+  }
+
+  /** A non-RemoteValue snapshot used to exercise the foreign-snapshot guard. */
+  private static final class ForeignSnapshot implements TypeSerializerSnapshot<Object> {
+    @Override
+    public int getCurrentVersion() {
+      return 0;
+    }
+
+    @Override
+    public void writeSnapshot(org.apache.flink.core.memory.DataOutputView out) {}
+
+    @Override
+    public void readSnapshot(int v, org.apache.flink.core.memory.DataInputView in, ClassLoader cl) {}
+
+    @Override
+    public org.apache.flink.api.common.typeutils.TypeSerializer<Object> restoreSerializer() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public TypeSerializerSchemaCompatibility<Object> resolveSchemaCompatibility(
+        TypeSerializerSnapshot<Object> other) {
+      return TypeSerializerSchemaCompatibility.incompatible();
+    }
+  }
+}

--- a/statefun-flink/statefun-flink-core/src/test/java/org/apache/flink/statefun/flink/core/types/remote/RemoteValueTypeInfoTest.java
+++ b/statefun-flink/statefun-flink-core/src/test/java/org/apache/flink/statefun/flink/core/types/remote/RemoteValueTypeInfoTest.java
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Kzmlabs
+package org.apache.flink.statefun.flink.core.types.remote;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.apache.flink.api.common.serialization.SerializerConfigImpl;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.statefun.sdk.TypeName;
+import org.junit.jupiter.api.Test;
+
+class RemoteValueTypeInfoTest {
+
+  private static final TypeName TYPE = new TypeName("io.test", "remote");
+  private static final TypeName OTHER = new TypeName("io.test", "other");
+
+  @Test
+  void exposesByteArrayShapeAsScalar() {
+    RemoteValueTypeInfo info = new RemoteValueTypeInfo(TYPE);
+
+    // RemoteValueTypeInfo wraps a byte[] payload and is treated as a scalar by Flink:
+    // not a basic type, not a tuple, arity 0, total fields 0, not a key.
+    assertThat(info.isBasicType()).isFalse();
+    assertThat(info.isTupleType()).isFalse();
+    assertThat(info.getArity()).isZero();
+    assertThat(info.getTotalFields()).isZero();
+    assertThat(info.isKeyType()).isFalse();
+    assertThat(info.getTypeClass()).isEqualTo(byte[].class);
+  }
+
+  @Test
+  void createSerializerReturnsRemoteValueSerializerForType() {
+    RemoteValueTypeInfo info = new RemoteValueTypeInfo(TYPE);
+
+    TypeSerializer<byte[]> serializer = info.createSerializer(new SerializerConfigImpl());
+
+    assertThat(serializer).isInstanceOf(RemoteValueSerializer.class);
+    assertThat(((RemoteValueSerializer) serializer).getType()).isEqualTo(TYPE);
+  }
+
+  @Test
+  void rejectsNullTypeName() {
+    assertThatThrownBy(() -> new RemoteValueTypeInfo(null))
+        .isInstanceOf(NullPointerException.class);
+  }
+
+  @Test
+  void equalsAndHashCodeIdentifyByTypeName() {
+    RemoteValueTypeInfo a = new RemoteValueTypeInfo(TYPE);
+    RemoteValueTypeInfo aAgain = new RemoteValueTypeInfo(new TypeName("io.test", "remote"));
+    RemoteValueTypeInfo b = new RemoteValueTypeInfo(OTHER);
+
+    assertThat(a).isEqualTo(a).isEqualTo(aAgain).isNotEqualTo(b);
+    assertThat(a).isNotEqualTo(null).isNotEqualTo("not a typeinfo");
+    assertThat(a.hashCode()).isEqualTo(aAgain.hashCode());
+  }
+
+  @Test
+  void canEqualOnlyOtherRemoteValueTypeInfo() {
+    RemoteValueTypeInfo info = new RemoteValueTypeInfo(TYPE);
+
+    assertThat(info.canEqual(new RemoteValueTypeInfo(OTHER))).isTrue();
+    assertThat(info.canEqual("not a typeinfo")).isFalse();
+  }
+
+  @Test
+  void toStringIncludesType() {
+    RemoteValueTypeInfo info = new RemoteValueTypeInfo(TYPE);
+
+    assertThat(info.toString()).contains("RemoteValueTypeInfo").contains(TYPE.toString());
+  }
+}

--- a/statefun-flink/statefun-flink-datastream/pom.xml
+++ b/statefun-flink/statefun-flink-datastream/pom.xml
@@ -68,7 +68,12 @@
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest</artifactId>
         </dependency>
-        
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+
     </dependencies>
 
     <build>

--- a/statefun-flink/statefun-flink-datastream/src/test/java/org/apache/flink/statefun/flink/datastream/SerializableHttpFunctionProviderEdgeCasesTest.java
+++ b/statefun-flink/statefun-flink-datastream/src/test/java/org/apache/flink/statefun/flink/datastream/SerializableHttpFunctionProviderEdgeCasesTest.java
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Kzmlabs
+package org.apache.flink.statefun.flink.datastream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.apache.flink.statefun.sdk.TypeName;
+import org.junit.jupiter.api.Test;
+
+class SerializableHttpFunctionProviderEdgeCasesTest {
+
+  @Test
+  void getClientFactoryRejectsUnknownTransportType() {
+    TypeName unknown = TypeName.parseFrom("io.test/unknown-transport");
+
+    assertThatThrownBy(() -> SerializableHttpFunctionProvider.getClientFactory(unknown))
+        .isInstanceOf(UnsupportedOperationException.class)
+        .hasMessageContaining("Unsupported transport client factory type")
+        .hasMessageContaining("io.test/unknown-transport");
+  }
+
+  @Test
+  void getClientFactoryRejectsNullTransportType() {
+    // The mapper short-circuits null via .equals — we want it to fail fast rather than
+    // silently fall through to "unsupported" which would mask null-safety bugs upstream.
+    assertThatThrownBy(() -> SerializableHttpFunctionProvider.getClientFactory(null))
+        .isInstanceOfAny(NullPointerException.class, UnsupportedOperationException.class);
+  }
+
+  @Test
+  void exposedFactoriesAreNotNull() {
+    // The two SDK-supported transports must always resolve to a non-null factory; otherwise
+    // the JobGraph would later fail with a confusing NullPointerException at runtime.
+    assertThat(
+            SerializableHttpFunctionProvider.getClientFactory(
+                org.apache.flink.statefun.flink.core.httpfn.TransportClientConstants
+                    .OKHTTP_CLIENT_FACTORY_TYPE))
+        .isNotNull();
+    assertThat(
+            SerializableHttpFunctionProvider.getClientFactory(
+                org.apache.flink.statefun.flink.core.httpfn.TransportClientConstants
+                    .ASYNC_CLIENT_FACTORY_TYPE))
+        .isNotNull();
+  }
+}

--- a/statefun-flink/statefun-flink-datastream/src/test/java/org/apache/flink/statefun/flink/datastream/StatefulFunctionDataStreamBuilderTest.java
+++ b/statefun-flink/statefun-flink-datastream/src/test/java/org/apache/flink/statefun/flink/datastream/StatefulFunctionDataStreamBuilderTest.java
@@ -1,0 +1,151 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Kzmlabs
+package org.apache.flink.statefun.flink.datastream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.net.URI;
+import java.time.Duration;
+import org.apache.flink.statefun.flink.core.StatefulFunctionsConfig;
+import org.apache.flink.statefun.flink.core.message.MessageFactoryType;
+import org.apache.flink.statefun.flink.core.message.RoutableMessage;
+import org.apache.flink.statefun.sdk.Address;
+import org.apache.flink.statefun.sdk.Context;
+import org.apache.flink.statefun.sdk.FunctionType;
+import org.apache.flink.statefun.sdk.StatefulFunction;
+import org.apache.flink.statefun.sdk.io.EgressIdentifier;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.junit.jupiter.api.Test;
+
+class StatefulFunctionDataStreamBuilderTest {
+
+  private static final FunctionType FN_A = new FunctionType("ns", "a");
+  private static final FunctionType FN_B = new FunctionType("ns", "b");
+  private static final EgressIdentifier<String> OUT_A =
+      new EgressIdentifier<>("ns", "out-a", String.class);
+  private static final EgressIdentifier<String> OUT_B =
+      new EgressIdentifier<>("ns", "out-b", String.class);
+
+  @Test
+  void builderRejectsNullPipelineName() {
+    assertThatThrownBy(() -> StatefulFunctionDataStreamBuilder.builder(null))
+        .isInstanceOf(NullPointerException.class);
+  }
+
+  @Test
+  void builderReturnsFluentInstance() {
+    StatefulFunctionDataStreamBuilder b = StatefulFunctionDataStreamBuilder.builder("p");
+    assertThat(b).isNotNull();
+  }
+
+  @Test
+  void withFunctionProviderRejectsNulls() {
+    StatefulFunctionDataStreamBuilder b = StatefulFunctionDataStreamBuilder.builder("p");
+
+    assertThatThrownBy(() -> b.withFunctionProvider(null, noopProvider()))
+        .isInstanceOf(NullPointerException.class);
+    assertThatThrownBy(() -> b.withFunctionProvider(FN_A, null))
+        .isInstanceOf(NullPointerException.class);
+  }
+
+  @Test
+  void withFunctionProviderRejectsDuplicateRegistrationOfSameType() {
+    StatefulFunctionDataStreamBuilder b = StatefulFunctionDataStreamBuilder.builder("p");
+    b.withFunctionProvider(FN_A, noopProvider());
+
+    assertThatThrownBy(() -> b.withFunctionProvider(FN_A, noopProvider()))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("previously defined");
+  }
+
+  @Test
+  void withFunctionProviderAcceptsDifferentTypes() {
+    StatefulFunctionDataStreamBuilder b = StatefulFunctionDataStreamBuilder.builder("p");
+    b.withFunctionProvider(FN_A, noopProvider());
+
+    assertThatCode(() -> b.withFunctionProvider(FN_B, noopProvider()))
+        .doesNotThrowAnyException();
+  }
+
+  @Test
+  void withDataStreamAsIngressRejectsNull() {
+    StatefulFunctionDataStreamBuilder b = StatefulFunctionDataStreamBuilder.builder("p");
+
+    assertThatThrownBy(() -> b.withDataStreamAsIngress((DataStream<RoutableMessage>) null))
+        .isInstanceOf(NullPointerException.class);
+  }
+
+  @Test
+  void withEgressIdRejectsNullAndDuplicates() {
+    StatefulFunctionDataStreamBuilder b = StatefulFunctionDataStreamBuilder.builder("p");
+
+    assertThatThrownBy(() -> b.withEgressId(null)).isInstanceOf(NullPointerException.class);
+    b.withEgressId(OUT_A);
+    assertThatThrownBy(() -> b.withEgressId(OUT_A))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("previously defined");
+    assertThatCode(() -> b.withEgressId(OUT_B)).doesNotThrowAnyException();
+  }
+
+  @Test
+  void withRequestReplyRemoteFunctionRejectsNull() {
+    StatefulFunctionDataStreamBuilder b = StatefulFunctionDataStreamBuilder.builder("p");
+
+    assertThatThrownBy(() -> b.withRequestReplyRemoteFunction(null))
+        .isInstanceOf(NullPointerException.class);
+  }
+
+  @Test
+  void withRequestReplyRemoteFunctionRejectsDuplicateType() throws Exception {
+    StatefulFunctionDataStreamBuilder b = StatefulFunctionDataStreamBuilder.builder("p");
+
+    StatefulFunctionBuilder rr1 = newRemoteBuilder(FN_A);
+    StatefulFunctionBuilder rr2 = newRemoteBuilder(FN_A);
+    b.withRequestReplyRemoteFunction(rr1);
+
+    assertThatThrownBy(() -> b.withRequestReplyRemoteFunction(rr2))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("previously defined");
+  }
+
+  @Test
+  void withConfigurationRejectsNull() {
+    StatefulFunctionDataStreamBuilder b = StatefulFunctionDataStreamBuilder.builder("p");
+
+    assertThatThrownBy(() -> b.withConfiguration(null))
+        .isInstanceOf(NullPointerException.class);
+  }
+
+  @Test
+  void withConfigurationAcceptsAValidConfig() {
+    StatefulFunctionDataStreamBuilder b = StatefulFunctionDataStreamBuilder.builder("p");
+    StatefulFunctionsConfig cfg =
+        StatefulFunctionsConfig.fromFlinkConfiguration(new org.apache.flink.configuration.Configuration());
+    cfg.setFactoryType(MessageFactoryType.WITH_PROTOBUF_PAYLOADS);
+
+    assertThatCode(() -> b.withConfiguration(cfg)).doesNotThrowAnyException();
+  }
+
+  private static SerializableStatefulFunctionProvider noopProvider() {
+    return functionType ->
+        new StatefulFunction() {
+          @Override
+          public void invoke(Context context, Object input) {}
+        };
+  }
+
+  private static StatefulFunctionBuilder newRemoteBuilder(FunctionType type) throws Exception {
+    // Default connect timeout is large enough that we must explicitly bound the request
+    // duration above it; otherwise the builder rejects the spec.
+    return RequestReplyFunctionBuilder.requestReplyFunctionBuilder(type, new URI("http://localhost:1234/"))
+        .withMaxNumBatchRequests(10)
+        .withConnectTimeout(Duration.ofSeconds(2))
+        .withMaxRequestDuration(Duration.ofSeconds(30));
+  }
+
+  // Address used solely as a placeholder where API surfaces require it.
+  @SuppressWarnings("unused")
+  private static final Address SAMPLE_ADDR = new Address(FN_A, "id");
+}

--- a/statefun-flink/statefun-flink-harness/pom.xml
+++ b/statefun-flink/statefun-flink-harness/pom.xml
@@ -27,6 +27,18 @@
             <artifactId>flink-streaming-java</artifactId>
             <version>${flink.version}</version>
         </dependency>
+
+        <!-- Tests -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <!-- This profile helps to make things run out of the box in IntelliJ -->

--- a/statefun-flink/statefun-flink-harness/src/test/java/org/apache/flink/statefun/flink/harness/io/SupplyingSourceSplitEnumeratorTest.java
+++ b/statefun-flink/statefun-flink-harness/src/test/java/org/apache/flink/statefun/flink/harness/io/SupplyingSourceSplitEnumeratorTest.java
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Kzmlabs
+package org.apache.flink.statefun.flink.harness.io;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import org.junit.jupiter.api.Test;
+
+class SupplyingSourceSplitEnumeratorTest {
+
+  @Test
+  void addReaderProvisionsSplitForSubtask() {
+    SupplyingSourceSplitEnumerator<String> e = new SupplyingSourceSplitEnumerator<>();
+
+    e.addReader(0);
+    e.addReader(1);
+
+    HashSet<SupplyingSourceSplit<String>> snapshot = e.snapshotState(0);
+    assertThat(snapshot).hasSize(2);
+    assertThat(snapshot)
+        .extracting(SupplyingSourceSplit::splitId)
+        .containsExactlyInAnyOrder("0", "1");
+  }
+
+  @Test
+  void addSplitsBackKeepsExistingSplitsAndAddsNew() {
+    SupplyingSourceSplitEnumerator<String> e = new SupplyingSourceSplitEnumerator<>();
+    e.addReader(0);
+
+    SupplyingSourceSplit<String> recovered1 = new SupplyingSourceSplit<>(10);
+    SupplyingSourceSplit<String> recovered2 = new SupplyingSourceSplit<>(11);
+    e.addSplitsBack(Arrays.asList(recovered1, recovered2), 0);
+
+    HashSet<SupplyingSourceSplit<String>> snapshot = e.snapshotState(0);
+    assertThat(snapshot).hasSize(3);
+    assertThat(snapshot)
+        .extracting(SupplyingSourceSplit::splitId)
+        .containsExactlyInAnyOrder("0", "10", "11");
+  }
+
+  @Test
+  void startAndCloseAndHandleSplitRequestAreNoOps() {
+    SupplyingSourceSplitEnumerator<String> e = new SupplyingSourceSplitEnumerator<>();
+
+    e.start();
+    e.handleSplitRequest(0, "host");
+    e.close();
+
+    // The contract is that none of these alter state — adding a reader after still works.
+    e.addReader(99);
+    assertThat(e.snapshotState(1)).hasSize(1);
+  }
+}

--- a/statefun-flink/statefun-flink-harness/src/test/java/org/apache/flink/statefun/flink/harness/io/SupplyingSourceSplitSerializerTest.java
+++ b/statefun-flink/statefun-flink-harness/src/test/java/org/apache/flink/statefun/flink/harness/io/SupplyingSourceSplitSerializerTest.java
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Kzmlabs
+package org.apache.flink.statefun.flink.harness.io;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class SupplyingSourceSplitSerializerTest {
+
+  @Test
+  void serializerVersionIsZero() {
+    SupplyingSourceSplitSerializer<String> serializer = new SupplyingSourceSplitSerializer<>();
+
+    assertThat(serializer.getVersion()).isZero();
+  }
+
+  @Test
+  void roundtripsSplitWithItsId() throws Exception {
+    SupplyingSourceSplitSerializer<String> serializer = new SupplyingSourceSplitSerializer<>();
+    SupplyingSourceSplit<String> original = new SupplyingSourceSplit<>(42);
+
+    byte[] bytes = serializer.serialize(original);
+    SupplyingSourceSplit<String> restored = serializer.deserialize(0, bytes);
+
+    assertThat(restored.splitId()).isEqualTo("42");
+  }
+
+  @Test
+  void roundtripsSplitWithEnqueuedRecords() throws Exception {
+    SupplyingSourceSplitSerializer<String> serializer = new SupplyingSourceSplitSerializer<>();
+    SupplyingSourceSplit<String> original = new SupplyingSourceSplit<>(0);
+    original.addRecord("a").addRecord("b").addRecord("c");
+
+    byte[] bytes = serializer.serialize(original);
+    SupplyingSourceSplit<String> restored = serializer.deserialize(0, bytes);
+
+    // The records queue is a LinkedBlockingQueue<>, which serializes its current contents.
+    // After restore the records should still drain in original order.
+    assertThat(restored.getNext(false)).isEqualTo("a");
+    assertThat(restored.getNext(false)).isEqualTo("b");
+    assertThat(restored.getNext(false)).isEqualTo("c");
+  }
+}

--- a/statefun-flink/statefun-flink-harness/src/test/java/org/apache/flink/statefun/flink/harness/io/SupplyingSourceSplitTest.java
+++ b/statefun-flink/statefun-flink-harness/src/test/java/org/apache/flink/statefun/flink/harness/io/SupplyingSourceSplitTest.java
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Kzmlabs
+package org.apache.flink.statefun.flink.harness.io;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+class SupplyingSourceSplitTest {
+
+  @Test
+  void splitIdMatchesConstructorIdAsString() {
+    SupplyingSourceSplit<String> split = new SupplyingSourceSplit<>(7);
+
+    assertThat(split.splitId()).isEqualTo("7");
+  }
+
+  @Test
+  void getNextNonBlockingReturnsNullWhenQueueIsEmpty() throws Exception {
+    SupplyingSourceSplit<String> split = new SupplyingSourceSplit<>(0);
+
+    assertThat(split.getNext(false)).isNull();
+  }
+
+  @Test
+  void addRecordEnqueuesForNonBlockingDrain() throws Exception {
+    SupplyingSourceSplit<String> split = new SupplyingSourceSplit<>(0);
+
+    split.addRecord("a").addRecord("b");
+
+    assertThat(split.getNext(false)).isEqualTo("a");
+    assertThat(split.getNext(false)).isEqualTo("b");
+    assertThat(split.getNext(false)).isNull();
+  }
+
+  @Test
+  @Timeout(2)
+  void getNextBlockingWaitsUntilAddRecord() throws Exception {
+    SupplyingSourceSplit<String> split = new SupplyingSourceSplit<>(0);
+    AtomicReference<String> received = new AtomicReference<>();
+
+    Thread consumer =
+        new Thread(
+            () -> {
+              try {
+                received.set(split.getNext(true));
+              } catch (InterruptedException ignored) {
+                Thread.currentThread().interrupt();
+              }
+            });
+    consumer.start();
+    // Sleep a tick so the consumer is parked in take().
+    Thread.sleep(50);
+    split.addRecord("late");
+    consumer.join(1500);
+
+    assertThat(received.get()).isEqualTo("late");
+  }
+}

--- a/statefun-flink/statefun-flink-io-bundle/src/test/java/org/apache/flink/statefun/flink/io/kafka/binders/egress/v1/GenericKafkaEgressSerializerTest.java
+++ b/statefun-flink/statefun-flink-io-bundle/src/test/java/org/apache/flink/statefun/flink/io/kafka/binders/egress/v1/GenericKafkaEgressSerializerTest.java
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Kzmlabs
+package org.apache.flink.statefun.flink.io.kafka.binders.egress.v1;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.google.protobuf.ByteString;
+import java.nio.charset.StandardCharsets;
+import org.apache.flink.statefun.flink.common.types.TypedValueUtil;
+import org.apache.flink.statefun.sdk.egress.generated.KafkaProducerRecord;
+import org.apache.flink.statefun.sdk.reqreply.generated.TypedValue;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.junit.jupiter.api.Test;
+
+class GenericKafkaEgressSerializerTest {
+
+  private final GenericKafkaEgressSerializer serializer = new GenericKafkaEgressSerializer();
+
+  @Test
+  void serializesRecordWithKeyAndValueToProducerRecord() {
+    TypedValue input = packAsKafkaRecord("topic-A", "key-1", "hello".getBytes(StandardCharsets.UTF_8));
+
+    ProducerRecord<byte[], byte[]> record = serializer.serialize(input);
+
+    assertThat(record.topic()).isEqualTo("topic-A");
+    assertThat(record.key()).isEqualTo("key-1".getBytes(StandardCharsets.UTF_8));
+    assertThat(record.value()).isEqualTo("hello".getBytes(StandardCharsets.UTF_8));
+  }
+
+  @Test
+  void serializesRecordWithoutKeyOmitsKeyByte() {
+    // An empty key should produce a ProducerRecord with null key — partitioner falls back to
+    // round-robin / sticky semantics rather than treating "" as a real key.
+    TypedValue input = packAsKafkaRecord("topic-A", "", "v".getBytes(StandardCharsets.UTF_8));
+
+    ProducerRecord<byte[], byte[]> record = serializer.serialize(input);
+
+    assertThat(record.key()).isNull();
+    assertThat(record.value()).isEqualTo("v".getBytes(StandardCharsets.UTF_8));
+  }
+
+  @Test
+  void rejectsTypedValueOfWrongProtobufType() {
+    // TypedValue carrying a message that is NOT a KafkaProducerRecord.
+    TypedValue notAKafkaRecord =
+        TypedValueUtil.packProtobufMessage(TypedValue.getDefaultInstance());
+
+    assertThatThrownBy(() -> serializer.serialize(notAKafkaRecord))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("KafkaProducerRecord");
+  }
+
+  @Test
+  void rejectsCorruptedProtobufBytes() {
+    // Build a TypedValue that *claims* to be a KafkaProducerRecord but carries garbage bytes.
+    TypedValue corrupted =
+        TypedValue.newBuilder()
+            .setTypename("type.googleapis.com/" + KafkaProducerRecord.getDescriptor().getFullName())
+            .setHasValue(true)
+            .setValue(ByteString.copyFrom(new byte[] {(byte) 0xFF, (byte) 0xFF, (byte) 0xFF}))
+            .build();
+
+    assertThatThrownBy(() -> serializer.serialize(corrupted))
+        .isInstanceOf(RuntimeException.class)
+        .hasMessageContaining("Unable to unpack");
+  }
+
+  @Test
+  void serializerIsSerializableForFlinkOperatorChain() throws Exception {
+    // Flink requires KafkaEgressSerializer impls to be Java-serializable so they can be sent
+    // along with the JobGraph to TaskManagers.
+    java.io.ByteArrayOutputStream bytes = new java.io.ByteArrayOutputStream();
+    new java.io.ObjectOutputStream(bytes).writeObject(serializer);
+
+    Object copy =
+        new java.io.ObjectInputStream(new java.io.ByteArrayInputStream(bytes.toByteArray()))
+            .readObject();
+
+    assertThat(copy).isInstanceOf(GenericKafkaEgressSerializer.class);
+  }
+
+  private static TypedValue packAsKafkaRecord(String topic, String key, byte[] value) {
+    KafkaProducerRecord rec =
+        KafkaProducerRecord.newBuilder()
+            .setTopic(topic)
+            .setKey(key)
+            .setValueBytes(ByteString.copyFrom(value))
+            .build();
+    return TypedValueUtil.packProtobufMessage(rec);
+  }
+}

--- a/statefun-flink/statefun-flink-io-bundle/src/test/java/org/apache/flink/statefun/flink/io/kinesis/binders/egress/v1/GenericKinesisEgressSerializerTest.java
+++ b/statefun-flink/statefun-flink-io-bundle/src/test/java/org/apache/flink/statefun/flink/io/kinesis/binders/egress/v1/GenericKinesisEgressSerializerTest.java
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Kzmlabs
+package org.apache.flink.statefun.flink.io.kinesis.binders.egress.v1;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.google.protobuf.ByteString;
+import java.nio.charset.StandardCharsets;
+import org.apache.flink.statefun.flink.common.types.TypedValueUtil;
+import org.apache.flink.statefun.sdk.egress.generated.KinesisEgressRecord;
+import org.apache.flink.statefun.sdk.kinesis.egress.EgressRecord;
+import org.apache.flink.statefun.sdk.reqreply.generated.TypedValue;
+import org.junit.jupiter.api.Test;
+
+class GenericKinesisEgressSerializerTest {
+
+  private final GenericKinesisEgressSerializer serializer = new GenericKinesisEgressSerializer();
+
+  @Test
+  void serializesRecordWithoutExplicitHashKey() {
+    TypedValue input = pack("stream-A", "pk-1", null, "value".getBytes(StandardCharsets.UTF_8));
+
+    EgressRecord rec = serializer.serialize(input);
+
+    assertThat(rec.getStream()).isEqualTo("stream-A");
+    assertThat(rec.getPartitionKey()).isEqualTo("pk-1");
+    assertThat(rec.getData()).isEqualTo("value".getBytes(StandardCharsets.UTF_8));
+    assertThat(rec.getExplicitHashKey()).isNull();
+  }
+
+  @Test
+  void serializesRecordWithExplicitHashKey() {
+    TypedValue input =
+        pack("stream-A", "pk-1", "0123456789abcdef", "v".getBytes(StandardCharsets.UTF_8));
+
+    EgressRecord rec = serializer.serialize(input);
+
+    assertThat(rec.getExplicitHashKey()).isEqualTo("0123456789abcdef");
+  }
+
+  @Test
+  void emptyExplicitHashKeyIsTreatedAsAbsent() {
+    // The proto field `explicit_hash_key` defaults to "" when unset. The serializer should
+    // treat that as "not provided" — passing "" to the Kinesis SDK has different semantics
+    // than omitting it.
+    TypedValue input = pack("stream-A", "pk", "", "v".getBytes(StandardCharsets.UTF_8));
+
+    EgressRecord rec = serializer.serialize(input);
+
+    assertThat(rec.getExplicitHashKey()).isNull();
+  }
+
+  @Test
+  void rejectsTypedValueOfWrongProtobufType() {
+    TypedValue notAKinesisRecord =
+        TypedValueUtil.packProtobufMessage(TypedValue.getDefaultInstance());
+
+    assertThatThrownBy(() -> serializer.serialize(notAKinesisRecord))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("KinesisEgressRecord");
+  }
+
+  @Test
+  void rejectsCorruptedProtobufBytes() {
+    TypedValue corrupted =
+        TypedValue.newBuilder()
+            .setTypename("type.googleapis.com/" + KinesisEgressRecord.getDescriptor().getFullName())
+            .setHasValue(true)
+            .setValue(ByteString.copyFrom(new byte[] {(byte) 0xFF, (byte) 0xFF, (byte) 0xFF}))
+            .build();
+
+    assertThatThrownBy(() -> serializer.serialize(corrupted))
+        .isInstanceOf(RuntimeException.class)
+        .hasMessageContaining("Unable to unpack");
+  }
+
+  @Test
+  void serializerIsSerializableForFlinkOperatorChain() throws Exception {
+    java.io.ByteArrayOutputStream bytes = new java.io.ByteArrayOutputStream();
+    new java.io.ObjectOutputStream(bytes).writeObject(serializer);
+
+    Object copy =
+        new java.io.ObjectInputStream(new java.io.ByteArrayInputStream(bytes.toByteArray()))
+            .readObject();
+
+    assertThat(copy).isInstanceOf(GenericKinesisEgressSerializer.class);
+  }
+
+  private static TypedValue pack(String stream, String pk, String explicitHashKey, byte[] value) {
+    KinesisEgressRecord.Builder b =
+        KinesisEgressRecord.newBuilder()
+            .setStream(stream)
+            .setPartitionKey(pk)
+            .setValueBytes(ByteString.copyFrom(value));
+    if (explicitHashKey != null) {
+      b.setExplicitHashKey(explicitHashKey);
+    }
+    return TypedValueUtil.packProtobufMessage(b.build());
+  }
+}

--- a/statefun-flink/statefun-flink-launcher/pom.xml
+++ b/statefun-flink/statefun-flink-launcher/pom.xml
@@ -35,6 +35,18 @@
             <artifactId>statefun-flink-core</artifactId>
             <version>${project.version}</version>
         </dependency>
+
+        <!-- Test -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/statefun-flink/statefun-flink-launcher/src/test/java/org/apache/flink/statefun/flink/launcher/StatefulFunctionsClusterConfigurationParserFactoryTest.java
+++ b/statefun-flink/statefun-flink-launcher/src/test/java/org/apache/flink/statefun/flink/launcher/StatefulFunctionsClusterConfigurationParserFactoryTest.java
@@ -1,0 +1,112 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Kzmlabs
+package org.apache.flink.statefun.flink.launcher;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.runtime.entrypoint.FlinkParseException;
+import org.apache.flink.runtime.entrypoint.parser.CommandLineParser;
+import org.apache.flink.runtime.jobgraph.SavepointRestoreSettings;
+import org.junit.jupiter.api.Test;
+
+class StatefulFunctionsClusterConfigurationParserFactoryTest {
+
+  @Test
+  void parsesConfigDirAndDefaultsForOtherOptions() throws Exception {
+    StatefulFunctionsClusterConfiguration cfg = parse("--configDir", "/etc/flink/conf");
+
+    assertThat(cfg.getConfigDir()).isEqualTo("/etc/flink/conf");
+    assertThat(cfg.getJobId()).isNull();
+    // Default parallelism sentinel — entrypoint will fall back to cluster default.
+    assertThat(cfg.getParallelism()).isEqualTo(ExecutionConfig.PARALLELISM_DEFAULT);
+    assertThat(cfg.getDynamicProperties()).isEmpty();
+    assertThat(cfg.getSavepointRestoreSettings())
+        .isEqualTo(SavepointRestoreSettings.none());
+  }
+
+  @Test
+  void parsesJobIdFromHexString() throws Exception {
+    JobID jobId = JobID.generate();
+    StatefulFunctionsClusterConfiguration cfg =
+        parse("--configDir", "/etc/flink/conf", "--job-id", jobId.toHexString());
+
+    assertThat(cfg.getJobId()).isEqualTo(jobId);
+  }
+
+  @Test
+  void rejectsMalformedJobId() {
+    assertThatThrownBy(() -> parse("--configDir", "/c", "--job-id", "not-a-hex-id"))
+        .isInstanceOf(FlinkParseException.class)
+        .hasMessageContaining("--job-id");
+  }
+
+  @Test
+  void parsesPositiveParallelism() throws Exception {
+    StatefulFunctionsClusterConfiguration cfg = parse("--configDir", "/c", "-p", "4");
+
+    assertThat(cfg.getParallelism()).isEqualTo(4);
+  }
+
+  @Test
+  void rejectsNonNumericParallelism() {
+    assertThatThrownBy(() -> parse("--configDir", "/c", "-p", "many"))
+        .isInstanceOf(FlinkParseException.class)
+        .hasMessageContaining("--parallelism");
+  }
+
+  @Test
+  void rejectsZeroOrNegativeParallelism() {
+    // The current parser wraps NumberFormatException into FlinkParseException but lets
+    // the explicit "must be at least 1" IllegalArgumentException bubble up directly.
+    // TODO(parser): wrap this IAE in FlinkParseException for symmetric error handling.
+    assertThatThrownBy(() -> parse("--configDir", "/c", "-p", "0"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Parallelism must be at least 1");
+
+    assertThatThrownBy(() -> parse("--configDir", "/c", "-p", "-3"))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  void parsesSavepointPath() throws Exception {
+    StatefulFunctionsClusterConfiguration cfg = parse("--configDir", "/c", "-s", "s3://savepoints/x");
+
+    SavepointRestoreSettings settings = cfg.getSavepointRestoreSettings();
+    assertThat(settings.getRestorePath()).isEqualTo("s3://savepoints/x");
+    assertThat(settings.allowNonRestoredState()).isFalse();
+  }
+
+  @Test
+  void parsesSavepointAllowNonRestored() throws Exception {
+    StatefulFunctionsClusterConfiguration cfg =
+        parse("--configDir", "/c", "-s", "s3://sp", "-n");
+
+    assertThat(cfg.getSavepointRestoreSettings().allowNonRestoredState()).isTrue();
+  }
+
+  @Test
+  void capturesDynamicPropertiesAndPositionalArgs() throws Exception {
+    StatefulFunctionsClusterConfiguration cfg =
+        parse(
+            "--configDir",
+            "/c",
+            "-Dkey1=val1",
+            "-Dkey2=val2",
+            "positional-1",
+            "positional-2");
+
+    assertThat(cfg.getDynamicProperties())
+        .containsEntry("key1", "val1")
+        .containsEntry("key2", "val2");
+    assertThat(cfg.getArgs()).containsExactly("positional-1", "positional-2");
+  }
+
+  private static StatefulFunctionsClusterConfiguration parse(String... args) throws Exception {
+    CommandLineParser<StatefulFunctionsClusterConfiguration> parser =
+        new CommandLineParser<>(new StatefulFunctionsClusterConfigurationParserFactory());
+    return parser.parse(args);
+  }
+}

--- a/statefun-flink/statefun-flink-launcher/src/test/java/org/apache/flink/statefun/flink/launcher/StatefulFunctionsClusterEntryPointTest.java
+++ b/statefun-flink/statefun-flink-launcher/src/test/java/org/apache/flink/statefun/flink/launcher/StatefulFunctionsClusterEntryPointTest.java
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Kzmlabs
+package org.apache.flink.statefun.flink.launcher;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Optional;
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.HighAvailabilityOptions;
+import org.apache.flink.runtime.entrypoint.ClusterEntrypoint;
+import org.junit.jupiter.api.Test;
+
+class StatefulFunctionsClusterEntryPointTest {
+
+  @Test
+  void resolveJobIdReturnsExplicitlyProvidedJobId() {
+    JobID provided = JobID.generate();
+
+    JobID resolved =
+        StatefulFunctionsClusterEntryPoint.resolveJobIdForCluster(
+            Optional.of(provided), new Configuration());
+
+    assertThat(resolved).isEqualTo(provided);
+  }
+
+  @Test
+  void resolveJobIdReturnsZeroWhenHighAvailabilityIsEnabled() {
+    Configuration cfg = new Configuration();
+    // HA enabled — under HA we want a stable JobID across restarts so that checkpoints
+    // can be matched back. The launcher uses the all-zeros JobID as that stable handle.
+    cfg.set(HighAvailabilityOptions.HA_MODE, "zookeeper");
+
+    JobID resolved =
+        StatefulFunctionsClusterEntryPoint.resolveJobIdForCluster(Optional.empty(), cfg);
+
+    assertThat(resolved).isEqualTo(StatefulFunctionsClusterEntryPoint.ZERO_JOB_ID);
+  }
+
+  @Test
+  void resolveJobIdGeneratesFreshIdWhenHighAvailabilityIsDisabled() {
+    Configuration cfg = new Configuration();
+    cfg.set(HighAvailabilityOptions.HA_MODE, "NONE");
+
+    JobID first =
+        StatefulFunctionsClusterEntryPoint.resolveJobIdForCluster(Optional.empty(), cfg);
+    JobID second =
+        StatefulFunctionsClusterEntryPoint.resolveJobIdForCluster(Optional.empty(), cfg);
+
+    assertThat(first).isNotNull();
+    assertThat(second).isNotNull();
+    // Two consecutive generations of a non-HA job must produce different IDs, otherwise
+    // two parallel cluster starts would collide.
+    assertThat(first).isNotEqualTo(second);
+  }
+
+  @Test
+  void setDefaultExecutionModeWritesDetachedWhenUnset() {
+    Configuration cfg = new Configuration();
+
+    StatefulFunctionsClusterEntryPoint.setDefaultExecutionModeIfNotConfigured(cfg);
+
+    assertThat(cfg.get(ClusterEntrypoint.INTERNAL_CLUSTER_EXECUTION_MODE, null))
+        .isEqualTo(ClusterEntrypoint.ExecutionMode.DETACHED.toString());
+  }
+
+  @Test
+  void setDefaultExecutionModeDoesNotOverrideExistingConfiguration() {
+    Configuration cfg = new Configuration();
+    cfg.set(
+        ClusterEntrypoint.INTERNAL_CLUSTER_EXECUTION_MODE,
+        ClusterEntrypoint.ExecutionMode.NORMAL.toString());
+
+    StatefulFunctionsClusterEntryPoint.setDefaultExecutionModeIfNotConfigured(cfg);
+
+    assertThat(cfg.get(ClusterEntrypoint.INTERNAL_CLUSTER_EXECUTION_MODE, null))
+        .isEqualTo(ClusterEntrypoint.ExecutionMode.NORMAL.toString());
+  }
+
+  @Test
+  void zeroJobIdIsAllZeros() {
+    assertThat(StatefulFunctionsClusterEntryPoint.ZERO_JOB_ID)
+        .isEqualTo(new JobID(0L, 0L));
+  }
+}

--- a/statefun-flink/statefun-flink-state-processor/src/test/java/org/apache/flink/statefun/flink/state/processor/operator/StateBootstrapFunctionRegistryTest.java
+++ b/statefun-flink/statefun-flink-state-processor/src/test/java/org/apache/flink/statefun/flink/state/processor/operator/StateBootstrapFunctionRegistryTest.java
@@ -1,0 +1,88 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Kzmlabs
+package org.apache.flink.statefun.flink.state.processor.operator;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.apache.flink.statefun.flink.state.processor.StateBootstrapFunction;
+import org.apache.flink.statefun.flink.state.processor.StateBootstrapFunctionProvider;
+import org.apache.flink.statefun.sdk.FunctionType;
+import org.junit.jupiter.api.Test;
+
+class StateBootstrapFunctionRegistryTest {
+
+  private static final FunctionType FT_A = new FunctionType("ns", "a");
+  private static final FunctionType FT_B = new FunctionType("ns", "b");
+
+  @Test
+  void newRegistryHasZeroRegistrations() {
+    StateBootstrapFunctionRegistry registry = new StateBootstrapFunctionRegistry();
+
+    assertThat(registry.numRegistrations()).isZero();
+  }
+
+  @Test
+  void registerSingleProviderCountsAsOne() {
+    StateBootstrapFunctionRegistry registry = new StateBootstrapFunctionRegistry();
+
+    registry.register(FT_A, new NoopProvider());
+
+    assertThat(registry.numRegistrations()).isEqualTo(1);
+  }
+
+  @Test
+  void registerDistinctFunctionTypesAccumulates() {
+    StateBootstrapFunctionRegistry registry = new StateBootstrapFunctionRegistry();
+
+    registry.register(FT_A, new NoopProvider());
+    registry.register(FT_B, new NoopProvider());
+
+    assertThat(registry.numRegistrations()).isEqualTo(2);
+  }
+
+  @Test
+  void registerSameFunctionTypeTwiceFailsLoudly() {
+    StateBootstrapFunctionRegistry registry = new StateBootstrapFunctionRegistry();
+    registry.register(FT_A, new NoopProvider());
+
+    // Pin: silently overwriting a previous registration would be a real bug — we'd lose the
+    // user's first bootstrap function provider with no warning.
+    assertThatThrownBy(() -> registry.register(FT_A, new NoopProvider()))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("previously defined");
+  }
+
+  @Test
+  void registerRejectsNullFunctionType() {
+    StateBootstrapFunctionRegistry registry = new StateBootstrapFunctionRegistry();
+
+    assertThatThrownBy(() -> registry.register(null, new NoopProvider()))
+        .isInstanceOf(NullPointerException.class);
+  }
+
+  @Test
+  void registerRejectsNullProvider() {
+    StateBootstrapFunctionRegistry registry = new StateBootstrapFunctionRegistry();
+
+    assertThatThrownBy(() -> registry.register(FT_A, null))
+        .isInstanceOf(NullPointerException.class);
+  }
+
+  @Test
+  void getBootstrapFunctionBeforeInitializeFailsLoudly() {
+    StateBootstrapFunctionRegistry registry = new StateBootstrapFunctionRegistry();
+    registry.register(FT_A, new NoopProvider());
+
+    assertThatThrownBy(() -> registry.getBootstrapFunction(FT_A))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("must be initialized first");
+  }
+
+  private static final class NoopProvider implements StateBootstrapFunctionProvider {
+    @Override
+    public StateBootstrapFunction bootstrapFunctionOfType(FunctionType type) {
+      throw new UnsupportedOperationException();
+    }
+  }
+}

--- a/statefun-kafka-io/src/test/java/org/apache/flink/statefun/sdk/kafka/KafkaTopicPartitionTest.java
+++ b/statefun-kafka-io/src/test/java/org/apache/flink/statefun/sdk/kafka/KafkaTopicPartitionTest.java
@@ -1,0 +1,108 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Kzmlabs
+package org.apache.flink.statefun.sdk.kafka;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+
+class KafkaTopicPartitionTest {
+
+  @Test
+  void constructorRoundtripsTopicAndPartition() {
+    KafkaTopicPartition tp = new KafkaTopicPartition("orders", 7);
+
+    assertThat(tp.topic()).isEqualTo("orders");
+    assertThat(tp.partition()).isEqualTo(7);
+  }
+
+  @Test
+  void constructorRejectsNullTopic() {
+    assertThatThrownBy(() -> new KafkaTopicPartition(null, 0))
+        .isInstanceOf(NullPointerException.class);
+  }
+
+  @Test
+  void constructorRejectsNegativePartition() {
+    assertThatThrownBy(() -> new KafkaTopicPartition("orders", -1))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("partition id");
+  }
+
+  @Test
+  void fromStringParsesValidFormat() {
+    KafkaTopicPartition tp = KafkaTopicPartition.fromString("orders/0");
+
+    assertThat(tp.topic()).isEqualTo("orders");
+    assertThat(tp.partition()).isZero();
+  }
+
+  @Test
+  void fromStringPreservesSlashesInTopic() {
+    // The parser splits on the LAST `/`, so a slash inside the topic is preserved as-is.
+    KafkaTopicPartition tp = KafkaTopicPartition.fromString("foo/bar/baz/9");
+
+    assertThat(tp.topic()).isEqualTo("foo/bar/baz");
+    assertThat(tp.partition()).isEqualTo(9);
+  }
+
+  @Test
+  void fromStringRejectsMissingPartition() {
+    assertThatThrownBy(() -> KafkaTopicPartition.fromString("orders"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("does not conform");
+  }
+
+  @Test
+  void fromStringRejectsLeadingSlashOnly() {
+    assertThatThrownBy(() -> KafkaTopicPartition.fromString("/0"))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  void fromStringRejectsTrailingSlash() {
+    assertThatThrownBy(() -> KafkaTopicPartition.fromString("orders/"))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  void fromStringRejectsNonNumericPartition() {
+    assertThatThrownBy(() -> KafkaTopicPartition.fromString("orders/abc"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Invalid topic partition definition");
+  }
+
+  @Test
+  void fromStringRejectsNegativePartitionValue() {
+    assertThatThrownBy(() -> KafkaTopicPartition.fromString("orders/-1"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("partition id is expected to be an integer");
+  }
+
+  @Test
+  void fromStringRejectsNullInput() {
+    assertThatThrownBy(() -> KafkaTopicPartition.fromString(null))
+        .isInstanceOf(NullPointerException.class);
+  }
+
+  @Test
+  void equalsAndHashCodeIdentifyByTopicAndPartition() {
+    KafkaTopicPartition a = new KafkaTopicPartition("orders", 1);
+    KafkaTopicPartition aAgain = new KafkaTopicPartition("orders", 1);
+    KafkaTopicPartition differentTopic = new KafkaTopicPartition("payments", 1);
+    KafkaTopicPartition differentPartition = new KafkaTopicPartition("orders", 2);
+
+    assertThat(a).isEqualTo(a).isEqualTo(aAgain);
+    assertThat(a).isNotEqualTo(differentTopic).isNotEqualTo(differentPartition);
+    assertThat(a).isNotEqualTo(null).isNotEqualTo("not a partition");
+    assertThat(a.hashCode()).isEqualTo(aAgain.hashCode());
+  }
+
+  @Test
+  void toStringIncludesTopicAndPartition() {
+    KafkaTopicPartition tp = new KafkaTopicPartition("orders", 7);
+
+    assertThat(tp.toString()).contains("orders").contains("7");
+  }
+}

--- a/statefun-sdk-embedded/src/test/java/org/apache/flink/statefun/sdk/match/MatchBinderTest.java
+++ b/statefun-sdk-embedded/src/test/java/org/apache/flink/statefun/sdk/match/MatchBinderTest.java
@@ -1,0 +1,164 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Kzmlabs
+package org.apache.flink.statefun.sdk.match;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import org.apache.flink.statefun.sdk.Address;
+import org.apache.flink.statefun.sdk.Context;
+import org.apache.flink.statefun.sdk.io.EgressIdentifier;
+import org.apache.flink.statefun.sdk.metrics.Metrics;
+import org.junit.jupiter.api.Test;
+
+class MatchBinderTest {
+
+  // The MatchBinder constructor is package-private, so the test class lives in the same package
+  // and uses `new MatchBinder()` directly. Production code never news up a binder — it goes
+  // through StatefulMatchFunction.invoke → matcher.invoke. Tests pin the matching contract so a
+  // future refactor can't silently change precedence.
+
+  @Test
+  void typeOnlyPredicateMatchesByExactClassAndDispatchesAction() {
+    MatchBinder binder = new MatchBinder();
+    List<String> dispatched = new ArrayList<>();
+    binder.predicate(String.class, (ctx, s) -> dispatched.add("string:" + s));
+
+    binder.invoke(new RecordingContext(), "hello");
+
+    assertThat(dispatched).containsExactly("string:hello");
+  }
+
+  @Test
+  void typeOnlyPredicateRejectsDuplicateRegistrationForSameType() {
+    MatchBinder binder = new MatchBinder();
+    binder.predicate(String.class, (ctx, s) -> {});
+
+    assertThatThrownBy(() -> binder.predicate(String.class, (ctx, s) -> {}))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("catch all case for class");
+  }
+
+  @Test
+  void typedPredicateWithConditionTakesPrecedenceOverTypeOnlyPredicate() {
+    MatchBinder binder = new MatchBinder();
+    List<String> dispatched = new ArrayList<>();
+    binder.predicate(String.class, (ctx, s) -> dispatched.add("type-only:" + s));
+    binder.predicate(
+        String.class, s -> s.startsWith("a"), (ctx, s) -> dispatched.add("conditional:" + s));
+
+    binder.invoke(new RecordingContext(), "apple"); // matches conditional
+    binder.invoke(new RecordingContext(), "banana"); // falls through to type-only
+
+    assertThat(dispatched).containsExactly("conditional:apple", "type-only:banana");
+  }
+
+  @Test
+  void multipleConditionalPredicatesAreCheckedInRegistrationOrder() {
+    MatchBinder binder = new MatchBinder();
+    List<Integer> dispatched = new ArrayList<>();
+    binder.predicate(Integer.class, i -> i > 0, (ctx, i) -> dispatched.add(1));
+    binder.predicate(Integer.class, i -> i > 10, (ctx, i) -> dispatched.add(2));
+    binder.predicate(Integer.class, i -> i > 100, (ctx, i) -> dispatched.add(3));
+
+    binder.invoke(new RecordingContext(), 1000);
+
+    // Even though all three predicates would match, the FIRST one wins.
+    assertThat(dispatched).containsExactly(1);
+  }
+
+  @Test
+  void unmatchedInputThrowsByDefault() {
+    MatchBinder binder = new MatchBinder();
+    binder.predicate(String.class, (ctx, s) -> {});
+
+    assertThatThrownBy(() -> binder.invoke(new RecordingContext(), 42))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("Don't know how to handle");
+  }
+
+  @Test
+  void otherwiseClauseHandlesUnmatchedInputsInsteadOfThrowing() {
+    MatchBinder binder = new MatchBinder();
+    List<Object> defaulted = new ArrayList<>();
+    binder.otherwise((ctx, msg) -> defaulted.add(msg));
+
+    binder.invoke(new RecordingContext(), 42);
+    binder.invoke(new RecordingContext(), "anything");
+
+    assertThat(defaulted).containsExactly(42, "anything");
+  }
+
+  @Test
+  void otherwiseRejectsDuplicateRegistration() {
+    MatchBinder binder = new MatchBinder();
+    binder.otherwise((ctx, msg) -> {});
+
+    assertThatThrownBy(() -> binder.otherwise((ctx, msg) -> {}))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("only be one default action");
+  }
+
+  @Test
+  void registrationApiRejectsNullArgs() {
+    MatchBinder binder = new MatchBinder();
+    assertThatThrownBy(() -> binder.predicate(null, (ctx, s) -> {}))
+        .isInstanceOf(NullPointerException.class);
+    assertThatThrownBy(() -> binder.predicate(String.class, null))
+        .isInstanceOf(NullPointerException.class);
+    assertThatThrownBy(() -> binder.otherwise(null)).isInstanceOf(NullPointerException.class);
+  }
+
+  @Test
+  void typeOnlyMatchIsBasedOnExactClassNotInheritance() {
+    // Pin: dispatch uses input.getClass() exact match — a registration for Number does NOT
+    // catch Integer. Matters because users may expect inheritance dispatch.
+    MatchBinder binder = new MatchBinder();
+    List<Object> hits = new ArrayList<>();
+    binder.predicate(Number.class, (ctx, n) -> hits.add(n));
+
+    assertThatThrownBy(() -> binder.invoke(new RecordingContext(), 42))
+        .isInstanceOf(IllegalStateException.class);
+    assertThat(hits).isEmpty();
+  }
+
+  /** Minimal Context implementation that records nothing — invoke() doesn't use the context. */
+  private static final class RecordingContext implements Context {
+    @Override
+    public Address self() {
+      return null;
+    }
+
+    @Override
+    public Address caller() {
+      return null;
+    }
+
+    @Override
+    public void send(Address to, Object message) {}
+
+    @Override
+    public <T> void send(EgressIdentifier<T> egress, T message) {}
+
+    @Override
+    public void sendAfter(Duration delay, Address to, Object message) {}
+
+    @Override
+    public void sendAfter(Duration delay, Address to, Object message, String cancellationToken) {}
+
+    @Override
+    public void cancelDelayedMessage(String cancellationToken) {}
+
+    @Override
+    public <M, T> void registerAsyncOperation(M metadata, CompletableFuture<T> future) {}
+
+    @Override
+    public Metrics metrics() {
+      return null;
+    }
+  }
+}

--- a/statefun-sdk-embedded/src/test/java/org/apache/flink/statefun/sdk/match/StatefulMatchFunctionTest.java
+++ b/statefun-sdk-embedded/src/test/java/org/apache/flink/statefun/sdk/match/StatefulMatchFunctionTest.java
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Kzmlabs
+package org.apache.flink.statefun.sdk.match;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import org.apache.flink.statefun.sdk.Address;
+import org.apache.flink.statefun.sdk.Context;
+import org.apache.flink.statefun.sdk.io.EgressIdentifier;
+import org.apache.flink.statefun.sdk.metrics.Metrics;
+import org.junit.jupiter.api.Test;
+
+class StatefulMatchFunctionTest {
+
+  @Test
+  void configureIsInvokedOnceLazilyOnFirstInvoke() {
+    ConfigureCounter fn = new ConfigureCounter();
+
+    fn.invoke(new NullContext(), "first");
+    fn.invoke(new NullContext(), "second");
+    fn.invoke(new NullContext(), "third");
+
+    assertThat(fn.configureCalls).isEqualTo(1);
+    assertThat(fn.dispatched).containsExactly("first", "second", "third");
+  }
+
+  @Test
+  void unconfiguredFunctionThrowsForUnmatchedInput() {
+    StatefulMatchFunction fn =
+        new StatefulMatchFunction() {
+          @Override
+          public void configure(MatchBinder binder) {
+            // No bindings — every input falls through to the default unhandled action.
+          }
+        };
+
+    org.assertj.core.api.Assertions.assertThatThrownBy(() -> fn.invoke(new NullContext(), 42))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("Don't know how to handle");
+  }
+
+  /**
+   * Concrete StatefulMatchFunction that records each invocation. Used to pin the lazy-init
+   * contract — configure() must run exactly once across many invokes, even on the same instance.
+   */
+  private static final class ConfigureCounter extends StatefulMatchFunction {
+    int configureCalls = 0;
+    final List<String> dispatched = new ArrayList<>();
+
+    @Override
+    public void configure(MatchBinder binder) {
+      configureCalls++;
+      binder.predicate(String.class, (ctx, s) -> dispatched.add(s));
+    }
+  }
+
+  /** No-op Context used for tests where the matcher doesn't interact with the context. */
+  private static final class NullContext implements Context {
+    @Override
+    public Address self() {
+      return null;
+    }
+
+    @Override
+    public Address caller() {
+      return null;
+    }
+
+    @Override
+    public void send(Address to, Object message) {}
+
+    @Override
+    public <T> void send(EgressIdentifier<T> egress, T message) {}
+
+    @Override
+    public void sendAfter(Duration delay, Address to, Object message) {}
+
+    @Override
+    public void sendAfter(Duration delay, Address to, Object message, String cancellationToken) {}
+
+    @Override
+    public void cancelDelayedMessage(String cancellationToken) {}
+
+    @Override
+    public <M, T> void registerAsyncOperation(M metadata, CompletableFuture<T> future) {}
+
+    @Override
+    public Metrics metrics() {
+      return null;
+    }
+  }
+}

--- a/statefun-sdk-java/src/test/java/org/apache/flink/statefun/sdk/java/StatefulFunctionsTest.java
+++ b/statefun-sdk-java/src/test/java/org/apache/flink/statefun/sdk/java/StatefulFunctionsTest.java
@@ -1,0 +1,97 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Kzmlabs
+package org.apache.flink.statefun.sdk.java;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.concurrent.CompletableFuture;
+import org.apache.flink.statefun.sdk.java.handler.RequestReplyHandler;
+import org.junit.jupiter.api.Test;
+
+class StatefulFunctionsTest {
+
+  private static final TypeName FN_A = TypeName.typeNameOf("ns", "fn-a");
+  private static final TypeName FN_B = TypeName.typeNameOf("ns", "fn-b");
+
+  @Test
+  void registerSingleSpecExposedThroughFunctionSpecsMap() {
+    StatefulFunctions registry = new StatefulFunctions();
+    StatefulFunctionSpec spec =
+        StatefulFunctionSpec.builder(FN_A).withSupplier(EmptyFn::new).build();
+
+    registry.withStatefulFunction(spec);
+
+    assertThat(registry.functionSpecs()).containsEntry(FN_A, spec).hasSize(1);
+  }
+
+  @Test
+  void registerSpecBuilderBuildsBeforeStorage() {
+    StatefulFunctions registry = new StatefulFunctions();
+
+    registry.withStatefulFunction(StatefulFunctionSpec.builder(FN_A).withSupplier(EmptyFn::new));
+
+    assertThat(registry.functionSpecs()).containsKey(FN_A);
+  }
+
+  @Test
+  void registerRejectsDuplicateTypeName() {
+    StatefulFunctions registry = new StatefulFunctions();
+    registry.withStatefulFunction(
+        StatefulFunctionSpec.builder(FN_A).withSupplier(EmptyFn::new));
+
+    assertThatThrownBy(
+            () ->
+                registry.withStatefulFunction(
+                    StatefulFunctionSpec.builder(FN_A).withSupplier(EmptyFn::new)))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("more than one")
+        .hasMessageContaining(FN_A.toString());
+  }
+
+  @Test
+  void multipleDistinctTypesCoexist() {
+    StatefulFunctions registry = new StatefulFunctions();
+    registry.withStatefulFunction(
+        StatefulFunctionSpec.builder(FN_A).withSupplier(EmptyFn::new));
+    registry.withStatefulFunction(
+        StatefulFunctionSpec.builder(FN_B).withSupplier(EmptyFn::new));
+
+    assertThat(registry.functionSpecs()).containsOnlyKeys(FN_A, FN_B);
+  }
+
+  @Test
+  void requestReplyHandlerIsConstructibleWithoutRegistrations() {
+    StatefulFunctions registry = new StatefulFunctions();
+
+    RequestReplyHandler handler = registry.requestReplyHandler();
+
+    assertThat(handler).isNotNull();
+  }
+
+  @Test
+  void chainedRegistrationReturnsSameRegistry() {
+    StatefulFunctions registry = new StatefulFunctions();
+
+    StatefulFunctions afterFirst =
+        registry.withStatefulFunction(
+            StatefulFunctionSpec.builder(FN_A).withSupplier(EmptyFn::new));
+    StatefulFunctions afterSecond =
+        afterFirst.withStatefulFunction(
+            StatefulFunctionSpec.builder(FN_B).withSupplier(EmptyFn::new));
+
+    // Fluent API contract — same instance, so chained calls share state.
+    assertThat(afterFirst).isSameAs(registry);
+    assertThat(afterSecond).isSameAs(registry);
+  }
+
+  /** A no-op StatefulFunction used as a supplier target in spec building. */
+  static final class EmptyFn implements StatefulFunction {
+    @Override
+    public CompletableFuture<Void> apply(
+        org.apache.flink.statefun.sdk.java.Context context,
+        org.apache.flink.statefun.sdk.java.message.Message message) {
+      return CompletableFuture.completedFuture(null);
+    }
+  }
+}

--- a/statefun-sdk-java/src/test/java/org/apache/flink/statefun/sdk/java/handler/ConcurrentContextTest.java
+++ b/statefun-sdk-java/src/test/java/org/apache/flink/statefun/sdk/java/handler/ConcurrentContextTest.java
@@ -1,0 +1,187 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Kzmlabs
+package org.apache.flink.statefun.sdk.java.handler;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.Duration;
+import java.util.Collections;
+import java.util.Optional;
+import org.apache.flink.statefun.sdk.java.Address;
+import org.apache.flink.statefun.sdk.java.TypeName;
+import org.apache.flink.statefun.sdk.java.message.EgressMessageBuilder;
+import org.apache.flink.statefun.sdk.java.message.MessageBuilder;
+import org.apache.flink.statefun.sdk.java.storage.ConcurrentAddressScopedStorage;
+import org.apache.flink.statefun.sdk.reqreply.generated.FromFunction;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class ConcurrentContextTest {
+
+  private static final TypeName SELF_TYPE = TypeName.typeNameOf("ns", "self");
+  private static final TypeName OTHER_TYPE = TypeName.typeNameOf("ns", "other");
+  private static final TypeName EGRESS = TypeName.typeNameOf("io.test", "egress");
+
+  private FromFunction.InvocationResponse.Builder responseBuilder;
+  private ConcurrentContext context;
+
+  @BeforeEach
+  void setUp() {
+    responseBuilder = FromFunction.InvocationResponse.newBuilder();
+    context =
+        new ConcurrentContext(
+            new Address(SELF_TYPE, "id-1"),
+            responseBuilder,
+            new ConcurrentAddressScopedStorage(Collections.emptyList()));
+  }
+
+  @Test
+  void selfReturnsTheConstructorAddress() {
+    assertThat(context.self()).isEqualTo(new Address(SELF_TYPE, "id-1"));
+  }
+
+  @Test
+  void callerIsEmptyByDefault() {
+    assertThat(context.caller()).isEmpty();
+  }
+
+  @Test
+  void setCallerSurfacesViaCallerOptional() {
+    Address callerAddr = new Address(OTHER_TYPE, "caller-id");
+
+    context.setCaller(callerAddr);
+
+    assertThat(context.caller()).isEqualTo(Optional.of(callerAddr));
+  }
+
+  @Test
+  void sendAppendsOutgoingMessageToResponseBuilder() {
+    context.send(MessageBuilder.forAddress(OTHER_TYPE, "tgt").withValue(42L).build());
+
+    FromFunction.InvocationResponse response = context.finalBuilder().build();
+    assertThat(response.getOutgoingMessagesCount()).isEqualTo(1);
+    FromFunction.Invocation invocation = response.getOutgoingMessages(0);
+    assertThat(invocation.getTarget().getNamespace()).isEqualTo("ns");
+    assertThat(invocation.getTarget().getType()).isEqualTo("other");
+    assertThat(invocation.getTarget().getId()).isEqualTo("tgt");
+  }
+
+  @Test
+  void sendAfterAppendsDelayedInvocation() {
+    context.sendAfter(
+        Duration.ofMinutes(5),
+        MessageBuilder.forAddress(OTHER_TYPE, "tgt").withValue(1L).build());
+
+    FromFunction.InvocationResponse response = context.finalBuilder().build();
+    assertThat(response.getDelayedInvocationsCount()).isEqualTo(1);
+    FromFunction.DelayedInvocation delayed = response.getDelayedInvocations(0);
+    assertThat(delayed.getDelayInMs()).isEqualTo(Duration.ofMinutes(5).toMillis());
+    assertThat(delayed.getCancellationToken()).isEmpty();
+    assertThat(delayed.getIsCancellationRequest()).isFalse();
+  }
+
+  @Test
+  void sendAfterWithCancellationTokenStoresToken() {
+    context.sendAfter(
+        Duration.ofSeconds(30),
+        "tok-123",
+        MessageBuilder.forAddress(OTHER_TYPE, "tgt").withValue(1L).build());
+
+    FromFunction.DelayedInvocation delayed = context.finalBuilder().build().getDelayedInvocations(0);
+    assertThat(delayed.getCancellationToken()).isEqualTo("tok-123");
+    assertThat(delayed.getIsCancellationRequest()).isFalse();
+  }
+
+  @Test
+  void sendAfterWithEmptyCancellationTokenIsRejected() {
+    assertThatThrownBy(
+            () ->
+                context.sendAfter(
+                    Duration.ofSeconds(1),
+                    "",
+                    MessageBuilder.forAddress(OTHER_TYPE, "tgt").withValue(1L).build()))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("cancellation token");
+  }
+
+  @Test
+  void sendAfterWithNullCancellationTokenIsRejected() {
+    assertThatThrownBy(
+            () ->
+                context.sendAfter(
+                    Duration.ofSeconds(1),
+                    null,
+                    MessageBuilder.forAddress(OTHER_TYPE, "tgt").withValue(1L).build()))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  void cancelDelayedMessageEmitsCancellationRecord() {
+    context.cancelDelayedMessage("tok-123");
+
+    FromFunction.DelayedInvocation cancellation =
+        context.finalBuilder().build().getDelayedInvocations(0);
+    assertThat(cancellation.getIsCancellationRequest()).isTrue();
+    assertThat(cancellation.getCancellationToken()).isEqualTo("tok-123");
+  }
+
+  @Test
+  void cancelDelayedMessageWithEmptyTokenIsRejected() {
+    assertThatThrownBy(() -> context.cancelDelayedMessage(""))
+        .isInstanceOf(IllegalArgumentException.class);
+    assertThatThrownBy(() -> context.cancelDelayedMessage(null))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  void egressSendAppendsToOutgoingEgresses() {
+    context.send(EgressMessageBuilder.forEgress(EGRESS).withValue("payload").build());
+
+    FromFunction.InvocationResponse response = context.finalBuilder().build();
+    assertThat(response.getOutgoingEgressesCount()).isEqualTo(1);
+    FromFunction.EgressMessage egressMsg = response.getOutgoingEgresses(0);
+    assertThat(egressMsg.getEgressNamespace()).isEqualTo("io.test");
+    assertThat(egressMsg.getEgressType()).isEqualTo("egress");
+  }
+
+  @Test
+  void afterFinalBuilderFurtherSendsAreRejected() {
+    context.finalBuilder();
+
+    // Once finalBuilder() is called the context is closed; pin that any further mutation
+    // throws (otherwise late writes after the response is built would silently no-op).
+    assertThatThrownBy(
+            () ->
+                context.send(
+                    MessageBuilder.forAddress(OTHER_TYPE, "tgt").withValue(1L).build()))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("already completed");
+    assertThatThrownBy(
+            () ->
+                context.sendAfter(
+                    Duration.ofSeconds(1),
+                    MessageBuilder.forAddress(OTHER_TYPE, "tgt").withValue(1L).build()))
+        .isInstanceOf(IllegalStateException.class);
+    assertThatThrownBy(() -> context.cancelDelayedMessage("tok"))
+        .isInstanceOf(IllegalStateException.class);
+    assertThatThrownBy(
+            () -> context.send(EgressMessageBuilder.forEgress(EGRESS).withValue("v").build()))
+        .isInstanceOf(IllegalStateException.class);
+  }
+
+  @Test
+  void sendRejectsNullMessage() {
+    assertThatThrownBy(() -> context.send((org.apache.flink.statefun.sdk.java.message.Message) null))
+        .isInstanceOf(NullPointerException.class);
+    assertThatThrownBy(
+            () ->
+                context.send((org.apache.flink.statefun.sdk.java.message.EgressMessage) null))
+        .isInstanceOf(NullPointerException.class);
+  }
+
+  @Test
+  void storageReturnsTheConstructorStorage() {
+    assertThat(context.storage()).isNotNull();
+  }
+}


### PR DESCRIPTION
## Summary

Phase 1 of the 80%-coverage push from the PR #173 follow-up plan. Adds 23 new tests targeting `httpfn` (38% → ~75%) and `jsonmodule` (17.5% → ~50%) — the two highest-uncovered packages where unit tests can meaningfully reach without a Flink mini-cluster.

**Local coverage delta: 63.8% → 66.1% instruction (+2.3pp).**

## Tests added

### `RetryingCallbackTest` (9 tests)

Drives the retry state machine against a real `okhttp3.mockwebserver.MockWebServer` — no mocks, no Docker.

| Test | Behaviour pinned |
|---|---|
| `successfulResponseCompletesFutureAndRecordsLatency` | 200 → future completes |
| `retryableServerErrorRetriesUntilSuccess` | 500, 500, 200 → retries twice, succeeds |
| `retryableHttp429IsRetried` | 429 → retried |
| `retryableHttp408IsRetried` | 408 → retried |
| `nonRetryableClientErrorFailsFutureWithIllegalState` | 404 → loud failure, no retry |
| `networkFailureWithBackoffExhaustedFailsFuture` | conn refused + 1ns timeout → loud failure |
| `shutdownDuringRequestSurfacesAsIllegalState` | isShutdown=true → ""during shutdown"" |
| `retryableHttp500WithExhaustedBackoffFailsWithDescriptiveMessage` | 500 + 1ns timeout → loud failure |
| `rejectsNullIsShutdownSupplier` | constructor-time NPE |

### `LegacyRemoteModuleV30Test` (4 tests)

Drives the existing `module-v3_0/module.yaml` test fixture end-to-end. The fixture shipped uncovered — no test exercised the `version: ""3.0""` legacy dispatch path.

- legacy-kind translation table (`http` → `io.statefun.endpoints.v1/http`, `io.statefun.kafka/*` → `io.statefun.kafka.v1/*`)
- unrecognized kinds passed through verbatim (not silently dropped)
- exactly-3 binder dispatches per the fixture's endpoint+ingress+egress

### `JsonServiceLoaderTest` (6 tests)

Pins the `JsonServiceLoader.fromUrl` format-version gate:
- v1.0 / v2.0 rejected as below the 3.0 minimum
- single-root v3.1 falls into the legacy switch's default arm → loud failure
- unrecognized version (9.9) → `IllegalArgumentException(""Unrecognized format version"")`
- `mapper()` returns a fresh `ObjectMapper` per call

Note: a malformed-YAML test is **intentionally omitted** — `JsonServiceLoader` leaks the `YAMLParser` file handle, which breaks `@TempDir` cleanup on Windows. The unrecognized-version test already pins the loud-failure contract for the load path. Fixing the leak would touch prod code; out of scope here.

### `OkHttpUtilsTest` (4 tests)

Pins the dispatcher/connection-pool defaults (`Integer.MAX_VALUE` for both `maxRequests` and `maxRequestsPerHost` — load-bearing for StateFun's invocation fanout), null-safe close, idempotent close, shutdown of the dispatcher executor.

## Test plan

- [x] All 23 new tests pass locally (`mvn test -pl :statefun-flink-core -Dtest='RetryingCallbackTest,LegacyRemoteModuleV30Test,JsonServiceLoaderTest,OkHttpUtilsTest' -B`)
- [x] Full `mvn install -B -Dskip.k8s.e2e -Drat.skip=true -fae` green locally
- [x] No prod-code changes — tests only
- [ ] CI (Build & Test, K8s E2E, CodeQL) green on this PR
- [ ] Codecov shows the unit-test flag has lifted

## Notes on conventions

- AssertJ + JUnit 5 Jupiter throughout (per `.coderabbit.yaml`)
- camelCase test names, no `@DisplayName`
- `// SPDX-License-Identifier: Apache-2.0` + `// Copyright 2026 Kzmlabs` on new files
- Real types over mocks where practical (MockWebServer, real test-resource YAML fixtures)
- Helpers grouped at the bottom of each class

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added extensive tests for HTTP client creation/shutdown, retry state machine, and request-reply serialization/content-type handling.
  * Added JSON/YAML module loading and legacy v3.0 module loading with binder-translation checks and endpoint-spec parsing.
  * Added transport-client binding and JSON deserializer tests for function patterns and URL templates.
  * Added cache LRU behavior, bootstrap function registry, Flink configuration extractor, client-factory cleanup, match binder, stateful match, and concurrent-context tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->