### PR TITLE
test(k8s-e2e): pre-load infra images + bound kinesis readiness poll

### DIFF
--- a/statefun-e2e-tests/statefun-e2e-k8s-native/scripts/setup-cluster.sh
+++ b/statefun-e2e-tests/statefun-e2e-k8s-native/scripts/setup-cluster.sh
@@ -85,6 +85,28 @@ echo "=== Loading Docker images into kind ==="
 kind load docker-image flink-statefun:e2e            --name "${CLUSTER_NAME}"
 kind load docker-image statefun-remote-function:e2e  --name "${CLUSTER_NAME}"
 
+# Pre-load infra images so kubelet doesn't pull on cold cache and overrun the
+# 180s readiness wait. Explicit --platform keeps the docker-save tarball
+# single-platform; kind load uses `ctr images import --all-platforms` and
+# otherwise fails on multi-arch manifest lists.
+echo "=== Pre-loading infra images into kind ==="
+# Match the kind node's actual architecture (which can differ from the host's
+# when KIND_NODE_IMAGE pins a specific platform), fall back to host uname.
+NODE_ARCH="$(docker inspect "${CLUSTER_NAME}-control-plane" --format '{{.Architecture}}' 2>/dev/null || uname -m)"
+case "${NODE_ARCH}" in
+  amd64|x86_64)   PRELOAD_PLATFORM="linux/amd64" ;;
+  arm64|aarch64)  PRELOAD_PLATFORM="linux/arm64" ;;
+  *)              PRELOAD_PLATFORM="linux/amd64" ;;
+esac
+PRELOAD_IMAGES=(
+  "${IMAGE_REGISTRY_PREFIX}apache/kafka:3.9.0"
+  "${IMAGE_REGISTRY_PREFIX}localstack/localstack:4.1"
+)
+for img in "${PRELOAD_IMAGES[@]}"; do
+  docker pull --platform "${PRELOAD_PLATFORM}" "${img}"
+  kind load docker-image "${img}" --name "${CLUSTER_NAME}"
+done
+
 # --- cert-manager + Flink Operator ------------------------------------------
 
 echo "=== Installing cert-manager ==="
@@ -136,13 +158,17 @@ done
 LOCALSTACK_POD=$(kubectl get pod -n "${NAMESPACE}" -l app=localstack -o jsonpath='{.items[0].metadata.name}')
 
 echo "=== Waiting for LocalStack kinesis provider to respond ==="
+# Bound each invocation: LocalStack's lazy `kinesis-local` install can stall a
+# single `awslocal` call ~70s on networks with proxy/cert issues, making the
+# nominal 60x2s loop budget meaningless. 10s gives slow-but-not-hung installs
+# a fair first chance while keeping the worst case finite (~10 min).
 for i in $(seq 1 60); do
   if MSYS_NO_PATHCONV=1 kubectl exec -n "${NAMESPACE}" "${LOCALSTACK_POD}" -- \
-      awslocal kinesis list-streams >/dev/null 2>&1; then
+      timeout 10 awslocal kinesis list-streams >/dev/null 2>&1; then
     echo "  LocalStack kinesis is responding"
     break
   fi
-  [[ $i -eq 60 ]] && { echo "ERROR: LocalStack kinesis not responding within 120s"; exit 1; }
+  [[ $i -eq 60 ]] && { echo "ERROR: LocalStack kinesis not responding"; exit 1; }
   sleep 2
 done
 


### PR DESCRIPTION
## What

Two small robustness fixes to `statefun-e2e-tests/statefun-e2e-k8s-native/scripts/setup-cluster.sh` surfaced while running the K8s E2E suite locally on a corp network behind a proxy. Both default to no behavior change on a healthy / unrestricted network.

### 1) Pre-load `apache/kafka:3.9.0` and `localstack/localstack:4.1` into the kind node

Cold containerd cache + large image pulls (kafka is ~1.34 GB) were overrunning the 180s `kubectl wait` readiness window. Pre-loading these from host docker via `kind load docker-image` moves the pull out of the readiness critical path. Subsequent cluster re-creates reuse the host-level cache and finish in seconds.

`docker pull --platform linux/<arch>` is used so `docker save` produces a single-platform tarball; without that, `kind load docker-image` (which under the hood runs `ctr images import --all-platforms`) fails on multi-arch manifest lists with `ctr: content digest sha256:...: not found`. Host arch is auto-detected via `uname -m`, so the same script works on Linux amd64 CI and arm64 macOS dev boxes.

### 2) Bound the kinesis readiness poll with `timeout 10`

The current loop's nominal "60 iterations × 2s = 120s" budget assumes each `awslocal kinesis list-streams` invocation returns quickly. But LocalStack lazy-installs `kinesis-local` on first request, and on networks where the install hangs (corp proxy with a self-signed CA that breaks npm cert validation), a single invocation can block ~70s — making the loop's worst case effectively unbounded.

`timeout 10` runs inside the LocalStack pod (Linux container, has `timeout` from coreutils), so it's host-OS-agnostic. With this wrap the loop is actually bounded at ~10 min worst case.

## Verified

Reproduced both failure modes locally (corp network, Zscaler MITM + Harbor proxy mirror), confirmed both fixes make the E2E suite pass green:

- `StateFunK8sE2E`: 4 tests, 0 failures (incl. `counterStateIsCleanedUpByTtl` from #223)
- `StateFunKinesisE2E`: 1 test, 0 failures

## Notes

- No new env vars added; the existing `LOCALSTACK_NPM_STRICT_SSL` / `LOCALSTACK_NODE_TLS_REJECT` knobs from #223 are still what users on restricted networks reach for first. These fixes are robustness on top of those.
- The pre-load adds two `docker pull && kind load` rounds (each ~5s when host cache is warm) to every cluster bring-up. Net cost is offset by elimination of the cold-pull inside kubelet during the readiness wait.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced cluster provisioning script with improved Kafka topic management and LocalStack TLS configuration support.
  * Added capability to override container image during cluster creation via environment variable.
  * Implemented infrastructure image pre-loading with optimized container import strategy based on system architecture.
  * Added readiness verification for Kinesis service with retry logic before stream creation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kzmlabs/flink-statefun/pull/231?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->