### PR TITLE
correct javadoc of statefun-sdk-java

### DIFF
--- a/statefun-sdk-java/src/main/java/org/apache/flink/statefun/sdk/java/Address.java
+++ b/statefun-sdk-java/src/main/java/org/apache/flink/statefun/sdk/java/Address.java
@@ -5,8 +5,8 @@ package org.apache.flink.statefun.sdk.java;
 import java.util.Objects;
 
 /**
- * An {@link Address} is the unique identity of an individual {@link StatefulFunction}, containing
- * of the function's {@link TypeName} and an unique identifier within the type. The function's type
+ * An {@link Address} is the unique identity of an individual {@link StatefulFunction}, consisting
+ * of the function's {@link TypeName} and a unique identifier within the type. The function's type
  * denotes the class of function to invoke, while the unique identifier addresses the invocation to
  * a specific function instance.
  */

--- a/statefun-sdk-java/src/main/java/org/apache/flink/statefun/sdk/java/AddressScopedStorage.java
+++ b/statefun-sdk-java/src/main/java/org/apache/flink/statefun/sdk/java/AddressScopedStorage.java
@@ -6,12 +6,12 @@ import java.util.Optional;
 import org.apache.flink.statefun.sdk.java.storage.IllegalStorageAccessException;
 
 /**
- * An {@link AddressScopedStorage} is used for reading and writing persistent values that is managed
+ * An {@link AddressScopedStorage} is used for reading and writing persistent values that are managed
  * by Stateful Functions for fault-tolerance and consistency.
  *
  * <p>All access to the storage is scoped to the current invoked function instance, identified by
  * the instance's {@link Address}. This means that within an invocation, function instances may only
- * access it's own persisted values through this storage.
+ * access its own persisted values through this storage.
  */
 public interface AddressScopedStorage {
 
@@ -21,7 +21,7 @@ public interface AddressScopedStorage {
    *
    * @param spec the {@link ValueSpec} to read the value for.
    * @param <T> the type of the value.
-   * @return the value, or {@link Optional#empty()} if there was not prior value set.
+   * @return the value, or {@link Optional#empty()} if there is no prior value set.
    * @throws IllegalStorageAccessException if the provided {@link ValueSpec} is not recognized by
    *     the storage (e.g., if it wasn't registered for the accessing function).
    */

--- a/statefun-sdk-java/src/main/java/org/apache/flink/statefun/sdk/java/Context.java
+++ b/statefun-sdk-java/src/main/java/org/apache/flink/statefun/sdk/java/Context.java
@@ -43,7 +43,7 @@ public interface Context {
   /**
    * Sends out a {@link Message} to another function, after a specified {@link Duration} delay.
    *
-   * @param duration the amount of time to delay the message delivery. * @param cancellationToken
+   * @param duration the amount of time to delay the message delivery.
    * @param cancellationToken the non-empty, non-null, unique token to attach to this message, to be
    *     used for message cancellation. (see {@link #cancelDelayedMessage(String)}.)
    * @param message the message to send.

--- a/statefun-sdk-java/src/main/java/org/apache/flink/statefun/sdk/java/Expiration.java
+++ b/statefun-sdk-java/src/main/java/org/apache/flink/statefun/sdk/java/Expiration.java
@@ -28,7 +28,7 @@ public final class Expiration implements Serializable {
   }
 
   /**
-   * Returns an {@link Expiration} configuration that would expire a @duration after the last write.
+   * Returns an {@link Expiration} configuration that would expire after a {@code duration} since the last write.
    *
    * @param duration a duration to wait before considering the state expired.
    */
@@ -37,7 +37,7 @@ public final class Expiration implements Serializable {
   }
 
   /**
-   * Returns an {@link Expiration} configuration that would expire a @duration after the last
+   * Returns an {@link Expiration} configuration that would expire after a {@code duration} since the last
    * invocation of the function.
    *
    * @param duration a duration to wait before considering the state expired.

--- a/statefun-sdk-java/src/main/java/org/apache/flink/statefun/sdk/java/StatefulFunction.java
+++ b/statefun-sdk-java/src/main/java/org/apache/flink/statefun/sdk/java/StatefulFunction.java
@@ -11,7 +11,7 @@ import org.apache.flink.statefun.sdk.java.message.Message;
  *
  * <h2>Concept</h2>
  *
- * <p>Each individual {@code StatefulFunction} is an uniquely invokable "instance" of a registered
+ * <p>Each individual {@code StatefulFunction} is a uniquely invokable "instance" of a registered
  * {@link StatefulFunctionSpec}. Each instance is identified by an {@link Address}, representing the
  * function's unique id (a string) within its type. From a user's perspective, it would seem as if
  * for each unique function id, there exists a stateful instance of the function that is always
@@ -19,7 +19,7 @@ import org.apache.flink.statefun.sdk.java.message.Message;
  *
  * <h2>Invoking a {@code StatefulFunction}</h2>
  *
- * <p>An individual {@code StatefulFunction} can be invoked with arbitrary input from any another
+ * <p>An individual {@code StatefulFunction} can be invoked with arbitrary input from any other
  * {@code StatefulFunction} (including itself), or routed from ingresses. To invoke a {@code
  * StatefulFunction}, the caller simply needs to know the {@code Address} of the target function.
  *

--- a/statefun-sdk-java/src/main/java/org/apache/flink/statefun/sdk/java/TypeName.java
+++ b/statefun-sdk-java/src/main/java/org/apache/flink/statefun/sdk/java/TypeName.java
@@ -55,7 +55,7 @@ public final class TypeName implements Serializable {
   /**
    * Creates a {@link TypeName}.
    *
-   * @param namespace the function type's namepsace.
+   * @param namespace the function type's namespace.
    * @param type the function type's name.
    */
   private TypeName(String namespace, String type) {

--- a/statefun-sdk-java/src/main/java/org/apache/flink/statefun/sdk/java/ValueSpec.java
+++ b/statefun-sdk-java/src/main/java/org/apache/flink/statefun/sdk/java/ValueSpec.java
@@ -12,7 +12,7 @@ import org.apache.flink.statefun.sdk.shaded.com.google.protobuf.ByteString;
 /**
  * A {@link ValueSpec} identifies a registered persistent value of a function, which will be managed
  * by the Stateful Functions runtime for consistency and fault-tolerance. A {@link ValueSpec} is
- * registered for a function by configuring it on the function's assoicated {@link
+ * registered for a function by configuring it on the function's associated {@link
  * StatefulFunctionSpec}.
  *
  * @see StatefulFunctionSpec.Builder#withValueSpec(ValueSpec)

--- a/statefun-sdk-java/src/main/java/org/apache/flink/statefun/sdk/java/testing/TestContext.java
+++ b/statefun-sdk-java/src/main/java/org/apache/flink/statefun/sdk/java/testing/TestContext.java
@@ -14,7 +14,7 @@ import org.apache.flink.statefun.sdk.java.message.EgressMessage;
 import org.apache.flink.statefun.sdk.java.message.Message;
 
 /**
- * An implementation of {@link Context} to to make it easier to test {@link
+ * An implementation of {@link Context} to make it easier to test {@link
  * org.apache.flink.statefun.sdk.java.StatefulFunction}s in isolation. It can be instantiated with
  * the address of the function under test and optionally the address of the caller.
  */
@@ -102,11 +102,7 @@ public final class TestContext implements Context {
 
   /**
    * This method returns a list of all messages sent by this function via {@link
-   * Context#send(Message)} or {@link Context#sendAfter(Duration, Message)}.
-   *
-   * <p>Messages are wrapped in an {@link SideEffects.SendSideEffect} that contains the message
-   * itself and the duration after which the message was sent. The Duration is {@link Duration#ZERO}
-   * for messages sent via {@link Context#send(Message)}.
+   * Context#send(Message)}.
    *
    * @return the list of sent messages wrapped in {@link SideEffects.SendSideEffect}s
    */

--- a/statefun-sdk-java/src/main/java/org/apache/flink/statefun/sdk/java/types/Types.java
+++ b/statefun-sdk-java/src/main/java/org/apache/flink/statefun/sdk/java/types/Types.java
@@ -70,7 +70,7 @@ public final class Types {
 
   /**
    * Compute the Protobuf field tag, as specified by the Protobuf wire format. See {@code
-   * WireFormat#makeTag(int, int)}}. NOTE: that, currently, for all StateFun provided wire types the
+   * WireFormat#makeTag(int, int)}. NOTE: that, currently, for all StateFun provided wire types the
    * tags should be 1 byte.
    *
    * @param fieldNumber the field number as specified in the message definition.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected Javadoc grammar, spelling, and formatting across SDK Java documentation
  * Fixed multiple grammatical errors and typos in class and method documentation
  * Improved Javadoc formatting for better readability and consistency
  * Enhanced documentation accuracy with corrected parameter descriptions and references

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kzmlabs/flink-statefun/pull/212)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->