### PR TITLE
test: address CodeQL + CodeRabbit review on PR #175

### DIFF
--- a/statefun-flink/statefun-flink-core/src/test/java/org/apache/flink/statefun/flink/core/httpfn/DefaultHttpRequestReplyClientFactoryTest.java
+++ b/statefun-flink/statefun-flink-core/src/test/java/org/apache/flink/statefun/flink/core/httpfn/DefaultHttpRequestReplyClientFactoryTest.java
@@ -12,12 +12,18 @@ import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.node.Obje
 import org.apache.flink.statefun.flink.core.reqreply.ClassLoaderSafeRequestReplyClient;
 import org.apache.flink.statefun.flink.core.reqreply.RequestReplyClient;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 class DefaultHttpRequestReplyClientFactoryTest {
 
   private final DefaultHttpRequestReplyClientFactory factory =
       DefaultHttpRequestReplyClientFactory.INSTANCE;
+
+  @BeforeEach
+  void resetSingleton() {
+    factory.cleanup();
+  }
 
   @AfterEach
   void cleanup() {
@@ -32,11 +38,13 @@ class DefaultHttpRequestReplyClientFactoryTest {
     assertThat(client).isNotNull();
   }
 
+  /**
+   * The factory wraps with {@link ClassLoaderSafeRequestReplyClient} when the calling thread's
+   * context classloader differs from the factory's own — the runtime scenario where user-provided
+   * modules drive transport creation through a different classloader.
+   */
   @Test
   void createsClassLoaderSafeWrapperWhenContextClassLoaderDiffersFromFactoryClassLoader() {
-    // The factory wraps with ClassLoaderSafeRequestReplyClient when the calling thread's
-    // context CL doesn't match the factory's own CL — this is the runtime scenario where
-    // user-provided modules drive transport creation through a different classloader.
     ClassLoader original = Thread.currentThread().getContextClassLoader();
     ClassLoader different = new ClassLoader(null) {};
     Thread.currentThread().setContextClassLoader(different);

--- a/statefun-flink/statefun-flink-core/src/test/java/org/apache/flink/statefun/flink/core/httpfn/HttpFunctionEndpointSpecTest.java
+++ b/statefun-flink/statefun-flink-core/src/test/java/org/apache/flink/statefun/flink/core/httpfn/HttpFunctionEndpointSpecTest.java
@@ -103,14 +103,18 @@ class HttpFunctionEndpointSpecTest {
         .isEqualTo(TransportClientConstants.ASYNC_CLIENT_FACTORY_TYPE);
   }
 
+  /**
+   * A comma-list pattern in {@code functions} must fail deserialization so misuse surfaces at
+   * config-load instead of silently dropping bindings.
+   */
   @Test
   void invalidFunctionsPatternFailsAtDeserialization() {
-    // Pin: a comma-list pattern in `functions` is rejected by the deserializer so misuse fails
-    // loud rather than silently dropping bindings (real-world bug class).
     String json =
         "{\"functions\": \"counter/a, counter/b\",\"urlPathTemplate\":\"http://upstream\"}";
 
-    assertThatThrownBy(() -> readSpec(json)).isNotNull();
+    assertThatThrownBy(() -> readSpec(json))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Must be of format <namespace>/<name>");
   }
 
   @Test

--- a/statefun-flink/statefun-flink-core/src/test/java/org/apache/flink/statefun/flink/core/httpfn/OkHttpUtilsTest.java
+++ b/statefun-flink/statefun-flink-core/src/test/java/org/apache/flink/statefun/flink/core/httpfn/OkHttpUtilsTest.java
@@ -11,13 +11,11 @@ import org.junit.jupiter.api.Test;
 class OkHttpUtilsTest {
 
   @Test
-  void newClientHasUnboundedDispatcherAndPositiveConnectionPool() {
+  void newClientHasUnboundedDispatcherAndIdleConnectionPool() {
     OkHttpClient client = OkHttpUtils.newClient();
     try {
-      // Dispatcher must be set high enough to never throttle StateFun's invocation fanout.
       assertThat(client.dispatcher().getMaxRequests()).isEqualTo(Integer.MAX_VALUE);
       assertThat(client.dispatcher().getMaxRequestsPerHost()).isEqualTo(Integer.MAX_VALUE);
-      // Pool capacity is 1024; pin it so a future shrink to a lower value gets noticed.
       assertThat(client.connectionPool().connectionCount()).isZero();
       assertThat(client.followRedirects()).isTrue();
       assertThat(client.followSslRedirects()).isTrue();
@@ -47,8 +45,6 @@ class OkHttpUtilsTest {
 
     OkHttpUtils.closeSilently(client);
 
-    // Pin: a second close on the same client must NOT throw — closeSilently swallows all
-    // throwables from already-closed dispatchers/pools by design.
     assertThatCode(() -> OkHttpUtils.closeSilently(client)).doesNotThrowAnyException();
   }
 }

--- a/statefun-flink/statefun-flink-core/src/test/java/org/apache/flink/statefun/flink/core/httpfn/RetryingCallbackTest.java
+++ b/statefun-flink/statefun-flink-core/src/test/java/org/apache/flink/statefun/flink/core/httpfn/RetryingCallbackTest.java
@@ -49,6 +49,7 @@ class RetryingCallbackTest {
   @AfterEach
   void tearDown() throws IOException {
     server.shutdown();
+    OkHttpUtils.closeSilently(client);
   }
 
   @Test

--- a/statefun-flink/statefun-flink-datastream/src/test/java/org/apache/flink/statefun/flink/datastream/StatefulFunctionDataStreamBuilderTest.java
+++ b/statefun-flink/statefun-flink-datastream/src/test/java/org/apache/flink/statefun/flink/datastream/StatefulFunctionDataStreamBuilderTest.java
@@ -139,7 +139,7 @@ class StatefulFunctionDataStreamBuilderTest {
   private static StatefulFunctionBuilder newRemoteBuilder(FunctionType type) throws Exception {
     // Default connect timeout is large enough that we must explicitly bound the request
     // duration above it; otherwise the builder rejects the spec.
-    return RequestReplyFunctionBuilder.requestReplyFunctionBuilder(type, new URI("http://localhost:1234/"))
+    return StatefulFunctionBuilder.requestReplyFunctionBuilder(type, new URI("http://localhost:1234/"))
         .withMaxNumBatchRequests(10)
         .withConnectTimeout(Duration.ofSeconds(2))
         .withMaxRequestDuration(Duration.ofSeconds(30));

--- a/statefun-sdk-embedded/src/test/java/org/apache/flink/statefun/sdk/match/MatchBinderTest.java
+++ b/statefun-sdk-embedded/src/test/java/org/apache/flink/statefun/sdk/match/MatchBinderTest.java
@@ -5,22 +5,16 @@ package org.apache.flink.statefun.sdk.match;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.CompletableFuture;
-import org.apache.flink.statefun.sdk.Address;
-import org.apache.flink.statefun.sdk.Context;
-import org.apache.flink.statefun.sdk.io.EgressIdentifier;
-import org.apache.flink.statefun.sdk.metrics.Metrics;
 import org.junit.jupiter.api.Test;
 
+/**
+ * Pins the matching contract of {@link MatchBinder}. Production code reaches the binder only via
+ * {@link StatefulMatchFunction#invoke}, so these tests guard against silent precedence changes
+ * during refactoring.
+ */
 class MatchBinderTest {
-
-  // The MatchBinder constructor is package-private, so the test class lives in the same package
-  // and uses `new MatchBinder()` directly. Production code never news up a binder — it goes
-  // through StatefulMatchFunction.invoke → matcher.invoke. Tests pin the matching contract so a
-  // future refactor can't silently change precedence.
 
   @Test
   void typeOnlyPredicateMatchesByExactClassAndDispatchesAction() {
@@ -28,7 +22,7 @@ class MatchBinderTest {
     List<String> dispatched = new ArrayList<>();
     binder.predicate(String.class, (ctx, s) -> dispatched.add("string:" + s));
 
-    binder.invoke(new RecordingContext(), "hello");
+    binder.invoke(new NoOpContext(), "hello");
 
     assertThat(dispatched).containsExactly("string:hello");
   }
@@ -51,8 +45,8 @@ class MatchBinderTest {
     binder.predicate(
         String.class, s -> s.startsWith("a"), (ctx, s) -> dispatched.add("conditional:" + s));
 
-    binder.invoke(new RecordingContext(), "apple"); // matches conditional
-    binder.invoke(new RecordingContext(), "banana"); // falls through to type-only
+    binder.invoke(new NoOpContext(), "apple");
+    binder.invoke(new NoOpContext(), "banana");
 
     assertThat(dispatched).containsExactly("conditional:apple", "type-only:banana");
   }
@@ -65,9 +59,8 @@ class MatchBinderTest {
     binder.predicate(Integer.class, i -> i > 10, (ctx, i) -> dispatched.add(2));
     binder.predicate(Integer.class, i -> i > 100, (ctx, i) -> dispatched.add(3));
 
-    binder.invoke(new RecordingContext(), 1000);
+    binder.invoke(new NoOpContext(), 1000);
 
-    // Even though all three predicates would match, the FIRST one wins.
     assertThat(dispatched).containsExactly(1);
   }
 
@@ -76,7 +69,7 @@ class MatchBinderTest {
     MatchBinder binder = new MatchBinder();
     binder.predicate(String.class, (ctx, s) -> {});
 
-    assertThatThrownBy(() -> binder.invoke(new RecordingContext(), 42))
+    assertThatThrownBy(() -> binder.invoke(new NoOpContext(), 42))
         .isInstanceOf(IllegalStateException.class)
         .hasMessageContaining("Don't know how to handle");
   }
@@ -87,8 +80,8 @@ class MatchBinderTest {
     List<Object> defaulted = new ArrayList<>();
     binder.otherwise((ctx, msg) -> defaulted.add(msg));
 
-    binder.invoke(new RecordingContext(), 42);
-    binder.invoke(new RecordingContext(), "anything");
+    binder.invoke(new NoOpContext(), 42);
+    binder.invoke(new NoOpContext(), "anything");
 
     assertThat(defaulted).containsExactly(42, "anything");
   }
@@ -113,52 +106,20 @@ class MatchBinderTest {
     assertThatThrownBy(() -> binder.otherwise(null)).isInstanceOf(NullPointerException.class);
   }
 
+  /**
+   * Dispatch uses {@code input.getClass()} for exact match: a registration for {@link Number}
+   * does NOT catch {@link Integer}. Pin so users don't get a silent miss when expecting
+   * inheritance dispatch.
+   */
   @Test
   void typeOnlyMatchIsBasedOnExactClassNotInheritance() {
-    // Pin: dispatch uses input.getClass() exact match — a registration for Number does NOT
-    // catch Integer. Matters because users may expect inheritance dispatch.
     MatchBinder binder = new MatchBinder();
     List<Object> hits = new ArrayList<>();
     binder.predicate(Number.class, (ctx, n) -> hits.add(n));
 
-    assertThatThrownBy(() -> binder.invoke(new RecordingContext(), 42))
+    assertThatThrownBy(() -> binder.invoke(new NoOpContext(), 42))
         .isInstanceOf(IllegalStateException.class);
     assertThat(hits).isEmpty();
   }
 
-  /** Minimal Context implementation that records nothing — invoke() doesn't use the context. */
-  private static final class RecordingContext implements Context {
-    @Override
-    public Address self() {
-      return null;
-    }
-
-    @Override
-    public Address caller() {
-      return null;
-    }
-
-    @Override
-    public void send(Address to, Object message) {}
-
-    @Override
-    public <T> void send(EgressIdentifier<T> egress, T message) {}
-
-    @Override
-    public void sendAfter(Duration delay, Address to, Object message) {}
-
-    @Override
-    public void sendAfter(Duration delay, Address to, Object message, String cancellationToken) {}
-
-    @Override
-    public void cancelDelayedMessage(String cancellationToken) {}
-
-    @Override
-    public <M, T> void registerAsyncOperation(M metadata, CompletableFuture<T> future) {}
-
-    @Override
-    public Metrics metrics() {
-      return null;
-    }
-  }
 }

--- a/statefun-sdk-embedded/src/test/java/org/apache/flink/statefun/sdk/match/NoOpContext.java
+++ b/statefun-sdk-embedded/src/test/java/org/apache/flink/statefun/sdk/match/NoOpContext.java
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Kzmlabs
+package org.apache.flink.statefun.sdk.match;
+
+import java.time.Duration;
+import java.util.concurrent.CompletableFuture;
+import org.apache.flink.statefun.sdk.Address;
+import org.apache.flink.statefun.sdk.Context;
+import org.apache.flink.statefun.sdk.io.EgressIdentifier;
+import org.apache.flink.statefun.sdk.metrics.Metrics;
+
+/** No-op {@link Context} stub for tests that do not exercise context interactions. */
+final class NoOpContext implements Context {
+  @Override
+  public Address self() {
+    return null;
+  }
+
+  @Override
+  public Address caller() {
+    return null;
+  }
+
+  @Override
+  public void send(Address to, Object message) {}
+
+  @Override
+  public <T> void send(EgressIdentifier<T> egress, T message) {}
+
+  @Override
+  public void sendAfter(Duration delay, Address to, Object message) {}
+
+  @Override
+  public void sendAfter(Duration delay, Address to, Object message, String cancellationToken) {}
+
+  @Override
+  public void cancelDelayedMessage(String cancellationToken) {}
+
+  @Override
+  public <M, T> void registerAsyncOperation(M metadata, CompletableFuture<T> future) {}
+
+  @Override
+  public Metrics metrics() {
+    return null;
+  }
+}

--- a/statefun-sdk-embedded/src/test/java/org/apache/flink/statefun/sdk/match/StatefulMatchFunctionTest.java
+++ b/statefun-sdk-embedded/src/test/java/org/apache/flink/statefun/sdk/match/StatefulMatchFunctionTest.java
@@ -3,15 +3,10 @@
 package org.apache.flink.statefun.sdk.match;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.CompletableFuture;
-import org.apache.flink.statefun.sdk.Address;
-import org.apache.flink.statefun.sdk.Context;
-import org.apache.flink.statefun.sdk.io.EgressIdentifier;
-import org.apache.flink.statefun.sdk.metrics.Metrics;
 import org.junit.jupiter.api.Test;
 
 class StatefulMatchFunctionTest {
@@ -20,9 +15,9 @@ class StatefulMatchFunctionTest {
   void configureIsInvokedOnceLazilyOnFirstInvoke() {
     ConfigureCounter fn = new ConfigureCounter();
 
-    fn.invoke(new NullContext(), "first");
-    fn.invoke(new NullContext(), "second");
-    fn.invoke(new NullContext(), "third");
+    fn.invoke(new NoOpContext(), "first");
+    fn.invoke(new NoOpContext(), "second");
+    fn.invoke(new NoOpContext(), "third");
 
     assertThat(fn.configureCalls).isEqualTo(1);
     assertThat(fn.dispatched).containsExactly("first", "second", "third");
@@ -33,19 +28,17 @@ class StatefulMatchFunctionTest {
     StatefulMatchFunction fn =
         new StatefulMatchFunction() {
           @Override
-          public void configure(MatchBinder binder) {
-            // No bindings — every input falls through to the default unhandled action.
-          }
+          public void configure(MatchBinder binder) {}
         };
 
-    org.assertj.core.api.Assertions.assertThatThrownBy(() -> fn.invoke(new NullContext(), 42))
+    assertThatThrownBy(() -> fn.invoke(new NoOpContext(), 42))
         .isInstanceOf(IllegalStateException.class)
         .hasMessageContaining("Don't know how to handle");
   }
 
   /**
-   * Concrete StatefulMatchFunction that records each invocation. Used to pin the lazy-init
-   * contract — configure() must run exactly once across many invokes, even on the same instance.
+   * Concrete {@link StatefulMatchFunction} recording each invocation to pin the lazy-init
+   * contract: {@code configure()} must run exactly once across many invokes on the same instance.
    */
   private static final class ConfigureCounter extends StatefulMatchFunction {
     int configureCalls = 0;
@@ -55,42 +48,6 @@ class StatefulMatchFunctionTest {
     public void configure(MatchBinder binder) {
       configureCalls++;
       binder.predicate(String.class, (ctx, s) -> dispatched.add(s));
-    }
-  }
-
-  /** No-op Context used for tests where the matcher doesn't interact with the context. */
-  private static final class NullContext implements Context {
-    @Override
-    public Address self() {
-      return null;
-    }
-
-    @Override
-    public Address caller() {
-      return null;
-    }
-
-    @Override
-    public void send(Address to, Object message) {}
-
-    @Override
-    public <T> void send(EgressIdentifier<T> egress, T message) {}
-
-    @Override
-    public void sendAfter(Duration delay, Address to, Object message) {}
-
-    @Override
-    public void sendAfter(Duration delay, Address to, Object message, String cancellationToken) {}
-
-    @Override
-    public void cancelDelayedMessage(String cancellationToken) {}
-
-    @Override
-    public <M, T> void registerAsyncOperation(M metadata, CompletableFuture<T> future) {}
-
-    @Override
-    public Metrics metrics() {
-      return null;
     }
   }
 }


### PR DESCRIPTION
## Summary

Follow-up to PR #175 addressing the bot comments.

**CodeQL ([alert #967](https://github.com/kzmlabs/flink-statefun/security/code-scanning/967))** — `RequestReplyFunctionBuilder.requestReplyFunctionBuilder` is deprecated; swap to the parent `StatefulFunctionBuilder.requestReplyFunctionBuilder` (identical signature).

**CodeRabbit:**
- `OkHttpUtilsTest` — drop misleading "pool capacity" comment (`connectionCount()` reports current connections, not configured max).
- `RetryingCallbackTest` — close `OkHttpClient` in `tearDown` to release the dispatcher executor + connection pool.
- `HttpFunctionEndpointSpecTest` — replace weak `.isNotNull()` with concrete `IllegalArgumentException` + message check.
- `DefaultHttpRequestReplyClientFactoryTest` — add `@BeforeEach` reset of the singleton factory so the first test doesn't inherit prior state.
- `MatchBinderTest` + `StatefulMatchFunctionTest` — extract shared `NoOpContext`, drop the fully-qualified `Assertions.assertThatThrownBy` import, prune verbose narrative `//` comments per project preference.

## Test plan
- [x] `mvn test -pl :statefun-flink-datastream -Dtest=StatefulFunctionDataStreamBuilderTest` — 11/11 pass
- [x] `mvn test -pl :statefun-flink-core -Dtest='OkHttpUtilsTest,RetryingCallbackTest,HttpFunctionEndpointSpecTest,DefaultHttpRequestReplyClientFactoryTest'` — 27/27 pass
- [x] `mvn test -pl :statefun-sdk-embedded -Dtest='MatchBinderTest,StatefulMatchFunctionTest'` — 11/11 pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test utilities to use a different builder approach.
  * Ensured shared factory state is reset before each test.
  * Added stricter validation for invalid function patterns.
  * Clarified a client-configuration test name and ensured client resources are closed after tests.
  * Refactored match-related tests to use a new no-op test context and added a small test stub.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->