### PR TITLE
docs(readme): reference FLIP-569 as upstream-sunset confirmation

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ flowchart LR
 
 Apache Stateful Functions stopped releasing in October 2024 at 3.4.0, locked to Flink 1.16 and Java 11. Anyone wanting to run it against modern Flink either pinned old dependencies or vendored their own patches. StateFun Actors is the public, actively maintained branch — same code, modern stack, no vendor lock-in.
 
+> **Update — May 2026:** Apache has filed [FLIP-569: Sunset the Stateful Functions sub-project](https://cwiki.apache.org/confluence/display/FLINK/FLIP-569%3A+Sunset+the+Stateful+Functions+%28StateFun%29+Sub-project), formalising the end of upstream maintenance and naming "fork the repository" as one of the migration paths. This fork was already active before the proposal landed; FLIP-569 confirms the read from October 2024 that picking the project up was worth doing.
+
 | | Apache StateFun 3.4.0 | StateFun Actors KZM-3.3 |
 |---|---|---|
 | **Flink runtime** | 1.16.2 | **2.2.0** |


### PR DESCRIPTION
Adds a short blockquote in README's "Why this exists" section linking to [FLIP-569: Sunset the Stateful Functions sub-project](https://cwiki.apache.org/confluence/display/FLINK/FLIP-569%3A+Sunset+the+Stateful+Functions+%28StateFun%29+Sub-project) — Apache's formal proposal to archive the upstream repo, filed by Martijn Visser in May 2026.

The FLIP explicitly names "fork the repository" as one of the migration paths for existing users, which is how this fork already operates. The README note makes the upstream-status story verifiable in one click for new visitors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated README with notice about Apache's FLIP-569 decision to sunset the Stateful Functions sub-project, confirming the end of upstream maintenance.
  * Documented the recommended migration strategy through repository forking for users requiring continued development and support.
  * Clarified that the community fork was established and became active prior to the official sunset announcement.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kzmlabs/flink-statefun/pull/211)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->