### PR TITLE
chore(security): pin GitHub Actions and Flink base image to SHAs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,45 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Dependabot config — keeps SHA-pinned GitHub Actions and Maven deps
+# current. The actions in .github/workflows/ are pinned to commit hashes
+# (per OpenSSF Scorecard supply-chain hardening). Dependabot watches for
+# new tag releases and opens PRs that bump the SHA in step with the tag.
+
+version: 2
+
+updates:
+  # Pinned GitHub Actions across all workflows.
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      actions:
+        patterns:
+          - "*"
+
+  # Maven dependency graph (root pom + all modules).
+  - package-ecosystem: maven
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+
+  # Docs site requirements (MkDocs Material + plugins).
+  - package-ecosystem: pip
+    directory: /docs
+    schedule:
+      interval: weekly
+
+  # Go SDK module graph. SDK is otherwise out-of-scope for active work,
+  # but security/CVE bumps still apply.
+  - package-ecosystem: gomod
+    directory: /statefun-sdk-go/v3
+    schedule:
+      interval: weekly
+
+  # Base image digest for the published statefun-docker image.
+  - package-ecosystem: docker
+    directory: /statefun-docker/src/main/docker
+    schedule:
+      interval: weekly

--- a/.github/workflows/attest-image.yml
+++ b/.github/workflows/attest-image.yml
@@ -35,16 +35,16 @@ jobs:
       contents: read
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - uses: docker/login-action@v4
+      - uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Generate Sigstore attestation
-        uses: actions/attest-build-provenance@v4
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4
         with:
           subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           subject-digest: ${{ inputs.digest }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,10 +22,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Set up JDK 21
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
         with:
           java-version: '21'
           distribution: 'temurin'
@@ -55,7 +55,7 @@ jobs:
       # anyone with read access to the repo can grab the ZIP from the Actions run page.
       - name: Upload coverage HTML report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: coverage-report-html
           path: statefun-coverage-report/target/site/jacoco-aggregate/
@@ -64,7 +64,7 @@ jobs:
 
       - name: Upload unit-test coverage to Codecov
         if: always()
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5
         with:
           files: ./statefun-coverage-report/target/site/jacoco-aggregate/jacoco.xml
           flags: unittests
@@ -94,7 +94,7 @@ jobs:
 
       - name: Upload E2E coverage HTML report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: coverage-report-e2e-html
           path: statefun-e2e-coverage-report/target/site/jacoco-e2e-aggregate/
@@ -103,7 +103,7 @@ jobs:
 
       - name: Upload E2E coverage to Codecov
         if: always()
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5
         with:
           files: ./statefun-e2e-coverage-report/target/site/jacoco-e2e-aggregate/jacoco.xml
           flags: e2e

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -30,16 +30,16 @@ jobs:
         language: [java]
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - uses: actions/setup-java@v5
+      - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
         with:
           java-version: "21"
           distribution: temurin
           cache: maven
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@7fd177fa680c9881b53cdab4d346d32574c9f7f4 # v3
         with:
           languages: ${{ matrix.language }}
           queries: security-and-quality
@@ -51,6 +51,6 @@ jobs:
         run: mvn install -DskipTests -B -Drat.skip=true -Dskip.k8s.e2e
 
       - name: Perform CodeQL analysis
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@7fd177fa680c9881b53cdab4d346d32574c9f7f4 # v3
         with:
           category: /language:${{ matrix.language }}

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -38,10 +38,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Set up JDK 21
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
         with:
           java-version: '21'
           distribution: 'temurin'
@@ -51,10 +51,10 @@ jobs:
         run: mvn clean install -B
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4
 
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v4
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -62,7 +62,7 @@ jobs:
 
       - name: Compute image tags
         id: meta
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
@@ -70,7 +70,7 @@ jobs:
 
       - name: Build and push Docker image
         id: build
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7
         with:
           context: statefun-docker/target/docker
           push: true
@@ -80,7 +80,7 @@ jobs:
           sbom: true
 
       - name: Scan image for CVEs (Trivy)
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # master
         with:
           image-ref: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ steps.build.outputs.digest }}
           format: table
@@ -89,7 +89,7 @@ jobs:
           ignore-unfixed: true
 
       - name: Attest image provenance (Sigstore keyless)
-        uses: actions/attest-build-provenance@v4
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4
         with:
           subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           subject-digest: ${{ steps.build.outputs.digest }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -22,10 +22,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: "3.12"
           cache: pip

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -33,10 +33,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Set up JDK 21
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
         with:
           java-version: '21'
           distribution: 'temurin'

--- a/.github/workflows/quickstart-smoke.yml
+++ b/.github/workflows/quickstart-smoke.yml
@@ -31,10 +31,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       - name: Start quickstart stack
         working-directory: examples/quickstart
@@ -52,7 +52,7 @@ jobs:
 
       - name: Upload logs on failure
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: quickstart-logs
           path: examples/quickstart/docker-compose.log

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,7 +53,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Determine release type
         id: release_type
@@ -73,7 +73,7 @@ jobs:
           fi
 
       - name: Set up JDK 21
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
         with:
           java-version: '21'
           distribution: 'temurin'
@@ -99,10 +99,10 @@ jobs:
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4
 
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v4
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -110,7 +110,7 @@ jobs:
 
       - name: Compute image tags
         id: meta
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
@@ -119,7 +119,7 @@ jobs:
 
       - name: Build and push Docker image
         id: build
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7
         with:
           context: statefun-docker/target/docker
           push: true
@@ -129,7 +129,7 @@ jobs:
           sbom: true
 
       - name: Scan image for CVEs (Trivy)
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # master
         with:
           image-ref: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ steps.build.outputs.digest }}
           format: table
@@ -138,7 +138,7 @@ jobs:
           ignore-unfixed: true
 
       - name: Attest image provenance (Sigstore keyless)
-        uses: actions/attest-build-provenance@v4
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4
         with:
           subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           subject-digest: ${{ steps.build.outputs.digest }}
@@ -153,7 +153,7 @@ jobs:
       # supply-chain signing already in place.
       - name: Install cosign
         if: steps.release_type.outputs.type == 'full'
-        uses: sigstore/cosign-installer@v3
+        uses: sigstore/cosign-installer@398d4b0eeef1380460a10c8013a76f728fb906ac # v3
 
       - name: Generate and sign release manifest
         if: steps.release_type.outputs.type == 'full'

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -22,23 +22,23 @@ jobs:
       actions: read
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
 
-      - uses: ossf/scorecard-action@v2.4.3
+      - uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
         with:
           results_file: results.sarif
           results_format: sarif
           publish_results: true
 
       - name: Upload SARIF to code-scanning dashboard
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@7fd177fa680c9881b53cdab4d346d32574c9f7f4 # v3
         with:
           sarif_file: results.sarif
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: scorecard-results
           path: results.sarif

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -17,10 +17,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Set up JDK 21
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
         with:
           java-version: '21'
           distribution: 'temurin'

--- a/statefun-docker/src/main/docker/Dockerfile
+++ b/statefun-docker/src/main/docker/Dockerfile
@@ -4,7 +4,7 @@
 # syntax=docker/dockerfile:1.7
 
 ARG IMAGE_REGISTRY_PREFIX=
-ARG FLINK_BASE_IMAGE=${IMAGE_REGISTRY_PREFIX}apache/flink:2.2.0-java21
+ARG FLINK_BASE_IMAGE=${IMAGE_REGISTRY_PREFIX}apache/flink:2.2.0-java21@sha256:923326dc76dd86e3ddcb08e2cd5fc71d8023a451cdeea324cb573e323a54ba64
 FROM ${FLINK_BASE_IMAGE}
 
 # Logging library versions (downloaded from Maven Central)


### PR DESCRIPTION
## Summary

Closes the bulk of the 50+ OpenSSF Scorecard `PinnedDependenciesID` alerts. GitHub Actions and the published Flink base image are now referenced by content hash, not by mutable tag, so a tag-rewrite supply-chain attack against an upstream action cannot land here silently. New `.github/dependabot.yml` keeps the pins from rotting.

## What's pinned

| Surface | Before | After |
|---|---|---|
| 10 workflow files (`.github/workflows/*.yml`) | `actions/checkout@v6` etc. | `actions/checkout@de0fac2e... # v6` |
| `statefun-docker/src/main/docker/Dockerfile` | `apache/flink:2.2.0-java21` | `apache/flink:2.2.0-java21@sha256:923326dc...` |
| `.github/dependabot.yml` | n/a | New — weekly updates for `github-actions`, `maven`, `pip` (docs), `gomod` (sdk-go), `docker` (statefun-docker) |

The original tag is preserved as a trailing `# v<N>` comment on every pin so reviewers can read intent at a glance.

## What stays unpinned (with rationale)

- **`examples/quickstart/greeter/Dockerfile`** and **`statefun-e2e-tests/.../remote-function/Dockerfile`** — eval-only and test-only Dockerfiles; not shipped as a published artifact.
- **`aquasecurity/trivy-action@master`** in `release.yml` — upstream uses a rolling `master` ref and has no semantically-versioned tag releases; pinned to current `master` SHA, will be hand-bumped if Trivy publishes a tag.

## Test plan

- [ ] CI green — all workflows resolve the pinned SHAs and behave identically.
- [ ] Dependabot opens a first round of update PRs within ~24 h of merge.
- [ ] Scorecard re-scan on `release` drops the bulk of `PinnedDependenciesID` alerts.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated weekly dependency updates for GitHub Actions, Maven, Python packages, Go modules, and Docker ecosystems.

* **Chores**
  * Pinned GitHub Actions and Docker base image to immutable commit SHAs across all workflows for enhanced security and build reproducibility.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kzmlabs/flink-statefun/pull/183)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->