### PR TITLE
Use early return in RemoteFunctionServer.java

### DIFF
--- a/statefun-e2e-tests/statefun-e2e-k8s-native/remote-function/src/main/java/org/apache/flink/statefun/e2e/k8s/RemoteFunctionServer.java
+++ b/statefun-e2e-tests/statefun-e2e-k8s-native/remote-function/src/main/java/org/apache/flink/statefun/e2e/k8s/RemoteFunctionServer.java
@@ -69,7 +69,8 @@ public class RemoteFunctionServer {
               System.err.println("[Server] Error handling request: " + error);
               error.printStackTrace(System.err);
               sendResponse(exchange, 500, "Internal Server Error");
-            } else {
+              return;
+            } 
               byte[] responseBytes = result.toByteArray();
               System.out.println("[Server] Response: " + responseBytes.length + " bytes");
               exchange.getResponseHeaders().set("Content-Type", "application/octet-stream");
@@ -81,7 +82,6 @@ public class RemoteFunctionServer {
               } catch (IOException e) {
                 System.err.println("[Server] Error sending response: " + e.getMessage());
               }
-            }
           });
     } catch (IOException e) {
       System.err.println("[Server] Error reading request: " + e.getMessage());


### PR DESCRIPTION
## Summary

<!-- What does this PR do and why? 1–3 bullets. -->

## Changes

<!-- Brief list of user-visible changes. -->

## Test plan

- [ ] `mvn spotless:apply` clean
- [ ] `mvn install -Dskip.k8s.e2e -B` passes
- [ ] New or updated tests cover the change
- [ ] K8s E2E run (if touching runtime/runner): `mvn verify -pl :statefun-e2e-k8s-native -am`

## Related issues

<!-- Fixes #123, Refs #456 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling in asynchronous request processing. Errors are now properly handled and logged without attempting further response processing, enhancing system reliability and preventing potential response-related issues.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kzmlabs/flink-statefun/pull/213)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->