### PR TITLE
chore(examples): bump quickstart to 3.4.0-KZM-3.3 post-release

### DIFF
--- a/examples/quickstart/docker-compose.yml
+++ b/examples/quickstart/docker-compose.yml
@@ -60,7 +60,7 @@ services:
       start_period: 10s
 
   jobmanager:
-    image: ghcr.io/kzmlabs/flink-statefun:3.4.0-KZM-3.1
+    image: ghcr.io/kzmlabs/flink-statefun:3.4.0-KZM-3.3
     container_name: quickstart-jobmanager
     command: jobmanager
     ports:
@@ -90,7 +90,7 @@ services:
       start_period: 30s
 
   taskmanager:
-    image: ghcr.io/kzmlabs/flink-statefun:3.4.0-KZM-3.1
+    image: ghcr.io/kzmlabs/flink-statefun:3.4.0-KZM-3.3
     container_name: quickstart-taskmanager
     command: taskmanager
     depends_on:
@@ -107,7 +107,7 @@ services:
         statefun.remote.module-name: file:///opt/statefun/module.yaml
 
   job-submit:
-    image: ghcr.io/kzmlabs/flink-statefun:3.4.0-KZM-3.1
+    image: ghcr.io/kzmlabs/flink-statefun:3.4.0-KZM-3.3
     container_name: quickstart-job-submit
     depends_on:
       jobmanager:

--- a/examples/quickstart/greeter/pom.xml
+++ b/examples/quickstart/greeter/pom.xml
@@ -17,7 +17,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>21</maven.compiler.source>
         <maven.compiler.target>21</maven.compiler.target>
-        <statefun.version>3.4.0-KZM-3.1</statefun.version>
+        <statefun.version>3.4.0-KZM-3.3</statefun.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
## Summary

Reverts the temporary pin from PR #203 (release-prep) — the 3.4.0-KZM-3.3 image and `statefun-sdk-java` artifact are now published, so `examples/quickstart/` can reference the current release again.

Verified post-pipeline:
- GHCR image `ghcr.io/kzmlabs/flink-statefun:3.4.0-KZM-3.3` exists (digest `sha256:56ac90d2...`)
- Maven Central `io.github.kzmlabs.flinkstatefun:statefun-bom:3.4.0-KZM-3.3:pom` resolves (HTTP 200)

## Test plan

- [ ] Quickstart Smoke runs green against the new tag.