### PR TITLE
fix(security): pin netty 4.1.135 + jackson 2.18.8, repin base image to Flink 2.2.1 (#247)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -122,6 +122,10 @@
         <scala.version>2.12.7</scala.version>
         <lz4-java.version>1.8.1</lz4-java.version>
         <flink-shaded-jackson.version>2.18.2-20.0</flink-shaded-jackson.version>
+        <!-- Security: pin transitive io.netty (via awssdk netty-nio-client) and
+             plain com.fasterxml.jackson (via aws-sdk) to patched versions. -->
+        <netty.version>4.1.135.Final</netty.version>
+        <jackson.version>2.18.8</jackson.version>
         <slf4j-log4j12.version>1.7.36</slf4j-log4j12.version>
         <test.unit.pattern>**/*Test.*</test.unit.pattern>
 
@@ -169,6 +173,24 @@
                 <groupId>software.amazon.awssdk</groupId>
                 <artifactId>bom</artifactId>
                 <version>${awssdk.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <!-- BOM: Netty — pins io.netty:* pulled transitively by awssdk
+                 netty-nio-client to a version without the 4.1.132 CVEs. -->
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-bom</artifactId>
+                <version>${netty.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <!-- BOM: Jackson — pins plain com.fasterxml.jackson:* pulled
+                 transitively by the aws-sdk to a patched 2.18.x. -->
+            <dependency>
+                <groupId>com.fasterxml.jackson</groupId>
+                <artifactId>jackson-bom</artifactId>
+                <version>${jackson.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/statefun-docker/src/main/docker/Dockerfile
+++ b/statefun-docker/src/main/docker/Dockerfile
@@ -4,7 +4,7 @@
 # syntax=docker/dockerfile:1.7
 
 ARG IMAGE_REGISTRY_PREFIX=
-ARG FLINK_BASE_IMAGE=${IMAGE_REGISTRY_PREFIX}apache/flink:2.2.0-java21@sha256:923326dc76dd86e3ddcb08e2cd5fc71d8023a451cdeea324cb573e323a54ba64
+ARG FLINK_BASE_IMAGE=${IMAGE_REGISTRY_PREFIX}apache/flink:2.2.1-java21@sha256:256a3dde6a0d613fff973f3d86b04c22bbeddabee4acb3376f24b6ac1f1d6a58
 FROM ${FLINK_BASE_IMAGE}
 
 # Logging library versions (downloaded from Maven Central)


### PR DESCRIPTION
Low-risk portion of the #247 CVE response. Patch-level, binary-compatible bumps plus a base-image repin — no StateFun API surface touched.

## Root-caused, not guessed
Unzipped the shipped jars: the vulnerable classes ship from **our `statefun-flink-distribution` uber jar** (into Flink's `/lib`), transitively — not from Flink's runtime libs.

| CVE group | Real source (verified) | Fix |
|---|---|---|
| io.netty 4.1.132 (6 CVEs) | `awssdk netty-nio-client` → `io.netty:*` in the fat jar | import `io.netty:netty-bom` **4.1.135.Final** |
| jackson-databind 2.18.2 (CVE-2026-54512/54513) | plain `com.fasterxml.jackson:*` from the aws-sdk | import `jackson-bom` **2.18.8** (patch bump within 2.18) |
| flink-table-planner CVE-2026-35194 + base openssl CVE-2026-45447 | base image | repin `FROM` → `apache/flink:2.2.1-java21@sha256:256a3dde…` (table jars already stripped at build; fresh OS packages) |

## Verification
`dependency:tree` for `statefun-flink-distribution` resolves `jackson-databind:2.18.8` and all `io.netty:*:4.1.135.Final`. Full local K8s E2E gate (Kafka + Kinesis) run on the cumulative branch.

Refs #247

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated security-sensitive transitive dependencies to patched Netty and Jackson versions.
  * Upgraded the container runtime to Apache Flink 2.2.1 for improved stability and security.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->