### PR TITLE
docs: bump Apache-vs-Kzmlabs comparison header to KZM-3.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ flowchart LR
 
 Apache Stateful Functions stopped releasing in October 2024 at 3.4.0, locked to Flink 1.16 and Java 11. Anyone wanting to run it against modern Flink either pinned old dependencies or vendored their own patches. StateFun Actors is the public, actively maintained branch — same code, modern stack, no vendor lock-in.
 
-| | Apache StateFun 3.4.0 | StateFun Actors KZM-3.1 |
+| | Apache StateFun 3.4.0 | StateFun Actors KZM-3.3 |
 |---|---|---|
 | **Flink runtime** | 1.16.2 | **2.2.0** |
 | **Java baseline** | 11 | **21** |

--- a/docs/index.md
+++ b/docs/index.md
@@ -116,7 +116,7 @@ Write functions in whichever language fits the team. Plug into the streaming and
 
 Apache Stateful Functions stopped releasing in **October 2024** at version 3.4.0, locked to **Flink 1.16** and **Java 11**. Anyone wanting to run it against modern Flink either pinned old dependencies or vendored their own patches. StateFun Actors is the public, actively maintained continuation — same code, modern stack, no vendor lock-in.
 
-| | Apache StateFun 3.4.0 | StateFun Actors KZM-3.1 |
+| | Apache StateFun 3.4.0 | StateFun Actors KZM-3.3 |
 |---|---|---|
 | **Flink runtime** | 1.16.2 | **2.2.0** |
 | **Java baseline** | 11 | **21** |

--- a/docs/upstream-vs-kzm.md
+++ b/docs/upstream-vs-kzm.md
@@ -9,7 +9,7 @@ description: Migration guide from Apache Stateful Functions 3.4.0 to StateFun Ac
 
 ## At a glance
 
-| | Apache StateFun 3.4.0 | StateFun Actors KZM-3.1 |
+| | Apache StateFun 3.4.0 | StateFun Actors KZM-3.3 |
 |---|---|---|
 | **Flink runtime** | 1.16.2 | **2.2.0** |
 | **Java baseline** | 11 | **21** |


### PR DESCRIPTION
Missed in release PR #203 — three comparison tables (README, docs/index, docs/upstream-vs-kzm) still showed `StateFun Actors KZM-3.1` in the header column. Version matrix rows (listing older Stable versions) intentionally keep `KZM-3.1` and `KZM-3.0`.