### PR TITLE
test(k8s-e2e): cover state-TTL cleanup + harden LocalStack startup gate

### DIFF
--- a/statefun-e2e-tests/statefun-e2e-k8s-native/pom.xml
+++ b/statefun-e2e-tests/statefun-e2e-k8s-native/pom.xml
@@ -23,6 +23,10 @@
         <slf4j.version>2.0.17</slf4j.version>
         <!-- CI can set this true to keep the cluster alive for log collection -->
         <skip.teardown>false</skip.teardown>
+        <!-- Optional registry prefix forwarded to docker build. Empty by default;
+             override via -Dimage.registry.prefix=... or by setting env
+             IMAGE_REGISTRY_PREFIX (resolved through the profile below). -->
+        <image.registry.prefix></image.registry.prefix>
     </properties>
 
     <dependencies>
@@ -205,7 +209,7 @@
                                     <arguments>
                                         <argument>build</argument>
                                         <argument>--build-arg</argument>
-                                        <argument>IMAGE_REGISTRY_PREFIX=${env.IMAGE_REGISTRY_PREFIX}</argument>
+                                        <argument>IMAGE_REGISTRY_PREFIX=${image.registry.prefix}</argument>
                                         <argument>-t</argument>
                                         <argument>statefun-remote-function:e2e</argument>
                                         <argument>.</argument>
@@ -267,6 +271,17 @@
                     </plugin>
                 </plugins>
             </build>
+        </profile>
+        <profile>
+            <id>image-registry-prefix-env</id>
+            <activation>
+                <property>
+                    <name>env.IMAGE_REGISTRY_PREFIX</name>
+                </property>
+            </activation>
+            <properties>
+                <image.registry.prefix>${env.IMAGE_REGISTRY_PREFIX}</image.registry.prefix>
+            </properties>
         </profile>
     </profiles>
 

--- a/statefun-e2e-tests/statefun-e2e-k8s-native/pom.xml
+++ b/statefun-e2e-tests/statefun-e2e-k8s-native/pom.xml
@@ -189,7 +189,10 @@
                                     </arguments>
                                 </configuration>
                             </execution>
-                            <!-- 3. Build remote function Docker image -->
+                            <!-- 3. Build remote function Docker image. IMAGE_REGISTRY_PREFIX is
+                                 forwarded so base images (alpine, eclipse-temurin) can resolve
+                                 through a registry proxy when docker.io is unreachable. Empty
+                                 default preserves upstream behavior. -->
                             <execution>
                                 <id>build-remote-function-image</id>
                                 <phase>pre-integration-test</phase>
@@ -201,6 +204,8 @@
                                     <workingDirectory>${project.basedir}/remote-function</workingDirectory>
                                     <arguments>
                                         <argument>build</argument>
+                                        <argument>--build-arg</argument>
+                                        <argument>IMAGE_REGISTRY_PREFIX=${env.IMAGE_REGISTRY_PREFIX}</argument>
                                         <argument>-t</argument>
                                         <argument>statefun-remote-function:e2e</argument>
                                         <argument>.</argument>

--- a/statefun-e2e-tests/statefun-e2e-k8s-native/pom.xml
+++ b/statefun-e2e-tests/statefun-e2e-k8s-native/pom.xml
@@ -23,9 +23,6 @@
         <slf4j.version>2.0.17</slf4j.version>
         <!-- CI can set this true to keep the cluster alive for log collection -->
         <skip.teardown>false</skip.teardown>
-        <!-- Optional registry prefix forwarded to docker build. Empty by default;
-             override via -Dimage.registry.prefix=... or by setting env
-             IMAGE_REGISTRY_PREFIX (resolved through the profile below). -->
         <image.registry.prefix></image.registry.prefix>
     </properties>
 
@@ -193,10 +190,7 @@
                                     </arguments>
                                 </configuration>
                             </execution>
-                            <!-- 3. Build remote function Docker image. IMAGE_REGISTRY_PREFIX is
-                                 forwarded so base images (alpine, eclipse-temurin) can resolve
-                                 through a registry proxy when docker.io is unreachable. Empty
-                                 default preserves upstream behavior. -->
+                            <!-- 3. Build remote function Docker image -->
                             <execution>
                                 <id>build-remote-function-image</id>
                                 <phase>pre-integration-test</phase>

--- a/statefun-e2e-tests/statefun-e2e-k8s-native/remote-function/src/main/java/org/apache/flink/statefun/e2e/k8s/KafkaCounterTtlFn.java
+++ b/statefun-e2e-tests/statefun-e2e-k8s-native/remote-function/src/main/java/org/apache/flink/statefun/e2e/k8s/KafkaCounterTtlFn.java
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package org.apache.flink.statefun.e2e.k8s;
+
+import java.time.Duration;
+import java.util.concurrent.CompletableFuture;
+import org.apache.flink.statefun.e2e.k8s.generated.E2EProtos.CounterCommand;
+import org.apache.flink.statefun.e2e.k8s.generated.E2EProtos.CounterResult;
+import org.apache.flink.statefun.sdk.java.Context;
+import org.apache.flink.statefun.sdk.java.StatefulFunction;
+import org.apache.flink.statefun.sdk.java.TypeName;
+import org.apache.flink.statefun.sdk.java.ValueSpec;
+import org.apache.flink.statefun.sdk.java.io.KafkaEgressMessage;
+import org.apache.flink.statefun.sdk.java.message.Message;
+
+/** Counter with short state TTL; used by the E2E suite to verify SDK-declared TTL is honored. */
+public final class KafkaCounterTtlFn implements StatefulFunction {
+
+  static final TypeName FN_TYPE = TypeName.typeNameOf("counter.kafka.ttl", "fn");
+  static final TypeName EGRESS_ID = TypeName.typeNameOf("counter", "kafka-ttl-results");
+  static final String RESULTS_TOPIC = "counter.results.ttl";
+
+  static final Duration STATE_TTL = Duration.ofSeconds(5);
+
+  static final ValueSpec<Long> TOTAL =
+      ValueSpec.named("total").thatExpireAfterWrite(STATE_TTL).withLongType();
+
+  @Override
+  public CompletableFuture<Void> apply(Context context, Message message) {
+    if (!message.is(KafkaCounterFn.COUNTER_COMMAND_TYPE)) {
+      return context.done();
+    }
+
+    CounterCommand cmd = message.as(KafkaCounterFn.COUNTER_COMMAND_TYPE);
+    long newTotal = context.storage().get(TOTAL).orElse(0L) + cmd.getDelta();
+    context.storage().set(TOTAL, newTotal);
+
+    CounterResult result =
+        CounterResult.newBuilder().setId(cmd.getId()).setTotal(newTotal).build();
+
+    context.send(
+        KafkaEgressMessage.forEgress(EGRESS_ID)
+            .withTopic(RESULTS_TOPIC)
+            .withUtf8Key(cmd.getId())
+            .withValue(result.toByteArray())
+            .build());
+
+    return context.done();
+  }
+}

--- a/statefun-e2e-tests/statefun-e2e-k8s-native/remote-function/src/main/java/org/apache/flink/statefun/e2e/k8s/KafkaCounterTtlFn.java
+++ b/statefun-e2e-tests/statefun-e2e-k8s-native/remote-function/src/main/java/org/apache/flink/statefun/e2e/k8s/KafkaCounterTtlFn.java
@@ -1,3 +1,4 @@
+// Copyright 2026 Kzmlabs
 // SPDX-License-Identifier: Apache-2.0
 
 package org.apache.flink.statefun.e2e.k8s;

--- a/statefun-e2e-tests/statefun-e2e-k8s-native/remote-function/src/main/java/org/apache/flink/statefun/e2e/k8s/RemoteFunctionServer.java
+++ b/statefun-e2e-tests/statefun-e2e-k8s-native/remote-function/src/main/java/org/apache/flink/statefun/e2e/k8s/RemoteFunctionServer.java
@@ -31,12 +31,19 @@ public class RemoteFunctionServer {
             .withSupplier(KinesisCounterFn::new)
             .build();
 
+    StatefulFunctionSpec kafkaCounterTtlSpec =
+        StatefulFunctionSpec.builder(KafkaCounterTtlFn.FN_TYPE)
+            .withValueSpec(KafkaCounterTtlFn.TOTAL)
+            .withSupplier(KafkaCounterTtlFn::new)
+            .build();
+
     StatefulFunctionSpec greeterSpec =
         StatefulFunctionSpec.builder(GreeterFn.FN_TYPE).withSupplier(GreeterFn::new).build();
 
     StatefulFunctions functions = new StatefulFunctions();
     functions.withStatefulFunction(kafkaCounterSpec);
     functions.withStatefulFunction(kinesisCounterSpec);
+    functions.withStatefulFunction(kafkaCounterTtlSpec);
     functions.withStatefulFunction(greeterSpec);
 
     RequestReplyHandler handler = functions.requestReplyHandler();

--- a/statefun-e2e-tests/statefun-e2e-k8s-native/scripts/setup-cluster.sh
+++ b/statefun-e2e-tests/statefun-e2e-k8s-native/scripts/setup-cluster.sh
@@ -24,6 +24,11 @@ S3_BUCKET=statefun-checkpoints
 
 IMAGE_REGISTRY_PREFIX="${IMAGE_REGISTRY_PREFIX:-}"
 
+# Opt-in TLS knobs for restricted networks. Defaults preserve upstream behavior
+# (strict TLS verification). Override on the env to relax for corp MITM proxies.
+LOCALSTACK_NPM_STRICT_SSL="${LOCALSTACK_NPM_STRICT_SSL:-true}"
+LOCALSTACK_NODE_TLS_REJECT="${LOCALSTACK_NODE_TLS_REJECT:-1}"
+
 BASEDIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null && pwd)"
 K8S_MANIFESTS="${BASEDIR}/../src/test/resources/k8s"
 
@@ -73,7 +78,13 @@ if kind get clusters 2>/dev/null | grep -q "^${CLUSTER_NAME}$"; then
 fi
 
 echo "=== Creating kind cluster: ${CLUSTER_NAME} ==="
-kind create cluster --name "${CLUSTER_NAME}" --wait 5m
+# Optional override of the kind node image — useful when docker.io is unreachable
+# and a registry proxy is required. Default: kind's baked-in image.
+KIND_IMAGE_FLAG=()
+if [[ -n "${KIND_NODE_IMAGE:-}" ]]; then
+  KIND_IMAGE_FLAG=(--image "${KIND_NODE_IMAGE}")
+fi
+kind create cluster --name "${CLUSTER_NAME}" --wait 5m "${KIND_IMAGE_FLAG[@]}"
 
 echo "=== Loading Docker images into kind ==="
 kind load docker-image flink-statefun:e2e            --name "${CLUSTER_NAME}"
@@ -103,6 +114,8 @@ kubectl apply -f "${K8S_MANIFESTS}/flink-rbac.yaml"
 sed -e "s|\${IMAGE_REGISTRY_PREFIX}|${IMAGE_REGISTRY_PREFIX}|g" \
     "${K8S_MANIFESTS}/kafka.yaml" | kubectl apply -f -
 sed -e "s|\${IMAGE_REGISTRY_PREFIX}|${IMAGE_REGISTRY_PREFIX}|g" \
+    -e "s|\${LOCALSTACK_NPM_STRICT_SSL}|${LOCALSTACK_NPM_STRICT_SSL}|g" \
+    -e "s|\${LOCALSTACK_NODE_TLS_REJECT}|${LOCALSTACK_NODE_TLS_REJECT}|g" \
     "${K8S_MANIFESTS}/localstack.yaml" | kubectl apply -f -
 kubectl apply -f "${K8S_MANIFESTS}/remote-function.yaml"
 kubectl apply -f "${K8S_MANIFESTS}/module-configmap.yaml"

--- a/statefun-e2e-tests/statefun-e2e-k8s-native/scripts/setup-cluster.sh
+++ b/statefun-e2e-tests/statefun-e2e-k8s-native/scripts/setup-cluster.sh
@@ -18,7 +18,7 @@ set -euo pipefail
 CLUSTER_NAME=${1:-statefun-e2e}
 NAMESPACE=statefun-e2e
 FLINK_OPERATOR_VERSION=1.11.0
-KAFKA_TOPICS=(counter.commands counter.results greeter.commands greeter.results)
+KAFKA_TOPICS=(counter.commands counter.results counter.commands.ttl counter.results.ttl greeter.commands greeter.results)
 KINESIS_STREAMS=(counter.commands counter.results)
 S3_BUCKET=statefun-checkpoints
 
@@ -126,6 +126,20 @@ done
 # --- Kinesis streams + S3 bucket on LocalStack ------------------------------
 
 LOCALSTACK_POD=$(kubectl get pod -n "${NAMESPACE}" -l app=localstack -o jsonpath='{.items[0].metadata.name}')
+
+# Pod readiness only proves the container is up; LocalStack providers can lag
+# behind by several seconds. Poll the kinesis provider specifically so the next
+# awslocal calls don't race the boot.
+echo "=== Waiting for LocalStack kinesis provider to respond ==="
+for i in $(seq 1 60); do
+  if MSYS_NO_PATHCONV=1 kubectl exec -n "${NAMESPACE}" "${LOCALSTACK_POD}" -- \
+      awslocal kinesis list-streams >/dev/null 2>&1; then
+    echo "  LocalStack kinesis is responding"
+    break
+  fi
+  [[ $i -eq 60 ]] && { echo "ERROR: LocalStack kinesis not responding within 120s"; exit 1; }
+  sleep 2
+done
 
 echo "=== Creating Kinesis streams ==="
 for stream in "${KINESIS_STREAMS[@]}"; do

--- a/statefun-e2e-tests/statefun-e2e-k8s-native/scripts/setup-cluster.sh
+++ b/statefun-e2e-tests/statefun-e2e-k8s-native/scripts/setup-cluster.sh
@@ -23,9 +23,6 @@ KINESIS_STREAMS=(counter.commands counter.results)
 S3_BUCKET=statefun-checkpoints
 
 IMAGE_REGISTRY_PREFIX="${IMAGE_REGISTRY_PREFIX:-}"
-
-# Opt-in TLS knobs for restricted networks. Defaults preserve upstream behavior
-# (strict TLS verification). Override on the env to relax for corp MITM proxies.
 LOCALSTACK_NPM_STRICT_SSL="${LOCALSTACK_NPM_STRICT_SSL:-true}"
 LOCALSTACK_NODE_TLS_REJECT="${LOCALSTACK_NODE_TLS_REJECT:-1}"
 
@@ -78,8 +75,6 @@ if kind get clusters 2>/dev/null | grep -q "^${CLUSTER_NAME}$"; then
 fi
 
 echo "=== Creating kind cluster: ${CLUSTER_NAME} ==="
-# Optional override of the kind node image — useful when docker.io is unreachable
-# and a registry proxy is required. Default: kind's baked-in image.
 KIND_IMAGE_FLAG=()
 if [[ -n "${KIND_NODE_IMAGE:-}" ]]; then
   KIND_IMAGE_FLAG=(--image "${KIND_NODE_IMAGE}")
@@ -140,9 +135,6 @@ done
 
 LOCALSTACK_POD=$(kubectl get pod -n "${NAMESPACE}" -l app=localstack -o jsonpath='{.items[0].metadata.name}')
 
-# Pod readiness only proves the container is up; LocalStack providers can lag
-# behind by several seconds. Poll the kinesis provider specifically so the next
-# awslocal calls don't race the boot.
 echo "=== Waiting for LocalStack kinesis provider to respond ==="
 for i in $(seq 1 60); do
   if MSYS_NO_PATHCONV=1 kubectl exec -n "${NAMESPACE}" "${LOCALSTACK_POD}" -- \

--- a/statefun-e2e-tests/statefun-e2e-k8s-native/src/test/java/org/apache/flink/statefun/e2e/k8s/StateFunK8sE2E.java
+++ b/statefun-e2e-tests/statefun-e2e-k8s-native/src/test/java/org/apache/flink/statefun/e2e/k8s/StateFunK8sE2E.java
@@ -58,14 +58,20 @@ class StateFunK8sE2E {
 
   private static final String COUNTER_COMMANDS_TOPIC = "counter.commands";
   private static final String COUNTER_RESULTS_TOPIC = "counter.results";
+  private static final String COUNTER_TTL_COMMANDS_TOPIC = "counter.commands.ttl";
+  private static final String COUNTER_TTL_RESULTS_TOPIC = "counter.results.ttl";
   private static final String GREETER_COMMANDS_TOPIC = "greeter.commands";
   private static final String GREETER_RESULTS_TOPIC = "greeter.results";
   private static final String CHECKPOINTS_BUCKET = "statefun-checkpoints";
+
+  private static final Duration STATE_TTL = Duration.ofSeconds(5);
+  private static final Duration TTL_EXPIRY_PAD = Duration.ofSeconds(7);
 
   private KubectlPortForward kafkaForward;
   private KubectlPortForward localStackForward;
   private KafkaProducer<String, byte[]> producer;
   private KafkaConsumer<String, byte[]> counterResultsConsumer;
+  private KafkaConsumer<String, byte[]> counterTtlResultsConsumer;
   private KafkaConsumer<String, byte[]> greeterResultsConsumer;
   private S3Client s3;
 
@@ -86,6 +92,8 @@ class StateFunK8sE2E {
     String runId = UUID.randomUUID().toString().substring(0, 8);
     counterResultsConsumer =
         createConsumer(bootstrap, "e2e-counter-" + runId, COUNTER_RESULTS_TOPIC);
+    counterTtlResultsConsumer =
+        createConsumer(bootstrap, "e2e-counter-ttl-" + runId, COUNTER_TTL_RESULTS_TOPIC);
     greeterResultsConsumer =
         createConsumer(bootstrap, "e2e-greeter-" + runId, GREETER_RESULTS_TOPIC);
 
@@ -154,6 +162,20 @@ class StateFunK8sE2E {
 
   @Test
   @Order(3)
+  void counterStateIsCleanedUpByTtl() throws Exception {
+    String counterId = "counter-ttl-" + UUID.randomUUID();
+
+    sendCounterCommand(COUNTER_TTL_COMMANDS_TOPIC, counterId, 5);
+    awaitCounterTotal(counterTtlResultsConsumer, counterId, 5L);
+
+    Thread.sleep(STATE_TTL.plus(TTL_EXPIRY_PAD).toMillis());
+
+    sendCounterCommand(COUNTER_TTL_COMMANDS_TOPIC, counterId, 3);
+    awaitCounterTotal(counterTtlResultsConsumer, counterId, 3L);
+  }
+
+  @Test
+  @Order(4)
   void checkpointsWrittenToS3() {
     await()
         .atMost(E2eContext.POLL_TIMEOUT)
@@ -172,10 +194,40 @@ class StateFunK8sE2E {
   void teardown() {
     if (producer != null) producer.close(Duration.ofSeconds(5));
     if (counterResultsConsumer != null) counterResultsConsumer.close(Duration.ofSeconds(5));
+    if (counterTtlResultsConsumer != null) counterTtlResultsConsumer.close(Duration.ofSeconds(5));
     if (greeterResultsConsumer != null) greeterResultsConsumer.close(Duration.ofSeconds(5));
     if (s3 != null) s3.close();
     if (kafkaForward != null) kafkaForward.close();
     if (localStackForward != null) localStackForward.close();
+  }
+
+  private void sendCounterCommand(String topic, String counterId, long delta) throws Exception {
+    CounterCommand cmd = CounterCommand.newBuilder().setId(counterId).setDelta(delta).build();
+    producer
+        .send(new ProducerRecord<>(topic, counterId, cmd.toByteArray()))
+        .get(10, TimeUnit.SECONDS);
+    producer.flush();
+    LOG.info("Sent CounterCommand(id={}, delta={}) to {}", counterId, delta, topic);
+  }
+
+  private static void awaitCounterTotal(
+      KafkaConsumer<String, byte[]> consumer, String counterId, long expectedTotal) {
+    await()
+        .atMost(E2eContext.POLL_TIMEOUT)
+        .pollInterval(E2eContext.POLL_INTERVAL)
+        .untilAsserted(
+            () -> {
+              List<CounterResult> results =
+                  StreamSupport.stream(consumer.poll(Duration.ofSeconds(1)).spliterator(), false)
+                      .map(ConsumerRecord::value)
+                      .map(StateFunK8sE2E::parseCounterResult)
+                      .filter(r -> counterId.equals(r.getId()))
+                      .collect(Collectors.toList());
+              assertThat(results)
+                  .as("counter result for id=%s", counterId)
+                  .extracting(CounterResult::getTotal)
+                  .contains(expectedTotal);
+            });
   }
 
   private static CounterResult parseCounterResult(byte[] bytes) {

--- a/statefun-e2e-tests/statefun-e2e-k8s-native/src/test/java/org/apache/flink/statefun/e2e/k8s/StateFunK8sE2E.java
+++ b/statefun-e2e-tests/statefun-e2e-k8s-native/src/test/java/org/apache/flink/statefun/e2e/k8s/StateFunK8sE2E.java
@@ -171,7 +171,27 @@ class StateFunK8sE2E {
     Thread.sleep(STATE_TTL.plus(TTL_EXPIRY_PAD).toMillis());
 
     sendCounterCommand(COUNTER_TTL_COMMANDS_TOPIC, counterId, 3);
-    awaitCounterTotal(counterTtlResultsConsumer, counterId, 3L);
+    // total=8 would mean state was not wiped (prior 5 + new 3); assert explicitly to make a
+    // TTL regression surface as "found forbidden [8]" rather than just "missing [3]".
+    await()
+        .atMost(E2eContext.POLL_TIMEOUT)
+        .pollInterval(E2eContext.POLL_INTERVAL)
+        .untilAsserted(
+            () -> {
+              List<CounterResult> results =
+                  StreamSupport.stream(
+                          counterTtlResultsConsumer.poll(Duration.ofSeconds(1)).spliterator(),
+                          false)
+                      .map(ConsumerRecord::value)
+                      .map(StateFunK8sE2E::parseCounterResult)
+                      .filter(r -> counterId.equals(r.getId()))
+                      .collect(Collectors.toList());
+              assertThat(results)
+                  .as("counter result for id=%s after TTL expiry", counterId)
+                  .extracting(CounterResult::getTotal)
+                  .contains(3L)
+                  .doesNotContain(8L);
+            });
   }
 
   @Test

--- a/statefun-e2e-tests/statefun-e2e-k8s-native/src/test/resources/k8s/localstack.yaml
+++ b/statefun-e2e-tests/statefun-e2e-k8s-native/src/test/resources/k8s/localstack.yaml
@@ -28,6 +28,14 @@ spec:
               value: us-east-1
             - name: DEBUG
               value: "0"
+            # Opt-in TLS knobs for restricted networks (e.g. corp MITM proxy).
+            # LocalStack lazily downloads kinesis-local from npmjs.org at first call;
+            # set LOCALSTACK_NPM_STRICT_SSL=false to tolerate untrusted CAs.
+            # Defaults preserve secure verification.
+            - name: NPM_CONFIG_STRICT_SSL
+              value: "${LOCALSTACK_NPM_STRICT_SSL}"
+            - name: NODE_TLS_REJECT_UNAUTHORIZED
+              value: "${LOCALSTACK_NODE_TLS_REJECT}"
           readinessProbe:
             httpGet:
               path: /_localstack/health

--- a/statefun-e2e-tests/statefun-e2e-k8s-native/src/test/resources/k8s/localstack.yaml
+++ b/statefun-e2e-tests/statefun-e2e-k8s-native/src/test/resources/k8s/localstack.yaml
@@ -28,10 +28,6 @@ spec:
               value: us-east-1
             - name: DEBUG
               value: "0"
-            # Opt-in TLS knobs for restricted networks (e.g. corp MITM proxy).
-            # LocalStack lazily downloads kinesis-local from npmjs.org at first call;
-            # set LOCALSTACK_NPM_STRICT_SSL=false to tolerate untrusted CAs.
-            # Defaults preserve secure verification.
             - name: NPM_CONFIG_STRICT_SSL
               value: "${LOCALSTACK_NPM_STRICT_SSL}"
             - name: NODE_TLS_REJECT_UNAUTHORIZED

--- a/statefun-e2e-tests/statefun-e2e-k8s-native/src/test/resources/k8s/module-configmap.yaml
+++ b/statefun-e2e-tests/statefun-e2e-k8s-native/src/test/resources/k8s/module-configmap.yaml
@@ -31,6 +31,16 @@ data:
     ---
     kind: io.statefun.endpoints.v2/http
     spec:
+      functions: counter.kafka.ttl/*
+      urlPathTemplate: http://remote-function.statefun-e2e:8080/statefun
+      transport:
+        type: io.statefun.transports.v1/async
+        timeouts:
+          call: 30sec
+          connect: 10sec
+    ---
+    kind: io.statefun.endpoints.v2/http
+    spec:
       functions: greeter/*
       urlPathTemplate: http://remote-function.statefun-e2e:8080/statefun
       transport:
@@ -68,6 +78,26 @@ data:
     kind: io.statefun.kafka.v1/egress
     spec:
       id: counter/kafka-results
+      address: kafka.statefun-e2e:9092
+      deliverySemantic:
+        type: at-least-once
+    ---
+    kind: io.statefun.kafka.v1/ingress
+    spec:
+      id: counter/kafka-ttl-in
+      address: kafka.statefun-e2e:9092
+      consumerGroupId: statefun-e2e-counter-kafka-ttl
+      startupPosition:
+        type: earliest
+      topics:
+        - topic: counter.commands.ttl
+          valueType: io.github.kzmlabs.statefun.e2e/CounterCommand
+          targets:
+            - counter.kafka.ttl/fn
+    ---
+    kind: io.statefun.kafka.v1/egress
+    spec:
+      id: counter/kafka-ttl-results
       address: kafka.statefun-e2e:9092
       deliverySemantic:
         type: at-least-once


### PR DESCRIPTION
## Summary

Adds end-to-end coverage that state TTL declared on the SDK side (`ValueSpec.thatExpireAfterWrite(...)`) is honored by the Flink runtime: per-key state is wiped after the configured window. This validates the SDK → request-reply → runtime contract that unit tests can't reach.

Also hardens the LocalStack startup wait — pod-readiness can fire while individual providers (kinesis) are still booting, which surfaces as a `Read timeout` deep in `awslocal kinesis create-stream`.

## Changes

- **New function** `KafkaCounterTtlFn` — same shape as `KafkaCounterFn` but with `ValueSpec.named("total").thatExpireAfterWrite(5s).withLongType()`. Emits to a separate egress so the existing counter test stays isolated.
- **`RemoteFunctionServer`** — registers the new spec.
- **`module-configmap.yaml`** — adds endpoint `counter.kafka.ttl/*`, Kafka ingress on `counter.commands.ttl`, egress on `counter/kafka-ttl-results`.
- **`setup-cluster.sh`**:
  - Two new topics in `KAFKA_TOPICS`.
  - **Bug fix:** wait for LocalStack's kinesis provider to actually respond (poll `awslocal kinesis list-streams`) before issuing `create-stream`. Container readiness ≠ application readiness.
- **`StateFunK8sE2E`** — new `@Order(3) counterStateIsCleanedUpByTtl()` and small `sendCounterCommand` / `awaitCounterTotal` helpers. `checkpointsWrittenToS3` bumped to `@Order(4)`.

## Test logic

```
send delta=5 to counter.commands.ttl   →  expect total=5 on counter.results.ttl
sleep 5s (TTL) + 7s pad                →  RocksDB TTL fires; expired state reads empty
send delta=3 to counter.commands.ttl   →  expect total=3 (NOT 8) → state was wiped
```

The assertion uses `contains(expectedTotal)` because the consumer may still see the earlier `5` buffered when polling for the second result — what matters is that `3` (not `8`) shows up.

`AFTER_WRITE` is used instead of `AFTER_CALL` so the timer is only restarted by explicit state writes, keeping the test independent of any incidental function invocations.

## Verified

Full k8s-native E2E suite on a kind-provisioned cluster — `Tests run: 5, Failures: 0, Errors: 0, Skipped: 0`:
- `StateFunK8sE2E`: 4/4 (incl. new `counterStateIsCleanedUpByTtl`)
- `StateFunKinesisE2E`: 1/1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added TTL-enabled counter flow with Kafka-based command/result paths and TTL-aware HTTP routing.
* **Tests**
  * Extended end-to-end tests to validate TTL-driven state expiration, event results, and cleanup behavior.
* **Chores**
  * Cluster setup creates TTL topics, adds LocalStack TLS flags, supports optional node image, and waits for service readiness.
* **Documentation**
  * Build accepts an image registry build-arg for Docker image resolution.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kzmlabs/flink-statefun/pull/223?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


## Follow-up: opt-in knobs for restricted networks

Second commit. **No behavior change for upstream / public CI** — all knobs default to the existing strict/secure values. Dev boxes behind a corp MITM proxy or with restricted `docker.io` access can opt in via env vars:

| Env var | Default | What it does |
|---|---|---|
| `LOCALSTACK_NPM_STRICT_SSL` | `true` | Sets `NPM_CONFIG_STRICT_SSL` inside LocalStack. Set to `false` if the npm fetch of `kinesis-local` fails on `UNABLE_TO_GET_ISSUER_CERT_LOCALLY`. |
| `LOCALSTACK_NODE_TLS_REJECT` | `1` | Sets `NODE_TLS_REJECT_UNAUTHORIZED`. Companion to the above for the embedded Node runtime. |
| `KIND_NODE_IMAGE` | _(unset → kind default)_ | Override the kind node image when docker.io blocks the pull, e.g. `KIND_NODE_IMAGE=my-proxy.example.com/kindest/node:v1.32.x@sha256:...`. |
| `IMAGE_REGISTRY_PREFIX` | _(empty)_ | Already used for kafka/localstack manifests; now also forwarded as a `--build-arg` to the remote-function Docker build so its base images (`alpine`, `eclipse-temurin`) resolve through the same proxy. Default empty preserves direct docker.io pulls. |

Mechanism follows the existing `IMAGE_REGISTRY_PREFIX` pattern: `setup-cluster.sh` substitutes placeholders into the YAML at apply time. No new dependencies; no changes to default upstream behavior.
