### PR TITLE
chore(deps): bump protobuf-go 1.33.0 and pygments 2.20.0 (security)

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,3 @@
 mkdocs-material==9.6.20
 pymdown-extensions==10.18
-pygments==2.18.0
+pygments==2.20.0

--- a/statefun-sdk-go/v3/go.mod
+++ b/statefun-sdk-go/v3/go.mod
@@ -7,5 +7,5 @@ go 1.16
 
 require (
 	github.com/stretchr/testify v1.7.0
-	google.golang.org/protobuf v1.26.0
+	google.golang.org/protobuf v1.33.0
 )

--- a/statefun-sdk-go/v3/go.sum
+++ b/statefun-sdk-go/v3/go.sum
@@ -11,8 +11,8 @@ github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
-google.golang.org/protobuf v1.26.0 h1:bxAC2xTBsZGibn2RTntX0oH50xLsqy1OxA9tTL3p/lk=
-google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
+google.golang.org/protobuf v1.33.0 h1:uNO2rsAINq/JlFpSdYEKIZ0uKD/R9cpdv0T+yoGwGmI=
+google.golang.org/protobuf v1.33.0/go.mod h1:c6P6GXX6sHbq/GpV6MGZEdwhWPcYBgnhAHhKbcUYpos=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=


### PR DESCRIPTION
## Summary

Closes the only Scorecard `VulnerabilitiesID` alert (#45) — 2 CVEs in transitive deps of the out-of-scope Go SDK and the docs site requirements:

| GHSA | Ecosystem | Package | CVSS | Before | After |
|---|---|---|---|---|---|
| `GHSA-8r3f-844c-mc37` | go | `google.golang.org/protobuf` | 7.5 (medium) | 1.26.0 | **1.33.0** |
| `GHSA-5239-wwwm-4pmq` | pip | `pygments` | 3.3 (low) | 2.18.0 | **2.20.0** |

The Go SDK and Python docs requirements live outside the actively-maintained Java surface, but a clean Scorecard signal is worth the one-line bump. Dependabot reports 0 open alerts on the Maven side.

## Verification

- `go.sum` updated with the sum.golang.org checksums for protobuf v1.33.0 (transitive dep set is identical to v1.26.0; no new modules required).
- `docs/requirements.txt` is consumed only by the MkDocs site build (`.github/workflows/docs.yml`).

## Test plan

- [ ] CI green (Build & Test, K8s E2E).
- [ ] Docs site builds clean with pygments 2.20.0.
- [ ] Scorecard re-scan on `release` drops the VulnerabilitiesID alert.
