### PR TITLE
fix(security): bump Flink 2.2.1 + flink-shaded-jackson 2.20.1-21.0 (#247)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -18,7 +18,7 @@ body:
     id: flink
     attributes:
       label: Flink version
-      placeholder: "2.2.0"
+      placeholder: "2.2.1"
     validations:
       required: true
   - type: input

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -34,7 +34,7 @@ updates:
     open-pull-requests-limit: 10
     ignore:
       # slf4j-log4j12 was renamed to slf4j-reload4j in slf4j 2.x and
-      # pulls slf4j-api 2.x transitively. Flink 2.2.0 still drags slf4j-api
+      # pulls slf4j-api 2.x transitively. Flink 2.2.1 still drags slf4j-api
       # 1.7.36, so the bump trips Maven enforcer's DependencyConvergence.
       # The shared <slf4j-log4j12.version> property pins BOTH slf4j-api
       # and slf4j-log4j12, so both must be ignored — Dependabot opens the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,22 @@ All notable changes to **StateFun Actors by Kzmlabs** are documented in this fil
   its Log4j2 default (JSON Operator logs would require a custom image, so the
   guide documents that as opt-in rather than baking it in).
 
+### Security
+
+- **Resolved the 12 High CVEs reported by a Trivy scan of the release-branch
+  image ([#247])**:
+  - **io.netty** (6 CVEs) — the fat `statefun-flink-distribution` jar pulled
+    `io.netty:*` transitively via `awssdk netty-nio-client`. Imported
+    `io.netty:netty-bom` **4.1.135.Final** to force the patched line.
+  - **jackson-databind** (CVE-2026-54512 / CVE-2026-54513) — the plain
+    `com.fasterxml.jackson:*` copy (also from the aws-sdk) is pinned via
+    `jackson-bom` **2.18.8**; `flink-shaded-jackson` moves **2.18.2-20.0 →
+    2.20.1-21.0** to clear the relocated copy.
+  - **flink-table-planner** (CVE-2026-35194) and base-image **openssl**
+    (CVE-2026-45447) — bumped **Flink 2.2.0 → 2.2.1** and repinned the
+    `statefun-docker` base image to `apache/flink:2.2.1-java21` (fresh OS
+    packages; table jars are already stripped at build time).
+
 ## [3.4.0-KZM-3.3] - 2026-05-11
 
 Patch release on the KZM-3.x line. Hardens the supply-chain security signal
@@ -294,6 +310,7 @@ First stable release of the KZM-2.0 line, promoting RC7 after successful Maven C
 - Add Docker image publishing to GitHub Container Registry
 - Add release setup guide and release script
 
+[#247]: https://github.com/kzmlabs/flink-statefun/issues/247
 [3.4.0-KZM-3.1]: https://github.com/kzmlabs/flink-statefun/releases/tag/v3.4.0-KZM-3.1
 [3.4.0-KZM-3.0]: https://github.com/kzmlabs/flink-statefun/releases/tag/v3.4.0-KZM-3.0
 [3.4.0-KZM-3.0-RC1]: https://github.com/kzmlabs/flink-statefun/releases/tag/v3.4.0-KZM-3.0-RC1

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing to Kzmlabs Flink StateFun
 
-Thanks for your interest in contributing! This project is an actively maintained continuation of the Stateful Functions framework, updated for Flink 2.2.0 and Java 21.
+Thanks for your interest in contributing! This project is an actively maintained continuation of the Stateful Functions framework, updated for Flink 2.2.1 and Java 21.
 
 ## Ways to Contribute
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Apache Stateful Functions stopped releasing in October 2024 at 3.4.0, locked to 
 
 | | Apache StateFun 3.4.0 | StateFun Actors KZM-3.3 |
 |---|---|---|
-| **Flink runtime** | 1.16.2 | **2.2.0** |
+| **Flink runtime** | 1.16.2 | **2.2.1** |
 | **Java baseline** | 11 | **21** |
 | **Maven group** | `org.apache.flink` | `io.github.kzmlabs.flinkstatefun` |
 | **Kinesis I/O** | Flink 1.x consumer | **Restored** on Flink 2.x source/sink |

--- a/docs/index.md
+++ b/docs/index.md
@@ -118,7 +118,7 @@ Apache Stateful Functions stopped releasing in **October 2024** at version 3.4.0
 
 | | Apache StateFun 3.4.0 | StateFun Actors KZM-3.3 |
 |---|---|---|
-| **Flink runtime** | 1.16.2 | **2.2.0** |
+| **Flink runtime** | 1.16.2 | **2.2.1** |
 | **Java baseline** | 11 | **21** |
 | **Maven group** | `org.apache.flink` | `io.github.kzmlabs.flinkstatefun` |
 | **Kinesis I/O** | Flink 1.x consumer | **Restored** on Flink 2.x source/sink |

--- a/docs/upstream-vs-kzm.md
+++ b/docs/upstream-vs-kzm.md
@@ -11,7 +11,7 @@ description: Migration guide from Apache Stateful Functions 3.4.0 to StateFun Ac
 
 | | Apache StateFun 3.4.0 | StateFun Actors KZM-3.3 |
 |---|---|---|
-| **Flink runtime** | 1.16.2 | **2.2.0** |
+| **Flink runtime** | 1.16.2 | **2.2.1** |
 | **Java baseline** | 11 | **21** |
 | **Maven group** | `org.apache.flink` | `io.github.kzmlabs.flinkstatefun` |
 | **Kinesis I/O** | Built for Flink 1.x Kinesis source | **Restored** on Flink 2.x's `KinesisStreamsSource`/`KinesisStreamsSink` |

--- a/pom.xml
+++ b/pom.xml
@@ -115,13 +115,13 @@
         <protobuf.version>3.25.5</protobuf.version>
         <unixsocket.version>2.10.1</unixsocket.version>
         <protoc-jar-maven-plugin.version>3.11.4</protoc-jar-maven-plugin.version>
-        <flink.version>2.2.0</flink.version>
+        <flink.version>2.2.1</flink.version>
         <flink-kafka.version>4.0.1-2.0</flink-kafka.version>
         <flink.connector.aws.version>6.0.0-2.0</flink.connector.aws.version>
         <scala.binary.version>2.12</scala.binary.version>
         <scala.version>2.12.7</scala.version>
         <lz4-java.version>1.8.1</lz4-java.version>
-        <flink-shaded-jackson.version>2.18.2-20.0</flink-shaded-jackson.version>
+        <flink-shaded-jackson.version>2.20.1-21.0</flink-shaded-jackson.version>
         <!-- Security: pin transitive io.netty (via awssdk netty-nio-client) and
              plain com.fasterxml.jackson (via aws-sdk) to patched versions. -->
         <netty.version>4.1.135.Final</netty.version>
@@ -261,6 +261,15 @@
                 <groupId>org.apache.flink</groupId>
                 <artifactId>flink-shaded-netty</artifactId>
                 <version>4.1.91.Final-17.0</version>
+            </dependency>
+
+            <!-- Resolve convergence: Flink 2.2.1 runtime bumps at.yawk.lz4:lz4-java
+                 to 1.10.3 while flink-connector-kafka's kafka-clients still pulls
+                 1.8.1. Align on the newer runtime version. -->
+            <dependency>
+                <groupId>at.yawk.lz4</groupId>
+                <artifactId>lz4-java</artifactId>
+                <version>1.10.3</version>
             </dependency>
 
             <!-- Resolve convergence: Flink 2.2 transitively pulls jsr305 1.3.9


### PR DESCRIPTION
Higher-risk portion of the #247 CVE response. **Stacked on #248** — review/merge that first (base retargets to `release` automatically once #248 merges).

## Changes
- **`flink.version` 2.2.0 → 2.2.1** — fixes `flink-table-planner` CVE-2026-35194 at source and aligns compile-time deps with the 2.2.1 base image.
- **`flink-shaded-jackson` 2.18.2-20.0 → 2.20.1-21.0** — clears the *relocated* jackson-databind copy also bundled in `statefun-flink-distribution`. This is the only Jackson minor jump, hence the separate PR.
- **`at.yawk.lz4:lz4-java` 1.10.3 convergence pin** — the 2.2.1 bump moved Flink's runtime lz4 fork to 1.10.3 while `flink-connector-kafka`'s kafka-clients still pulls 1.8.1, tripping the enforcer `DependencyConvergence` rule. Aligned on the newer runtime version (matches the existing convergence-fix pattern in the root pom).

## Docs
Current-runtime references bumped to 2.2.1 (README / docs/index / upstream-vs-kzm comparison tables, CONTRIBUTING, dependabot comment, bug-report template) + a `### Security` CHANGELOG entry. Historical per-release tables and past changelog entries left at 2.2.0 (they're factual records).

## Verification
Clean `install` of the distribution + runner graph builds green; `DependencyConvergence` passes for every module. Full local K8s E2E gate (Kafka + Kinesis) run on this branch.

Refs #247