### PR TITLE
docs: add Kzmlabs attribution block to NOTICE

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,3 +1,12 @@
+StateFun Actors by Kzmlabs
+Copyright 2026 Kzmlabs
+
+This product is a modified continuation of Apache Flink Stateful Functions
+(flink-statefun) targeting Apache Flink 2.x and Java 21. Modifications are
+made available under the Apache License, Version 2.0.
+
+Original work:
+
 Apache Flink Stateful Functions (flink-statefun)
 Copyright 2014-2025 The Apache Software Foundation
 


### PR DESCRIPTION
## Summary

- Adds a Kzmlabs copyright block to `NOTICE` while preserving the original Apache attribution verbatim.
- Apache 2.0 §4(d) requires that derivative works preserve the upstream `NOTICE` and add their own modifications-copyright separately. The file previously carried only the Apache block, missing the continuation-author attribution.

## Test plan

- [x] Diff inspected — only additions, original Apache section unchanged.
- [ ] CI green (compile + license header checks).
- [ ] Visual review by maintainer.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated licensing and attribution information with a new NOTICE file header. Identified the project as StateFun Actors by Kzmlabs and added 2026 copyright notice. Clarified that this is a modified continuation of Apache Flink Stateful Functions, targeting Apache Flink 2.x and Java 21 environments, and distributed under Apache License 2.0.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kzmlabs/flink-statefun/pull/180)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->