### PR TITLE
Reformat COUNTER_COMMAND_TYPE in KafkaCounterFn.java

### DIFF
--- a/statefun-e2e-tests/statefun-e2e-k8s-native/remote-function/src/main/java/org/apache/flink/statefun/e2e/k8s/KafkaCounterFn.java
+++ b/statefun-e2e-tests/statefun-e2e-k8s-native/remote-function/src/main/java/org/apache/flink/statefun/e2e/k8s/KafkaCounterFn.java
@@ -28,7 +28,9 @@ public final class KafkaCounterFn implements StatefulFunction {
 
   static final Type<CounterCommand> COUNTER_COMMAND_TYPE =
       SimpleType.simpleTypeFrom(
-          COUNTER_COMMAND_TYPE_NAME, CounterCommand::toByteArray, CounterCommand::parseFrom);
+          COUNTER_COMMAND_TYPE_NAME, 
+          CounterCommand::toByteArray, 
+          (byte[] bytes) -> CounterCommand.parseFrom(bytes));
 
   @Override
   public CompletableFuture<Void> apply(Context context, Message message) {


### PR DESCRIPTION
## Summary

 Reformats COUNTER_COMMAND_TYPE Kafka message deserialization to convert raw bytes 
       to CounterCommand objects

## Changes

CounterCommand was reformated from method reference to an explicit lambda

## Test plan

- [ ] `mvn spotless:apply` clean
- [ ] `mvn install -Dskip.k8s.e2e -B` passes
- [ ] New or updated tests cover the change
- [ ] K8s E2E run (if touching runtime/runner): `mvn verify -pl :statefun-e2e-k8s-native -am`

## Related issues

<!-- Fixes #123, Refs #456 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved code formatting and readability in test infrastructure.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kzmlabs/flink-statefun/pull/214)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->