### PR TITLE
Upgrade Flink Kubernetes Operator 1.11 → 1.15 (flinkVersion v2_2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to **StateFun Actors by Kzmlabs** are documented in this fil
 
 > **Reading guide:** "KZM-x.y" releases are this fork's versions on Flink 2.x. Apache StateFun's last release was [3.4.0](https://github.com/apache/flink-statefun/releases/tag/release-3.4.0) (October 2024) on Flink 1.16. See [docs/upstream-vs-kzm.md](https://kzmlabs.github.io/flink-statefun/upstream-vs-kzm/) for the full migration matrix.
 
+## [Unreleased]
+
+### Changed
+
+- **Flink Kubernetes Operator 1.11 → 1.15** — the K8s E2E release gate, the
+  deployment guide, and the runner example now target Operator **1.15.0**,
+  which adds Flink 2.2 support. Both `FlinkDeployment` CRs move from
+  `flinkVersion: v2_0` to **`v2_2`**, matching the Flink 2.2.0 runtime image —
+  previously pinned to `v2_0` only because Operator 1.11 capped there. The
+  Helm install, cert-manager dependency, and the conservatively-audited
+  `flinkConfiguration` keys are otherwise unchanged; the Operator pod stays on
+  its Log4j2 default (JSON Operator logs would require a custom image, so the
+  guide documents that as opt-in rather than baking it in).
+
 ## [3.4.0-KZM-3.3] - 2026-05-11
 
 Patch release on the KZM-3.x line. Hardens the supply-chain security signal

--- a/docs/guides/k8s-deployment.md
+++ b/docs/guides/k8s-deployment.md
@@ -24,7 +24,7 @@ flowchart LR
 
 - **Kubernetes 1.27+**
 - **Cert-manager** (Operator dependency)
-- **Flink Kubernetes Operator 1.11+**
+- **Flink Kubernetes Operator 1.15+** (adds Flink 2.2 support)
 - An **S3-compatible bucket** for checkpoints (S3, GCS via interop, MinIO, Ceph)
 - IAM Roles for Service Accounts (IRSA) on EKS for credential-free S3 / Kinesis access (recommended)
 
@@ -38,7 +38,7 @@ metadata:
   namespace: my-app
 spec:
   image: ghcr.io/kzmlabs/flink-statefun:3.4.0-KZM-3.3
-  flinkVersion: v2_0
+  flinkVersion: v2_2
   flinkConfiguration:
     state.backend.type: rocksdb
     state.checkpoints.dir: s3://my-bucket/checkpoints
@@ -108,6 +108,14 @@ Flink 2.x renamed several configuration keys. The differences most likely to bit
 !!! warning "Use the fully-qualified keys"
 
     The short forms are no longer recognized in Flink 2.x. The Operator will silently use defaults if you keep the old keys.
+
+## Logging
+
+JobManager and TaskManager emit **JSON logs** out of the box — the runtime image bundles the Logback JSON encoder, driven by the `spec.logConfiguration` (`logback-console.xml`) on the `FlinkDeployment`. No image changes needed.
+
+!!! note "Operator pod logs"
+
+    The **Operator pod** itself logs plain text via Log4j2 (its default). Operator 1.15 can run on Logback, but its base image bundles Logback 1.2.x with no JSON encoder, so JSON Operator logs would require a custom Operator image bundling `logstash-logback-encoder`. The Operator is infra, not application output, so this is rarely worth the maintenance — leave it on the Log4j2 default unless your log pipeline requires JSON from every pod.
 
 ## Tuning
 

--- a/statefun-e2e-tests/statefun-e2e-k8s-native/scripts/setup-cluster.sh
+++ b/statefun-e2e-tests/statefun-e2e-k8s-native/scripts/setup-cluster.sh
@@ -17,7 +17,7 @@ set -euo pipefail
 
 CLUSTER_NAME=${1:-statefun-e2e}
 NAMESPACE=statefun-e2e
-FLINK_OPERATOR_VERSION=1.11.0
+FLINK_OPERATOR_VERSION=1.15.0
 KAFKA_TOPICS=(counter.commands counter.results counter.commands.ttl counter.results.ttl greeter.commands greeter.results)
 KINESIS_STREAMS=(counter.commands counter.results)
 S3_BUCKET=statefun-checkpoints
@@ -116,11 +116,17 @@ for dep in cert-manager cert-manager-webhook cert-manager-cainjector; do
 done
 
 echo "=== Installing Flink Kubernetes Operator ${FLINK_OPERATOR_VERSION} ==="
-helm repo add flink-operator-repo \
-  "https://archive.apache.org/dist/flink/flink-kubernetes-operator-${FLINK_OPERATOR_VERSION}/" || true
-helm repo update
+# --force-update overwrites any stale version-specific URL left by a previous run
+# (the repo URL embeds the operator version, so a plain `repo add` on a machine
+# that already has the repo would silently keep the old version's chart).
+helm repo add --force-update flink-operator-repo \
+  "https://archive.apache.org/dist/flink/flink-kubernetes-operator-${FLINK_OPERATOR_VERSION}/"
+helm repo update flink-operator-repo
+# Pin --version so a chart/URL skew fails loudly instead of installing a
+# mismatched chart against the requested image.tag.
 helm install flink-kubernetes-operator flink-operator-repo/flink-kubernetes-operator \
   --namespace flink-operator --create-namespace --wait --timeout 5m \
+  --version "${FLINK_OPERATOR_VERSION}" \
   --set image.tag="${FLINK_OPERATOR_VERSION}"
 
 # --- In-namespace infra -----------------------------------------------------

--- a/statefun-e2e-tests/statefun-e2e-k8s-native/src/test/resources/k8s/flink-deployment.yaml
+++ b/statefun-e2e-tests/statefun-e2e-k8s-native/src/test/resources/k8s/flink-deployment.yaml
@@ -9,7 +9,7 @@ metadata:
 spec:
   image: flink-statefun:e2e
   imagePullPolicy: Never
-  flinkVersion: "v2_0"
+  flinkVersion: "v2_2"
   serviceAccount: flink
   flinkConfiguration:
     # --- Classloader ---

--- a/statefun-flink-runner/example-flinkdeployment.yaml
+++ b/statefun-flink-runner/example-flinkdeployment.yaml
@@ -10,8 +10,8 @@ metadata:
   name: statefun-app
 spec:
   image: ghcr.io/kzmlabs/flink-statefun:3.4.0-KZM-2.0-RC5-k8s
-  # Flink K8s Operator 1.11 only supports up to v2_0 (not v2_2)
-  flinkVersion: "v2_0"
+  # Requires Flink K8s Operator 1.15+ (adds Flink 2.2 support); matches the 2.2.x runtime image
+  flinkVersion: "v2_2"
   flinkConfiguration:
     taskmanager.numberOfTaskSlots: "1"
     state.backend.type: hashmap


### PR DESCRIPTION
## What

Upgrades the Flink Kubernetes Operator from **1.11.0 → 1.15.0** and moves both `FlinkDeployment` CRs from `flinkVersion: v2_0` to **`v2_2`**, matching the Flink 2.2.0 runtime image.

Operator 1.11 capped `flinkVersion` at `v2_0`; 1.15 adds Flink 2.2 support, so the long-standing `v2_0` workaround can finally go.

## Changes

- **`setup-cluster.sh`** — operator `1.11.0 → 1.15.0`; hardened Helm repo handling (see below).
- **`flink-deployment.yaml`, `example-flinkdeployment.yaml`** — `flinkVersion: v2_2`.
- **`docs/guides/k8s-deployment.md`** — Operator 1.15+ prerequisite, `v2_2`, and a Logging section.
- **`CHANGELOG.md`** — Unreleased entry.

## Config audit (conservative)

`flinkVersion` drives the operator's reconciler semantics, not runtime config parsing — the `flinkConfiguration` keys already run against the 2.2.0 runtime today. The audit found nothing provably removed/renamed on Flink 2.2, so all keys are retained.

## Operator logging

Considered switching the operator pod to Logback for JSON-log consistency, but its image ships Logback 1.2.x with no JSON encoder — JSON would require a custom operator image. Left on the Log4j2 default and documented as opt-in. JM/TM still emit JSON via the CR `logConfiguration` (unchanged).

## Robustness fix found during validation

A stale persisted Helm repo (URL embeds the operator version) made `helm repo add … || true` silently keep the old `1.11.0` chart while `--set image.tag=1.15.0` swapped only the image. The 1.15 binary then 403'd on the new `FlinkBlueGreenDeployment` CRD/RBAC the old chart never created → operator crashloop. Fixed with `helm repo add --force-update` + a pinned `helm install --version` (skew now fails loudly). CI's fresh runners never hit this; local-first validation caught it.

## Validation

Full local K8s E2E green on operator 1.15.0 + `v2_2`:
- `FlinkDeployment` READY; operator `2/2 Running`, chart `1.15.0 deployed`, `flinkbluegreendeployments` CRD present.
- `StateFunK8sE2E` 3/3, `StateFunKinesisE2E` 1/1 — **4/4, 0 failures**.

## Note

Stacked on `feature/logback-json-default`; base is that branch, so the diff is scoped to the operator migration. Retarget to `release` once the logback PR merges.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Kubernetes deployment guides to reflect Flink Kubernetes Operator 1.15+ requirements.
  * Added logging configuration documentation for JobManager and TaskManager.

* **Chores**
  * Updated example and test configurations to support Flink 2.2 runtime.
  * Updated test infrastructure to provision Flink Kubernetes Operator 1.15.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->