### PR TITLE
feat: ship user-facing quickstart docker-compose stack

### DIFF
--- a/.github/scripts/README.md
+++ b/.github/scripts/README.md
@@ -9,6 +9,7 @@ readable and the script can be tested locally without the workflow harness.
 | Script | Used by | Purpose |
 |---|---|---|
 | `coverage_summary.py` | `ci.yml` | Render JaCoCo coverage tables (unit / e2e / union) into the GitHub Actions job summary. |
+| `quickstart-smoke.sh` | `quickstart-smoke.yml` | Produce `alice:{"name":"Alice"}` to `greeter.commands` and assert `Hello, Alice!` lands on `greeter.results` within 60 s. |
 
 ## Local testing
 

--- a/.github/scripts/quickstart-smoke.sh
+++ b/.github/scripts/quickstart-smoke.sh
@@ -27,11 +27,13 @@ echo 'alice:{"name":"Alice"}' | docker exec -i "${KAFKA_CONTAINER}" \
 echo "==> Polling ${CONSUME_TOPIC} for '${EXPECTED}' (up to ${TIMEOUT_SECONDS}s)"
 deadline=$(( $(date +%s) + TIMEOUT_SECONDS ))
 while [ "$(date +%s)" -lt "${deadline}" ]; do
+  # --max-messages bounded high (not 1) so the grep still finds the expected
+  # output even if other records land on the topic; --timeout-ms caps the wait.
   output=$(docker exec "${KAFKA_CONTAINER}" \
     /opt/kafka/bin/kafka-console-consumer.sh \
     --bootstrap-server kafka:9092 \
     --topic "${CONSUME_TOPIC}" \
-    --from-beginning --max-messages 1 --timeout-ms 5000 2>/dev/null || true)
+    --from-beginning --max-messages 100 --timeout-ms 5000 2>/dev/null || true)
   if printf '%s' "${output}" | grep -F -q "${EXPECTED}"; then
     echo "==> Received: ${output}"
     echo "PASS: round-trip completed."

--- a/.github/scripts/quickstart-smoke.sh
+++ b/.github/scripts/quickstart-smoke.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+#
+# Quickstart compose smoke test:
+#   - Produces alice:{"name":"Alice"} to greeter.commands
+#   - Polls greeter.results for "Hello, Alice!" with a 60s ceiling
+#   - Exits 0 on match, 1 on timeout
+#
+# Assumes the quickstart stack is already up (docker compose up -d --wait)
+# and that kafka is reachable as the "quickstart-kafka" container.
+
+set -euo pipefail
+
+KAFKA_CONTAINER="${KAFKA_CONTAINER:-quickstart-kafka}"
+PRODUCE_TOPIC="${PRODUCE_TOPIC:-greeter.commands}"
+CONSUME_TOPIC="${CONSUME_TOPIC:-greeter.results}"
+EXPECTED='Hello, Alice!'
+TIMEOUT_SECONDS="${TIMEOUT_SECONDS:-60}"
+
+echo "==> Producing alice:{\"name\":\"Alice\"} to ${PRODUCE_TOPIC}"
+echo 'alice:{"name":"Alice"}' | docker exec -i "${KAFKA_CONTAINER}" \
+  /opt/kafka/bin/kafka-console-producer.sh \
+  --bootstrap-server kafka:9092 \
+  --topic "${PRODUCE_TOPIC}" \
+  --property "parse.key=true" --property "key.separator=:"
+
+echo "==> Polling ${CONSUME_TOPIC} for '${EXPECTED}' (up to ${TIMEOUT_SECONDS}s)"
+deadline=$(( $(date +%s) + TIMEOUT_SECONDS ))
+while [ "$(date +%s)" -lt "${deadline}" ]; do
+  output=$(docker exec "${KAFKA_CONTAINER}" \
+    /opt/kafka/bin/kafka-console-consumer.sh \
+    --bootstrap-server kafka:9092 \
+    --topic "${CONSUME_TOPIC}" \
+    --from-beginning --max-messages 1 --timeout-ms 5000 2>/dev/null || true)
+  if printf '%s' "${output}" | grep -F -q "${EXPECTED}"; then
+    echo "==> Received: ${output}"
+    echo "PASS: round-trip completed."
+    exit 0
+  fi
+  sleep 2
+done
+
+echo "FAIL: did not receive '${EXPECTED}' within ${TIMEOUT_SECONDS}s." >&2
+exit 1

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -3,9 +3,19 @@ name: K8s E2E Test
 on:
   workflow_call:    # reusable by release workflows
   workflow_dispatch:
-  pull_request:    # gate every PR — no path filter, full E2E coverage
+  pull_request:    # gate every PR that touches code; quickstart-only changes are covered by quickstart-smoke.yml
+    paths-ignore:
+      - 'examples/quickstart/**'
+      - 'docs/quickstart.md'
+      - '.github/workflows/quickstart-smoke.yml'
+      - '.github/scripts/quickstart-smoke.sh'
   push:
     branches: [release, master]    # post-merge validation on protected branches
+    paths-ignore:
+      - 'examples/quickstart/**'
+      - 'docs/quickstart.md'
+      - '.github/workflows/quickstart-smoke.yml'
+      - '.github/scripts/quickstart-smoke.sh'
 
 concurrency:
   group: e2e-${{ github.ref }}

--- a/.github/workflows/quickstart-smoke.yml
+++ b/.github/workflows/quickstart-smoke.yml
@@ -1,0 +1,63 @@
+name: Quickstart Smoke
+
+on:
+  pull_request:
+    paths:
+      - 'examples/quickstart/**'
+      - 'docs/quickstart.md'
+      - '.github/workflows/quickstart-smoke.yml'
+      - '.github/scripts/quickstart-smoke.sh'
+  push:
+    branches: [release]
+    paths:
+      - 'examples/quickstart/**'
+      - 'docs/quickstart.md'
+      - '.github/workflows/quickstart-smoke.yml'
+      - '.github/scripts/quickstart-smoke.sh'
+  workflow_dispatch:
+
+concurrency:
+  group: quickstart-smoke-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  smoke:
+    runs-on: ubuntu-latest
+    name: Quickstart docker-compose round-trip
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Start quickstart stack
+        working-directory: examples/quickstart
+        run: docker compose up -d --wait --build
+
+      - name: Run round-trip smoke
+        run: bash .github/scripts/quickstart-smoke.sh
+
+      - name: Collect logs on failure
+        if: failure()
+        working-directory: examples/quickstart
+        run: |
+          docker compose ps
+          docker compose logs --no-color > docker-compose.log
+
+      - name: Upload logs on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: quickstart-logs
+          path: examples/quickstart/docker-compose.log
+
+      - name: Teardown
+        if: always()
+        working-directory: examples/quickstart
+        run: docker compose down -v --remove-orphans

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -73,7 +73,7 @@ docker exec quickstart-kafka \
 
 Expected output:
 
-```
+```json
 {"greeting":"Hello, Alice!"}
 ```
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -5,15 +5,14 @@ description: Run a StateFun Actors job on Apache Flink locally in five minutes �
 
 # Quickstart
 
-> Five minutes from `git clone` to a verified round-trip message. Copy-pasteable, idempotent, no AWS credentials required.
+> Five minutes from `git clone` to a verified round-trip message. Copy-pasteable, all containers pulled from public registries plus one tiny local build.
 
 ## Before you start
 
 You'll need:
 
 - **Docker** (`docker compose` v2)
-- **`curl`** (any modern version)
-- ~3 GB free disk space and ~2 GB RAM available to Docker
+- ~3 GB free disk space and ~4 GB RAM available to Docker
 
 That's it. No JDK, no Maven, no Kubernetes.
 
@@ -27,76 +26,66 @@ cd flink-statefun
 ## 2. Start the local stack
 
 ```bash
-cd dev
-docker compose up -d
+cd examples/quickstart
+docker compose up -d --wait --build
 ```
 
-This brings up four containers:
+`--wait` blocks until every healthcheck passes; `--build` builds the local greeter image on first run (~1–2 min cold, cached afterwards). This brings up six containers:
 
 | Container | Role |
 |---|---|
-| `statefun-jobmanager` | Flink 2.2 JobManager running the StateFun runtime |
-| `statefun-taskmanager` | Flink 2.2 TaskManager (workers) |
-| `statefun-kafka` | Kafka KRaft mode, single broker |
-| `statefun-remote-function` | HTTP endpoint exposing a sample `GreeterFn` |
+| `quickstart-kafka` | Kafka 3.9 in KRaft mode, single broker (no ZooKeeper) |
+| `quickstart-kafka-init` | One-shot: creates the `greeter.commands` and `greeter.results` topics, then exits |
+| `quickstart-greeter` | Sample StateFun remote function over HTTP (`/statefun`) |
+| `quickstart-jobmanager` | Flink 2.2 JobManager + StateFun runtime, exposes the Web UI on `localhost:8081` |
+| `quickstart-taskmanager` | Flink 2.2 TaskManager (one slot, parallelism 1) |
+| `quickstart-job-submit` | One-shot: submits the StateFun job to the JobManager, then exits |
 
-Wait ~30 s for the cluster to settle, then verify:
+Verify everything is up:
 
 ```bash
 docker compose ps
 ```
 
-Every container should be `Up (healthy)`.
+`kafka`, `greeter`, `jobmanager`, and `taskmanager` should be `Up (healthy)`. `kafka-init` and `job-submit` are one-shots — they appear as `Exited (0)`.
 
-## 3. Create the ingress topic
-
-```bash
-docker exec statefun-kafka kafka-topics --bootstrap-server localhost:9092 \
-  --create --topic dev.events.test-ingress \
-  --partitions 1 --replication-factor 1
-```
-
-## 4. Send a message
+## 3. Send a message
 
 ```bash
-echo 'alice:{"message": "Hello!"}' | docker exec -i statefun-kafka \
-  kafka-console-producer --broker-list localhost:9092 \
-  --topic dev.events.test-ingress \
+echo 'alice:{"name":"Alice"}' | docker exec -i quickstart-kafka \
+  /opt/kafka/bin/kafka-console-producer.sh \
+  --bootstrap-server kafka:9092 \
+  --topic greeter.commands \
   --property "parse.key=true" --property "key.separator=:"
 ```
 
-Format: `<key>:<JSON value>`. The key (`alice`) is the function instance id; the value is the message payload.
+Format: `<key>:<JSON value>`. The key (`alice`) becomes the function instance id; the value is parsed by the function.
 
-## 5. Watch the function react
+## 4. Read the response
 
-=== "Tail the function logs"
+```bash
+docker exec quickstart-kafka \
+  /opt/kafka/bin/kafka-console-consumer.sh \
+  --bootstrap-server kafka:9092 \
+  --topic greeter.results \
+  --from-beginning --max-messages 1
+```
 
-    ```bash
-    docker logs -f statefun-remote-function
-    ```
+Expected output:
 
-    You should see a line like:
+```
+{"greeting":"Hello, Alice!"}
+```
 
-    ```
-    [GreeterFn] alice → "Hello, alice!"
-    ```
+The Flink Web UI on [http://localhost:8081](http://localhost:8081) shows the running `statefun-quickstart` job — checkpoint counters tick up every 10 seconds.
 
-=== "Read from the egress topic"
-
-    ```bash
-    docker exec statefun-kafka kafka-console-consumer \
-      --bootstrap-server localhost:9092 \
-      --topic dev.events.test-egress \
-      --from-beginning --max-messages 1
-    ```
-
-## 6. Tear down
+## 5. Tear down
 
 ```bash
 docker compose down -v
 ```
 
-Removes containers + volumes. Re-running `docker compose up -d` starts a clean cluster.
+Removes containers + volumes. Re-running `docker compose up -d --wait` starts a clean cluster.
 
 ## What just happened
 
@@ -109,16 +98,39 @@ sequenceDiagram
     participant Fn as GreeterFn (remote)
     participant E as Kafka egress
 
-    You->>K: produce key=alice, value={message}
+    You->>K: produce key=alice, value={"name":"Alice"}
     K->>SF: poll record
-    SF->>SF: route by namespace/name/id
+    SF->>SF: route by namespace/name/id → greeter/fn/alice
     SF->>Fn: HTTP POST /statefun (Address + state + message)
     Fn->>SF: response (egress message + state delta)
-    SF->>E: emit "Hello, alice!"
+    SF->>E: emit {"greeting":"Hello, Alice!"}
     SF->>SF: checkpoint state
 ```
 
 The runtime owns state, routing, exactly-once delivery, and checkpointing. Your function is just `Context + Message → response`.
+
+## Troubleshooting
+
+??? failure "`docker compose up` hangs on `--wait`"
+
+    Check which container is unhealthy:
+
+    ```bash
+    docker compose ps
+    docker compose logs jobmanager
+    docker compose logs taskmanager
+    docker compose logs greeter
+    ```
+
+    Most common causes: Docker has less than 4 GB RAM available, or host ports `8081` / `9094` are already in use.
+
+??? failure "`pull access denied` on the GHCR image"
+
+    The image is public. If you see this, your local Docker is logged into a different GHCR account that lacks access. Run `docker logout ghcr.io` and try again, or pin to a different tag with `docker pull ghcr.io/kzmlabs/flink-statefun:3.4.0-KZM-3.1` to verify connectivity.
+
+??? failure "Step 4 returns no output / consumer hangs"
+
+    Either the job hasn't submitted yet (check `docker compose logs job-submit` for the submission line), the greeter container isn't healthy (check `docker compose logs greeter`), or the producer failed silently (re-run step 3 and watch for errors). The Flink Web UI on `localhost:8081` will show whether the job is `RUNNING`.
 
 ## Next steps
 

--- a/examples/quickstart/.gitattributes
+++ b/examples/quickstart/.gitattributes
@@ -1,0 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+*.yml text eol=lf
+*.yaml text eol=lf
+*.java text eol=lf
+*.sh text eol=lf
+*.xml text eol=lf
+Dockerfile text eol=lf

--- a/examples/quickstart/docker-compose.yml
+++ b/examples/quickstart/docker-compose.yml
@@ -51,7 +51,9 @@ services:
     build:
       context: ./greeter
     healthcheck:
-      test: ["CMD-SHELL", "wget -q --spider http://localhost:8080/statefun || exit 1"]
+      # GET (not HEAD/--spider) — GreeterServer's lightweight handler responds with 200/OK to GET,
+      # but HEAD trips the server's "send response body" path with a stream-closed warning.
+      test: ["CMD-SHELL", "wget -q -O /dev/null http://localhost:8080/statefun"]
       interval: 5s
       timeout: 5s
       retries: 10

--- a/examples/quickstart/docker-compose.yml
+++ b/examples/quickstart/docker-compose.yml
@@ -118,8 +118,19 @@ services:
         condition: service_completed_successfully
       greeter:
         condition: service_healthy
-    entrypoint: ["/bin/bash", "-c"]
+    # `flink run` builds the job graph on the CLIENT side, so the runner's
+    # Main.main() executes here — module.yaml must be mounted and the
+    # remote module URL must point at it. JM/TM mounts alone are not enough.
+    volumes:
+      - ./module.yaml:/opt/statefun/module.yaml:ro
+    environment:
+      FLINK_PROPERTIES: |
+        statefun.remote.module-name: file:///opt/statefun/module.yaml
+        classloader.parent-first-patterns.additional: org.apache.flink.statefun;org.apache.kafka;com.google.protobuf
+        classloader.resolve-order: parent-first
     command:
+      - bash
+      - -c
       - >
         /opt/flink/bin/flink run -d
         -m jobmanager:8081

--- a/examples/quickstart/docker-compose.yml
+++ b/examples/quickstart/docker-compose.yml
@@ -1,0 +1,125 @@
+# SPDX-License-Identifier: Apache-2.0
+
+services:
+  kafka:
+    image: apache/kafka:3.9.0
+    container_name: quickstart-kafka
+    ports:
+      - "9094:9094"
+    environment:
+      KAFKA_NODE_ID: "1"
+      KAFKA_PROCESS_ROLES: "broker,controller"
+      KAFKA_LISTENERS: "INTERNAL://:9092,EXTERNAL://:9094,CONTROLLER://:9093"
+      KAFKA_ADVERTISED_LISTENERS: "INTERNAL://kafka:9092,EXTERNAL://localhost:9094"
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: "CONTROLLER:PLAINTEXT,INTERNAL:PLAINTEXT,EXTERNAL:PLAINTEXT"
+      KAFKA_INTER_BROKER_LISTENER_NAME: "INTERNAL"
+      KAFKA_CONTROLLER_QUORUM_VOTERS: "1@localhost:9093"
+      KAFKA_CONTROLLER_LISTENER_NAMES: "CONTROLLER"
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: "1"
+      KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: "1"
+      KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: "1"
+      KAFKA_AUTO_CREATE_TOPICS_ENABLE: "false"
+      KAFKA_NUM_PARTITIONS: "1"
+      KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: "0"
+      CLUSTER_ID: "MkU3OEVBNTcwNTJENDM2Qk"
+    healthcheck:
+      test: ["CMD-SHELL", "/opt/kafka/bin/kafka-broker-api-versions.sh --bootstrap-server localhost:9092 > /dev/null 2>&1"]
+      interval: 5s
+      timeout: 10s
+      retries: 12
+      start_period: 10s
+
+  kafka-init:
+    image: apache/kafka:3.9.0
+    container_name: quickstart-kafka-init
+    depends_on:
+      kafka:
+        condition: service_healthy
+    entrypoint: ["/bin/sh", "-c"]
+    command:
+      - |
+        /opt/kafka/bin/kafka-topics.sh --bootstrap-server kafka:9092 \
+          --create --if-not-exists --topic greeter.commands \
+          --partitions 1 --replication-factor 1 && \
+        /opt/kafka/bin/kafka-topics.sh --bootstrap-server kafka:9092 \
+          --create --if-not-exists --topic greeter.results \
+          --partitions 1 --replication-factor 1
+    restart: "no"
+
+  greeter:
+    container_name: quickstart-greeter
+    build:
+      context: ./greeter
+    healthcheck:
+      test: ["CMD-SHELL", "wget -q --spider http://localhost:8080/statefun || exit 1"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+      start_period: 10s
+
+  jobmanager:
+    image: ghcr.io/kzmlabs/flink-statefun:3.4.0-KZM-3.1
+    container_name: quickstart-jobmanager
+    command: jobmanager
+    ports:
+      - "8081:8081"
+    volumes:
+      - ./module.yaml:/opt/statefun/module.yaml:ro
+    environment:
+      FLINK_PROPERTIES: |
+        jobmanager.rpc.address: jobmanager
+        taskmanager.numberOfTaskSlots: 1
+        parallelism.default: 1
+        classloader.parent-first-patterns.additional: org.apache.flink.statefun;org.apache.kafka;com.google.protobuf
+        classloader.resolve-order: parent-first
+        state.backend.type: hashmap
+        execution.checkpointing.interval: 10000
+        execution.checkpointing.mode: AT_LEAST_ONCE
+        state.checkpoints.dir: file:///tmp/flink/checkpoints
+        statefun.flink-job-name: statefun-quickstart
+        statefun.remote.module-name: file:///opt/statefun/module.yaml
+        execution.restart-strategy.type: fixed-delay
+        execution.restart-strategy.fixed-delay.attempts: 3
+    healthcheck:
+      test: ["CMD-SHELL", "curl -sf http://localhost:8081/overview > /dev/null"]
+      interval: 5s
+      timeout: 5s
+      retries: 20
+      start_period: 30s
+
+  taskmanager:
+    image: ghcr.io/kzmlabs/flink-statefun:3.4.0-KZM-3.1
+    container_name: quickstart-taskmanager
+    command: taskmanager
+    depends_on:
+      jobmanager:
+        condition: service_healthy
+    volumes:
+      - ./module.yaml:/opt/statefun/module.yaml:ro
+    environment:
+      FLINK_PROPERTIES: |
+        jobmanager.rpc.address: jobmanager
+        taskmanager.numberOfTaskSlots: 1
+        classloader.parent-first-patterns.additional: org.apache.flink.statefun;org.apache.kafka;com.google.protobuf
+        classloader.resolve-order: parent-first
+        statefun.remote.module-name: file:///opt/statefun/module.yaml
+
+  job-submit:
+    image: ghcr.io/kzmlabs/flink-statefun:3.4.0-KZM-3.1
+    container_name: quickstart-job-submit
+    depends_on:
+      jobmanager:
+        condition: service_healthy
+      taskmanager:
+        condition: service_started
+      kafka-init:
+        condition: service_completed_successfully
+      greeter:
+        condition: service_healthy
+    entrypoint: ["/bin/bash", "-c"]
+    command:
+      - >
+        /opt/flink/bin/flink run -d
+        -m jobmanager:8081
+        /opt/flink/statefun-flink-runner.jar
+    restart: "no"

--- a/examples/quickstart/greeter/Dockerfile
+++ b/examples/quickstart/greeter/Dockerfile
@@ -1,0 +1,16 @@
+# SPDX-License-Identifier: Apache-2.0
+
+# syntax=docker/dockerfile:1.7
+
+FROM maven:3.9-eclipse-temurin-21 AS builder
+WORKDIR /build
+COPY pom.xml ./
+RUN --mount=type=cache,target=/root/.m2 mvn -B -q dependency:go-offline
+COPY src ./src
+RUN --mount=type=cache,target=/root/.m2 mvn -B -q package
+
+FROM eclipse-temurin:21-jre
+WORKDIR /opt
+COPY --from=builder /build/target/statefun-quickstart-greeter.jar /opt/greeter.jar
+EXPOSE 8080
+ENTRYPOINT ["java", "-jar", "/opt/greeter.jar"]

--- a/examples/quickstart/greeter/pom.xml
+++ b/examples/quickstart/greeter/pom.xml
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>io.github.kzmlabs.flinkstatefun.examples</groupId>
+    <artifactId>statefun-quickstart-greeter</artifactId>
+    <version>1.0.0</version>
+    <packaging>jar</packaging>
+
+    <name>StateFun Quickstart Greeter</name>
+    <description>Sample StateFun remote function for the docker-compose quickstart.</description>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <maven.compiler.source>21</maven.compiler.source>
+        <maven.compiler.target>21</maven.compiler.target>
+        <statefun.version>3.4.0-KZM-3.1</statefun.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.github.kzmlabs.flinkstatefun</groupId>
+            <artifactId>statefun-sdk-java</artifactId>
+            <version>${statefun.version}</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <finalName>statefun-quickstart-greeter</finalName>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.13.0</version>
+                <configuration>
+                    <source>21</source>
+                    <target>21</target>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>3.6.1</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <createDependencyReducedPom>false</createDependencyReducedPom>
+                            <transformers>
+                                <transformer
+                                        implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                                    <mainClass>io.github.kzmlabs.quickstart.GreeterServer</mainClass>
+                                </transformer>
+                                <transformer
+                                        implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+                            </transformers>
+                            <filters>
+                                <filter>
+                                    <artifact>*:*</artifact>
+                                    <excludes>
+                                        <exclude>META-INF/*.SF</exclude>
+                                        <exclude>META-INF/*.DSA</exclude>
+                                        <exclude>META-INF/*.RSA</exclude>
+                                    </excludes>
+                                </filter>
+                            </filters>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/examples/quickstart/greeter/src/main/java/io/github/kzmlabs/quickstart/GreeterFn.java
+++ b/examples/quickstart/greeter/src/main/java/io/github/kzmlabs/quickstart/GreeterFn.java
@@ -41,7 +41,7 @@ public final class GreeterFn implements StatefulFunction {
     String input = message.as(JSON_STRING_TYPE);
     Matcher m = NAME_PATTERN.matcher(input);
     String name = m.find() ? m.group(1) : input;
-    String greeting = "{\"greeting\":\"Hello, " + name + "!\"}";
+    String greeting = "{\"greeting\":\"Hello, " + jsonEscape(name) + "!\"}";
 
     context.send(
         KafkaEgressMessage.forEgress(EGRESS_ID)
@@ -51,5 +51,37 @@ public final class GreeterFn implements StatefulFunction {
             .build());
 
     return context.done();
+  }
+
+  /** Minimal JSON string escape so the emitted greeting stays valid for names with quotes/backslashes. */
+  private static String jsonEscape(String s) {
+    StringBuilder sb = new StringBuilder(s.length() + 8);
+    for (int i = 0; i < s.length(); i++) {
+      char c = s.charAt(i);
+      switch (c) {
+        case '"':
+          sb.append("\\\"");
+          break;
+        case '\\':
+          sb.append("\\\\");
+          break;
+        case '\n':
+          sb.append("\\n");
+          break;
+        case '\r':
+          sb.append("\\r");
+          break;
+        case '\t':
+          sb.append("\\t");
+          break;
+        default:
+          if (c < 0x20) {
+            sb.append(String.format("\\u%04x", (int) c));
+          } else {
+            sb.append(c);
+          }
+      }
+    }
+    return sb.toString();
   }
 }

--- a/examples/quickstart/greeter/src/main/java/io/github/kzmlabs/quickstart/GreeterFn.java
+++ b/examples/quickstart/greeter/src/main/java/io/github/kzmlabs/quickstart/GreeterFn.java
@@ -1,0 +1,55 @@
+// Copyright 2026 Kzmlabs
+// SPDX-License-Identifier: Apache-2.0
+
+package io.github.kzmlabs.quickstart;
+
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.CompletableFuture;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.apache.flink.statefun.sdk.java.Context;
+import org.apache.flink.statefun.sdk.java.StatefulFunction;
+import org.apache.flink.statefun.sdk.java.TypeName;
+import org.apache.flink.statefun.sdk.java.io.KafkaEgressMessage;
+import org.apache.flink.statefun.sdk.java.message.Message;
+import org.apache.flink.statefun.sdk.java.types.SimpleType;
+import org.apache.flink.statefun.sdk.java.types.Type;
+
+/** Extracts a name from a JSON payload and emits a greeting to the Kafka egress. */
+public final class GreeterFn implements StatefulFunction {
+
+  static final TypeName FN_TYPE = TypeName.typeNameOf("greeter", "fn");
+  static final TypeName EGRESS_ID = TypeName.typeNameOf("greeter", "results");
+  static final String RESULTS_TOPIC = "greeter.results";
+
+  static final TypeName JSON_STRING_TYPE_NAME = TypeName.typeNameOf("greeter", "json-string");
+
+  static final Type<String> JSON_STRING_TYPE =
+      SimpleType.simpleImmutableTypeFrom(
+          JSON_STRING_TYPE_NAME,
+          str -> str.getBytes(StandardCharsets.UTF_8),
+          bytes -> new String(bytes, StandardCharsets.UTF_8));
+
+  private static final Pattern NAME_PATTERN = Pattern.compile("\"name\"\\s*:\\s*\"([^\"]+)\"");
+
+  @Override
+  public CompletableFuture<Void> apply(Context context, Message message) {
+    if (!message.is(JSON_STRING_TYPE)) {
+      return context.done();
+    }
+
+    String input = message.as(JSON_STRING_TYPE);
+    Matcher m = NAME_PATTERN.matcher(input);
+    String name = m.find() ? m.group(1) : input;
+    String greeting = "{\"greeting\":\"Hello, " + name + "!\"}";
+
+    context.send(
+        KafkaEgressMessage.forEgress(EGRESS_ID)
+            .withTopic(RESULTS_TOPIC)
+            .withUtf8Key(context.self().id())
+            .withUtf8Value(greeting)
+            .build());
+
+    return context.done();
+  }
+}

--- a/examples/quickstart/greeter/src/main/java/io/github/kzmlabs/quickstart/GreeterServer.java
+++ b/examples/quickstart/greeter/src/main/java/io/github/kzmlabs/quickstart/GreeterServer.java
@@ -1,0 +1,89 @@
+// Copyright 2026 Kzmlabs
+// SPDX-License-Identifier: Apache-2.0
+
+package io.github.kzmlabs.quickstart;
+
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpServer;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.util.concurrent.CompletableFuture;
+import org.apache.flink.statefun.sdk.java.StatefulFunctionSpec;
+import org.apache.flink.statefun.sdk.java.StatefulFunctions;
+import org.apache.flink.statefun.sdk.java.handler.RequestReplyHandler;
+import org.apache.flink.statefun.sdk.java.slice.Slice;
+import org.apache.flink.statefun.sdk.java.slice.Slices;
+
+/** Minimal HTTP server exposing the GreeterFn at POST /statefun. */
+public final class GreeterServer {
+
+  private static final int PORT = 8080;
+
+  public static void main(String[] args) throws IOException {
+    StatefulFunctionSpec greeterSpec =
+        StatefulFunctionSpec.builder(GreeterFn.FN_TYPE).withSupplier(GreeterFn::new).build();
+
+    StatefulFunctions functions = new StatefulFunctions();
+    functions.withStatefulFunction(greeterSpec);
+
+    RequestReplyHandler handler = functions.requestReplyHandler();
+
+    HttpServer server = HttpServer.create(new InetSocketAddress(PORT), 0);
+    server.createContext("/statefun", exchange -> handleRequest(exchange, handler));
+    server.start();
+
+    System.out.println("Greeter server started on port " + PORT);
+  }
+
+  private static void handleRequest(HttpExchange exchange, RequestReplyHandler handler) {
+    if ("GET".equalsIgnoreCase(exchange.getRequestMethod())) {
+      sendResponse(exchange, 200, "OK");
+      return;
+    }
+    if (!"POST".equalsIgnoreCase(exchange.getRequestMethod())) {
+      sendResponse(exchange, 405, "Method Not Allowed");
+      return;
+    }
+
+    try {
+      byte[] requestBytes = exchange.getRequestBody().readAllBytes();
+      CompletableFuture<Slice> responseFuture = handler.handle(Slices.wrap(requestBytes));
+
+      responseFuture.whenComplete(
+          (result, error) -> {
+            if (error != null) {
+              System.err.println("[Greeter] Error handling request: " + error);
+              error.printStackTrace(System.err);
+              sendResponse(exchange, 500, "Internal Server Error");
+            } else {
+              byte[] responseBytes = result.toByteArray();
+              exchange.getResponseHeaders().set("Content-Type", "application/octet-stream");
+              try {
+                exchange.sendResponseHeaders(200, responseBytes.length);
+                try (OutputStream os = exchange.getResponseBody()) {
+                  os.write(responseBytes);
+                }
+              } catch (IOException e) {
+                System.err.println("[Greeter] Error sending response: " + e.getMessage());
+              }
+            }
+          });
+    } catch (IOException e) {
+      System.err.println("[Greeter] Error reading request: " + e.getMessage());
+      sendResponse(exchange, 500, "Internal Server Error");
+    }
+  }
+
+  private static void sendResponse(HttpExchange exchange, int statusCode, String body) {
+    try {
+      byte[] bytes = body.getBytes();
+      exchange.sendResponseHeaders(statusCode, bytes.length);
+      try (OutputStream os = exchange.getResponseBody()) {
+        os.write(bytes);
+      }
+    } catch (IOException e) {
+      System.err.println("[Greeter] Error sending error response: " + e.getMessage());
+    }
+  }
+}

--- a/examples/quickstart/module.yaml
+++ b/examples/quickstart/module.yaml
@@ -1,0 +1,32 @@
+# SPDX-License-Identifier: Apache-2.0
+
+---
+kind: io.statefun.endpoints.v2/http
+spec:
+  functions: greeter/*
+  urlPathTemplate: http://greeter:8080/statefun
+  transport:
+    type: io.statefun.transports.v1/async
+    timeouts:
+      call: 30sec
+      connect: 10sec
+---
+kind: io.statefun.kafka.v1/ingress
+spec:
+  id: greeter/kafka-in
+  address: kafka:9092
+  consumerGroupId: statefun-quickstart-greeter
+  startupPosition:
+    type: earliest
+  topics:
+    - topic: greeter.commands
+      valueType: greeter/json-string
+      targets:
+        - greeter/fn
+---
+kind: io.statefun.kafka.v1/egress
+spec:
+  id: greeter/results
+  address: kafka:9092
+  deliverySemantic:
+    type: at-least-once


### PR DESCRIPTION
## Summary

- The current `docs/quickstart.md` instructs users to `cd dev && docker compose up -d`, but `dev/` is gitignored (`.gitignore:69`) — anyone running `git clone` does not have that directory, so the very first command fails. The maintainer copy of `dev/docker-compose.yml` compounded the problem by referencing a never-published `flink-statefun:3.4.0-KZM-1.0-SNAPSHOT` image.
- This PR ships a real user-facing path under `examples/quickstart/` (KRaft Kafka 3.9 + the published `ghcr.io/kzmlabs/flink-statefun:3.4.0-KZM-3.1` image + a small Maven-built greeter), rewrites `docs/quickstart.md` to point there, and gates the round-trip with a CI smoke workflow so the contract stays alive.
- The eval/tire-kicking audience is explicit: Java/Flink devs who want to see `produce → function → consume` work in five minutes before investing in K8s. Heap state + ephemeral checkpoints; production stays K8s.

## What's in here

- `examples/quickstart/docker-compose.yml` — 6 services: `kafka`, `kafka-init` (creates topics, exits), `greeter` (built from `./greeter/`), `jobmanager`, `taskmanager`, `job-submit` (one-shot `flink run`).
- `examples/quickstart/module.yaml` — single greeter endpoint + Kafka ingress (`greeter.commands`) + Kafka egress (`greeter.results`), mirroring the K8s e2e setup.
- `examples/quickstart/greeter/` — standalone Maven project (single dependency on `io.github.kzmlabs.flinkstatefun:statefun-sdk-java:3.4.0-KZM-3.1`) with `GreeterFn` (regex JSON parsing, identical to the K8s e2e function) and `GreeterServer` (com.sun.net.httpserver). Two-stage Dockerfile: `maven:3.9-eclipse-temurin-21` builder → `eclipse-temurin:21-jre` runtime.
- `docs/quickstart.md` — rewritten end-to-end: new directory, `--bootstrap-server`, `docker compose up --wait`, RAM 2 GB → 4 GB, drops the false "KRaft mode" claim about the old ZooKeeper setup, drops "no AWS credentials required" (leak from K8s guide), adds Troubleshooting section.
- `.github/workflows/quickstart-smoke.yml` + `.github/scripts/quickstart-smoke.sh` — round-trip test on every PR touching the quickstart surface.
- `.github/workflows/e2e-test.yml` — `paths-ignore` for `examples/quickstart/**`, `docs/quickstart.md`, and the smoke files so quickstart-only PRs do not pay for a 25-minute K8s gate.

Spec lives at `.docs-internal/specs/2026-05-10-quickstart-compose-design.md` (gitignored — not part of this PR).

## Test plan

- [ ] CI `Quickstart Smoke` workflow runs green (real `docker compose up --wait --build` + round-trip).
- [ ] CI `K8s E2E Test` does **not** trigger on this PR (path filter respected).
- [ ] Manual: `cd examples/quickstart && docker compose up -d --wait --build`, run the produce + consume commands from the rewritten quickstart, see `{"greeting":"Hello, Alice!"}` within 5 s.
- [ ] Manual: `docker compose down -v` cleans up.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a runnable quickstart stack showcasing an end-to-end Kafka → StateFun greeter flow with a Greeter service and HTTP endpoint.

* **Documentation**
  * Rewrote the quickstart guide for copy-paste usage, updated message examples and expected payloads, resource notes, and expanded troubleshooting.

* **Tests**
  * Added an automated quickstart smoke test that produces a sample message and verifies the greeting within a timeout.

* **Chores**
  * Added a Quickstart Smoke CI workflow and refined E2E test triggers to skip quickstart-only changes.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kzmlabs/flink-statefun/pull/181)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->