### PR TITLE
fix: address CodeQL real-bug findings (resource leaks, sync, immutability)

### DIFF
--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/logger/UnboundedFeedbackLogger.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/logger/UnboundedFeedbackLogger.java
@@ -107,9 +107,10 @@ public final class UnboundedFeedbackLogger<T> implements FeedbackLogger<T> {
 
   public void replyLoggedEnvelops(InputStream rawKeyedStateInputs, FeedbackConsumer<T> consumer)
       throws Exception {
-    DataInputView in =
-        new DataInputViewStreamWrapper(Header.skipHeaderSilently(rawKeyedStateInputs));
-    KeyGroupStream.readFrom(in, serializer, consumer);
+    try (DataInputViewStreamWrapper in =
+        new DataInputViewStreamWrapper(Header.skipHeaderSilently(rawKeyedStateInputs))) {
+      KeyGroupStream.readFrom(in, serializer, consumer);
+    }
   }
 
   @Nonnull

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/nettyclient/NettyProtobuf.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/nettyclient/NettyProtobuf.java
@@ -60,7 +60,9 @@ final class NettyProtobuf {
 
   private static <M extends Message> void serializeOutputStream(M message, ByteBuf buf)
       throws IOException {
-    message.writeTo(new ByteBufOutputStream(buf));
+    try (ByteBufOutputStream out = new ByteBufOutputStream(buf)) {
+      message.writeTo(out);
+    }
   }
 
   private static <M extends Message> M zeroCopyDeserialize(ByteBuf buf, Parser<M> parser)

--- a/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/spi/ModuleSpecs.java
+++ b/statefun-flink/statefun-flink-core/src/main/java/org/apache/flink/statefun/flink/core/spi/ModuleSpecs.java
@@ -87,7 +87,7 @@ public class ModuleSpecs implements Iterable<ModuleSpec>, Serializable {
     private final List<URI> artifactUrls;
 
     private ModuleSpec(List<URI> artifacts) {
-      this.artifactUrls = Collections.unmodifiableList(artifacts);
+      this.artifactUrls = List.copyOf(artifacts);
     }
 
     static Builder builder() {

--- a/statefun-flink/statefun-flink-core/src/test/java/org/apache/flink/statefun/flink/core/logger/OneBytePerReadByteArrayInputStream.java
+++ b/statefun-flink/statefun-flink-core/src/test/java/org/apache/flink/statefun/flink/core/logger/OneBytePerReadByteArrayInputStream.java
@@ -27,7 +27,7 @@ final class OneBytePerReadByteArrayInputStream extends ByteArrayInputStream {
   }
 
   @Override
-  public int read(byte[] b, int off, int len) {
+  public synchronized int read(byte[] b, int off, int len) {
     return super.read(b, off, Math.min(len, 1));
   }
 

--- a/statefun-flink/statefun-flink-core/src/test/java/org/apache/flink/statefun/flink/core/logger/RandomReadLengthByteArrayInputStream.java
+++ b/statefun-flink/statefun-flink-core/src/test/java/org/apache/flink/statefun/flink/core/logger/RandomReadLengthByteArrayInputStream.java
@@ -30,7 +30,7 @@ final class RandomReadLengthByteArrayInputStream extends ByteArrayInputStream {
   }
 
   @Override
-  public int read(byte[] b, int off, int len) {
+  public synchronized int read(byte[] b, int off, int len) {
     final int randomNumBytesToRead = RANDOM.nextInt(len) + 1;
     return super.read(b, off, randomNumBytesToRead);
   }

--- a/statefun-flink/statefun-flink-core/src/test/java/org/apache/flink/statefun/flink/core/logger/UnboundedFeedbackLoggerTest.java
+++ b/statefun-flink/statefun-flink-core/src/test/java/org/apache/flink/statefun/flink/core/logger/UnboundedFeedbackLoggerTest.java
@@ -85,10 +85,11 @@ public class UnboundedFeedbackLoggerTest {
     out.writeInt(456);
     InputStream in = new RandomReadLengthByteArrayInputStream(out.getCopyOfBuffer());
 
-    DataInputViewStreamWrapper view = new DataInputViewStreamWrapper(Header.skipHeaderSilently(in));
-
-    assertThat(view.readInt(), is(123));
-    assertThat(view.readInt(), is(456));
+    try (DataInputViewStreamWrapper view =
+        new DataInputViewStreamWrapper(Header.skipHeaderSilently(in))) {
+      assertThat(view.readInt(), is(123));
+      assertThat(view.readInt(), is(456));
+    }
   }
 
   @Test
@@ -98,10 +99,11 @@ public class UnboundedFeedbackLoggerTest {
     out.writeInt(456);
     InputStream in = new RandomReadLengthByteArrayInputStream(out.getCopyOfBuffer());
 
-    DataInputViewStreamWrapper view = new DataInputViewStreamWrapper(Header.skipHeaderSilently(in));
-
-    assertThat(view.readInt(), is(123));
-    assertThat(view.readInt(), is(456));
+    try (DataInputViewStreamWrapper view =
+        new DataInputViewStreamWrapper(Header.skipHeaderSilently(in))) {
+      assertThat(view.readInt(), is(123));
+      assertThat(view.readInt(), is(456));
+    }
   }
 
   @Test
@@ -110,16 +112,19 @@ public class UnboundedFeedbackLoggerTest {
     Header.writeHeader(out);
     InputStream in = new RandomReadLengthByteArrayInputStream(out.getCopyOfBuffer());
 
-    DataInputViewStreamWrapper view = new DataInputViewStreamWrapper(Header.skipHeaderSilently(in));
-
-    assertThat(view.read(), is(-1));
+    try (DataInputViewStreamWrapper view =
+        new DataInputViewStreamWrapper(Header.skipHeaderSilently(in))) {
+      assertThat(view.read(), is(-1));
+    }
   }
 
   @Test
   public void emptyKeyGroupWithoutHeader() throws IOException {
     InputStream in = new RandomReadLengthByteArrayInputStream(new byte[0]);
-    DataInputViewStreamWrapper view = new DataInputViewStreamWrapper(Header.skipHeaderSilently(in));
-    assertThat(view.read(), is(-1));
+    try (DataInputViewStreamWrapper view =
+        new DataInputViewStreamWrapper(Header.skipHeaderSilently(in))) {
+      assertThat(view.read(), is(-1));
+    }
   }
 
   private void roundTrip(int numElements, int maxMemoryInBytes) throws Exception {


### PR DESCRIPTION
## Summary

Targeted fixes for the **real correctness bugs** CodeQL surfaced — resource leaks, missing synchronization, and immutability gaps. Skips the ~787 style-only findings (missing-override, unused-parameter, etc.) which are Apache Flink legacy patterns and would just create diff noise.

## What's fixed in code

**Production** — 3 alerts:
| File | Bug | Fix |
|---|---|---|
| `UnboundedFeedbackLogger.java:111` | `input-resource-leak` — DataInputViewStreamWrapper not closed | try-with-resources |
| `NettyProtobuf.java:63` | `output-resource-leak` — ByteBufOutputStream not closed | try-with-resources (ByteBufOutputStream.close does NOT release the underlying ByteBuf — verified via Netty docs) |
| `ModuleSpecs.java:90` | `internal-representation-exposure` — backing list reachable via the unmodifiable view | `List.copyOf` (truly immutable, CodeQL trusts it) |

**Test code** — 6 alerts:
| File | Bug | Fix |
|---|---|---|
| `UnboundedFeedbackLoggerTest.java:88,101,113,121` | 4× `input-resource-leak` | 4× try-with-resources |
| `RandomReadLengthByteArrayInputStream.java:33` | `non-sync-override` of `ByteArrayInputStream.read(byte[],int,int)` | add `synchronized` |
| `OneBytePerReadByteArrayInputStream.java:30` | same | add `synchronized` |

## Deliberately left unfixed (will dismiss via API after merge)

| Alert | Why |
|---|---|
| `StatefulFunctionsUniverse.ingress()` / `.egress()` exposure (2) | `Harness.java:158-159` intentionally mutates these maps via the accessors to inject test-time replacements. Wrapping in `unmodifiableMap` would break the harness contract. |
| `CommandInterpreter.java parseInt` × 2 in smoke e2e drivers | The id is generated by the smoke harness and is always numeric; warning is inert in test scope. |
| `ObjectOpenHashMap.java inconsistent-equals-and-hashcode` | Vendored fastutil code (`it.unimi.dsi`) — not our code to touch. |
| ~787 style alerts | Apache Flink legacy idioms; auto-fixing creates noise without behaviour change. Filter the `code-quality` CodeQL category in the Security tab to triage. |

## Test plan

- [ ] CI green — Build & Test + K8s E2E + Analyze (both CodeQL packs).
- [ ] CodeQL re-scan drops these 9 alerts on next run.
- [ ] Manual verification of `replyLoggedEnvelops` callers: both pass the stream and never read again (`FeedbackUnionOperator` and the unit test itself).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resource management to ensure proper cleanup of internal streams and prevent potential resource leaks.
  
* **Tests**
  * Updated test cases to validate proper resource handling and cleanup behavior.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kzmlabs/flink-statefun/pull/202)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->