### PR TITLE
feat(codeql): re-enable code-quality analysis as a separate SARIF category

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -20,7 +20,11 @@ concurrency:
 
 jobs:
   analyze:
-    name: Analyze (${{ matrix.language }})
+    # Two parallel jobs, distinct SARIF categories so the Security tab
+    # separates security-extended findings (real CVEs / injection paths)
+    # from code-quality findings (style / lint / refactor hints). Use
+    # the category filter in the Security UI to view one set at a time.
+    name: Analyze (${{ matrix.language }} / ${{ matrix.queries }})
     runs-on: ubuntu-latest
     timeout-minutes: 60
 
@@ -28,6 +32,7 @@ jobs:
       fail-fast: false
       matrix:
         language: [java]
+        queries: [security-extended, code-quality]
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -42,7 +47,7 @@ jobs:
         uses: github/codeql-action/init@7fd177fa680c9881b53cdab4d346d32574c9f7f4 # v3
         with:
           languages: ${{ matrix.language }}
-          queries: security-extended
+          queries: ${{ matrix.queries }}
           paths-ignore: |
             **/target/generated-sources/**
             **/target/generated-test-sources/**
@@ -53,4 +58,4 @@ jobs:
       - name: Perform CodeQL analysis
         uses: github/codeql-action/analyze@7fd177fa680c9881b53cdab4d346d32574c9f7f4 # v3
         with:
-          category: /language:${{ matrix.language }}
+          category: /language:${{ matrix.language }}/${{ matrix.queries }}


### PR DESCRIPTION
## Summary

Brings code-quality CodeQL findings back online, but **categorised separately** from security so the Security tab stays scannable.

Two parallel matrix jobs:

| Category | Pack | Surface |
|---|---|---|
| `/language:java/security-extended` | `security-extended` | Real security findings (CVEs, injection paths, unsafe deserialization) |
| `/language:java/code-quality` | `code-quality` | Lint / style / refactor (missing-override, unused-parameter, confusing-method-signature) |

GitHub's Security tab will show both, filtered by category. You can ignore code-quality at a glance when triaging security, and vice versa.

## What changes after merge

- Next scheduled scan (weekly Monday) and the post-merge `push` scan will run both packs.
- Pre-existing code-quality alerts that auto-closed when PR #190 landed will **reopen under the new `code-quality` category** — same findings, just tagged separately now.
- Workflow runtime ≈5 min × 2 in parallel; Maven cache from `actions/setup-java` keeps the second build fast. `fail-fast: false` so a code-quality regression cannot mask a security regression, and the reverse.

## Test plan

- [ ] Both `Analyze (java / security-extended)` and `Analyze (java / code-quality)` jobs pass on this PR.
- [ ] After merge, Security tab shows two distinct category entries.
- [ ] Filtering by category in the Security UI works as expected.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CodeQL static analysis workflow to execute both security-extended and code-quality checks in parallel, with improved categorization of analysis results.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kzmlabs/flink-statefun/pull/193)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->