### PR TITLE
ci: add merged coverage (line-union) summary to Build & Test page

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,3 +140,69 @@ jobs:
           fail_ci_if_error: false
           disable_search: true
           use_oidc: true
+
+      # ---- Merged total (line-union of unit + e2e) ----
+      # Each Codecov flag is uploaded separately, so the per-flag tables above only show
+      # one half each. The union number below matches what Codecov computes as the project
+      # total: a line is "covered" if it is hit by either flag.
+      - name: Combined coverage (line-union) summary in run UI
+        if: always()
+        run: |
+          UNIT=statefun-coverage-report/target/site/jacoco-aggregate/jacoco.xml
+          E2E=statefun-e2e-coverage-report/target/site/jacoco-e2e-aggregate/jacoco.xml
+          [ -s "$UNIT" ] && [ -s "$E2E" ] || { echo "Need both reports for union summary"; exit 0; }
+          python3 - <<'PY'
+          import xml.etree.ElementTree as ET, os
+
+          def read_lines(path):
+              # (package, sourcefile, line_nr) -> (mi, ci, mb, cb)
+              out = {}
+              for pkg in ET.parse(path).getroot().iter('package'):
+                  pname = pkg.get('name', '')
+                  for sf in pkg.findall('sourcefile'):
+                      sname = sf.get('name', '')
+                      for ln in sf.findall('line'):
+                          key = (pname, sname, ln.get('nr'))
+                          out[key] = (
+                              int(ln.get('mi', 0)),
+                              int(ln.get('ci', 0)),
+                              int(ln.get('mb', 0)),
+                              int(ln.get('cb', 0)),
+                          )
+              return out
+
+          unit = read_lines('statefun-coverage-report/target/site/jacoco-aggregate/jacoco.xml')
+          e2e = read_lines('statefun-e2e-coverage-report/target/site/jacoco-e2e-aggregate/jacoco.xml')
+
+          total_lines = covered_lines = 0
+          total_branches = covered_branches = 0
+          total_instr = covered_instr = 0
+          for key in set(unit) | set(e2e):
+              u = unit.get(key, (0, 0, 0, 0))
+              e = e2e.get(key, (0, 0, 0, 0))
+              # Per-line union: covered if either flag covered any instruction on this line.
+              line_covered = (u[1] + e[1]) > 0
+              total_lines += 1
+              if line_covered:
+                  covered_lines += 1
+              # Instructions: take max coverage per line (under-counts when the two reports
+              # cover different instructions on the same line, but matches Codecov's view).
+              total_instr += max(u[0] + u[1], e[0] + e[1])
+              covered_instr += max(u[1], e[1])
+              total_branches += max(u[2] + u[3], e[2] + e[3])
+              covered_branches += max(u[3], e[3])
+
+          def pct(c, t):
+              return f'{100 * c / t:.1f}%' if t else 'n/a'
+
+          with open(os.environ['GITHUB_STEP_SUMMARY'], 'a') as f:
+              f.write('## Combined coverage (line-union of unit + e2e)\n\n')
+              f.write('Matches the merged total Codecov shows on the project dashboard ')
+              f.write('([app.codecov.io](https://app.codecov.io/gh/kzmlabs/flink-statefun)). ')
+              f.write('A line counts as covered if it is hit by either flag.\n\n')
+              f.write('| Metric | Covered | Total | % |\n')
+              f.write('|---|---:|---:|---:|\n')
+              f.write(f'| Line | {covered_lines:,} | {total_lines:,} | **{pct(covered_lines, total_lines)}** |\n')
+              f.write(f'| Instruction | {covered_instr:,} | {total_instr:,} | **{pct(covered_instr, total_instr)}** |\n')
+              f.write(f'| Branch | {covered_branches:,} | {total_branches:,} | **{pct(covered_branches, total_branches)}** |\n')
+          PY


### PR DESCRIPTION
## Summary

The Build & Test job summary currently shows two coverage tables (unit-only ~74% and e2e-only ~25%) because each is uploaded as a separate Codecov flag. Codecov merges them on its dashboard (project total ~81%), but the GitHub Actions page did not — readers had to leave GitHub to see the merged number.

This adds a third **Combined coverage (line-union)** table to the same Build & Test summary. The Python script reads both `jacoco.xml` files, indexes by `(package, sourcefile, line_nr)`, and a line counts as covered if it is hit by either flag — same semantics Codecov uses.

Local sanity check on the current `jacoco.xml` files in this checkout: 79.8% line / 80.6% instruction — matches the Codecov dashboard (~81% on the latest commit).

## Test plan
- [ ] Push triggers CI; the Build & Test job summary now contains three coverage tables (unit aggregate, e2e aggregate, combined).
- [ ] Combined Line % is within 1 point of the Codecov project total for the same commit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI workflow to include a combined coverage summary in GitHub Actions run UI, displaying merged coverage metrics from unit and integration tests directly in the workflow run summary.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->