### PR TITLE
chore(dependabot): persistent ignore for slf4j-api/log4j12 major bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -35,11 +35,16 @@ updates:
     ignore:
       # slf4j-log4j12 was renamed to slf4j-reload4j in slf4j 2.x and
       # pulls slf4j-api 2.x transitively. Flink 2.2.0 still drags slf4j-api
-      # 1.7.36, so the bump triggers Maven enforcer's DependencyConvergence.
-      # slf4j 2.x migration is tracked as a coordinated effort, not a
-      # Dependabot one-shot. See PR #187 for the failure mode.
+      # 1.7.36, so the bump trips Maven enforcer's DependencyConvergence.
+      # The shared <slf4j-log4j12.version> property pins BOTH slf4j-api
+      # and slf4j-log4j12, so both must be ignored — Dependabot opens the
+      # PR keyed on whichever artifact it sees first. See PR #221 for the
+      # failure mode; slf4j 2.x migration is tracked as a coordinated
+      # change gated on upstream Flink.
       - dependency-name: "org.slf4j:slf4j-log4j12"
-        versions: [">=2.0"]
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "org.slf4j:slf4j-api"
+        update-types: ["version-update:semver-major"]
 
   # Docs site requirements (MkDocs Material + plugins).
   - package-ecosystem: pip


### PR DESCRIPTION
## Summary

- Existing ignore (`versions: [">=2.0"]`) was bypassed by Dependabot — the shared `<slf4j-log4j12.version>` property pins **both** `slf4j-api` and `slf4j-log4j12`, and the PR is keyed on whichever artifact is un-ignored first.
- Switches to `update-types: ["version-update:semver-major"]` and adds `slf4j-api` to the ignore list.
- Comment updated to record the failure mode (PR #221) and the gating constraint (Flink 2.2.0 still ships slf4j-api 1.7.36).

## Why now

PR #221 (`slf4j-log4j12.version 1.7.36 → 2.0.18`) failed the Maven enforcer DependencyConvergence rule:

```
+-flink-core:2.2.0 → flink-core-api → slf4j-api:1.7.36
+-flink-core:2.2.0 → flink-annotations → slf4j-api:1.7.36
+-slf4j-reload4j:2.0.18 → slf4j-api:2.0.18
```

Two converging versions of `slf4j-api` are unavoidable while Flink itself is on 1.7.x. Without this fix, Dependabot will keep re-proposing the same broken bump weekly.

## Test plan

- [ ] CI passes (no Java code changes, but want to confirm `actions/dependabot-validate` accepts the new schema)
- [ ] Verify next weekly Dependabot run does not re-open #221's bump