### PR TITLE
chore(deps): scope Dependabot actions group to minor/patch only

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,11 @@ version: 2
 
 updates:
   # Pinned GitHub Actions across all workflows.
+  #
+  # Grouping reduces noise for patch/minor bumps — they land as one weekly
+  # PR. Major bumps each get their own PR (Dependabot's default once the
+  # group's update-types excludes major) so the workflow API changes that
+  # often come with vN -> vN+1 can be reviewed one upgrade at a time.
   - package-ecosystem: github-actions
     directory: /
     schedule:
@@ -17,6 +22,9 @@ updates:
       actions:
         patterns:
           - "*"
+        update-types:
+          - "minor"
+          - "patch"
 
   # Maven dependency graph (root pom + all modules).
   - package-ecosystem: maven


### PR DESCRIPTION
## Summary

PR #192 (closed) was Dependabot's first batched actions group PR — and it bundled five simultaneous major-version bumps into one diff:

| Action | From | To |
|---|---|---|
| `actions/upload-artifact` | 4.6.2 | 7.0.1 (Node 24, ESM mandatory) |
| `codecov/codecov-action` | 5.5.4 | 6.0.0 |
| `github/codeql-action` | 3.35.4 | 4.35.4 |
| `docker/setup-buildx-action` | 3.12.0 | 4.0.0 |
| `sigstore/cosign-installer` | 3.9.1 | 4.1.2 |

Each of those carries enough breaking-change potential that reviewing them as a single batch is hostile to careful triage. Root cause was `groups: actions: patterns: "*"` in `.github/dependabot.yml`, which grouped majors right alongside patches.

This restricts the actions group to `minor` and `patch` updates. Majors will each open their own PR (Dependabot's default behaviour once they're excluded from a group). After merge, Dependabot's next run will re-open the four major-bump PRs from #192 individually.

## Test plan

- [ ] Merge.
- [ ] Wait for next Dependabot run (≤ 24h or trigger manually via "Check for updates" in the Dependabot settings).
- [ ] Confirm four separate PRs land: upload-artifact v7, codecov-action v6, codeql-action v4, setup-buildx v4, cosign-installer v4 — each evaluable on its own.
