### PR TITLE
chore(codeql): drop code-quality pack, keep security-extended

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -42,7 +42,7 @@ jobs:
         uses: github/codeql-action/init@7fd177fa680c9881b53cdab4d346d32574c9f7f4 # v3
         with:
           languages: ${{ matrix.language }}
-          queries: security-and-quality
+          queries: security-extended
           paths-ignore: |
             **/target/generated-sources/**
             **/target/generated-test-sources/**


### PR DESCRIPTION
## Summary

Single-line CodeQL config change: `queries: security-and-quality` → `queries: security-extended`. Drops the ~800 code-quality / lint findings (missing-override, unused-parameter, confusing-method-signature, etc.) while keeping the full security analysis depth.

**No Java code is touched** — the entire diff is one word in `.github/workflows/codeql.yml`.

## Why

The `security-and-quality` pack combines two unrelated concerns:
- **security** — real CVEs / injection paths / unsafe deserialization — we want all of it
- **code-quality** — lint-style style suggestions — duplicates spotless / IDE coverage and obscures the security signal

`security-extended` is a strict superset of the default security pack (includes the slower, more-thorough security queries that `security-and-quality` was already running). We lose zero security coverage; we lose ~800 lint findings that nobody was going to action.

## What happens to existing alerts

Existing code-quality alerts (e.g. `java/missing-override-annotation`) will be **auto-closed by CodeQL on the next scan** — they're not detected by the new pack, so GH marks them as fixed automatically. No manual triage needed.

## Test plan

- [ ] CodeQL workflow runs green on this PR with the new pack.
- [ ] After merge, the next scheduled scan (weekly Monday) drops the open alert count from ~830 to <50.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated code security analysis configuration to use extended security queries in continuous integration workflows, expanding the scope of vulnerability detection during build processes.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kzmlabs/flink-statefun/pull/190)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->