### PR TITLE
chore(deps): ignore slf4j-log4j12 2.x bumps in Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,6 +24,14 @@ updates:
     schedule:
       interval: weekly
     open-pull-requests-limit: 10
+    ignore:
+      # slf4j-log4j12 was renamed to slf4j-reload4j in slf4j 2.x and
+      # pulls slf4j-api 2.x transitively. Flink 2.2.0 still drags slf4j-api
+      # 1.7.36, so the bump triggers Maven enforcer's DependencyConvergence.
+      # slf4j 2.x migration is tracked as a coordinated effort, not a
+      # Dependabot one-shot. See PR #187 for the failure mode.
+      - dependency-name: "org.slf4j:slf4j-log4j12"
+        versions: [">=2.0"]
 
   # Docs site requirements (MkDocs Material + plugins).
   - package-ecosystem: pip


### PR DESCRIPTION
## Summary

Tells Dependabot to stop opening `slf4j-log4j12 2.x` PRs. PR #187 was the first attempt and failed CI on Maven enforcer `DependencyConvergence` — the underlying issue is that `slf4j-log4j12` was renamed to `slf4j-reload4j` in slf4j 2.x and pulls `slf4j-api 2.x`, which collides with the `slf4j-api 1.7.36` that Flink 2.2.0 still drags in transitively.

This is a coordinated slf4j 2.x migration effort (`dependencyManagement` pin + transitive audit + artifact rename), not a one-shot Dependabot bump.

## Test plan

- [ ] After merge, Dependabot does not re-open the slf4j-log4j12 2.x PR.
- [ ] When the slf4j 2.x migration lands as its own PR, this `ignore` block can be removed in the same commit.
