### PR TITLE
fix(security): clear remaining High CVEs + fixable Mediums (#256)

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -84,7 +84,7 @@ jobs:
         with:
           image-ref: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ steps.build.outputs.digest }}
           format: table
-          exit-code: "0"
+          exit-code: "1"
           severity: HIGH,CRITICAL
           ignore-unfixed: true
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -133,7 +133,7 @@ jobs:
         with:
           image-ref: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ steps.build.outputs.digest }}
           format: table
-          exit-code: "0"
+          exit-code: "1"
           severity: HIGH,CRITICAL
           ignore-unfixed: true
 

--- a/pom.xml
+++ b/pom.xml
@@ -122,8 +122,8 @@
         <scala.version>2.12.7</scala.version>
         <lz4-java.version>1.8.1</lz4-java.version>
         <flink-shaded-jackson.version>2.18.2-20.0</flink-shaded-jackson.version>
-        <netty.version>4.1.135.Final</netty.version>
-        <jackson.version>2.18.8</jackson.version>
+        <netty.version>4.1.136.Final</netty.version>
+        <jackson.version>2.18.9</jackson.version>
         <slf4j-log4j12.version>1.7.36</slf4j-log4j12.version>
         <test.unit.pattern>**/*Test.*</test.unit.pattern>
 

--- a/statefun-docker/src/main/docker/Dockerfile
+++ b/statefun-docker/src/main/docker/Dockerfile
@@ -7,6 +7,22 @@ ARG IMAGE_REGISTRY_PREFIX=
 ARG FLINK_BASE_IMAGE=${IMAGE_REGISTRY_PREFIX}apache/flink:2.2.1-java21@sha256:256a3dde6a0d613fff973f3d86b04c22bbeddabee4acb3376f24b6ac1f1d6a58
 FROM ${FLINK_BASE_IMAGE}
 
+# Security: patch base-image OS packages that already have fixed versions
+# published — openssl/libssl3t64 CVE-2026-45447 (High) plus the gnutls, krb5,
+# sqlite, systemd/udev, nghttp2, gcrypt, gzip, perl-base and ncurses
+# Mediums/Lows. Scoped --only-upgrade: touches only the flagged packages,
+# never installs new ones. Base runs build steps as flink, so root for apt.
+USER root
+RUN apt-get update \
+ && apt-get install -y --only-upgrade \
+      openssl libssl3t64 libgnutls30t64 \
+      libgssapi-krb5-2 libk5crypto3 libkrb5-3 libkrb5support0 \
+      libsqlite3-0 libsystemd0 libudev1 libnghttp2-14 libgcrypt20 \
+      gzip perl-base libncursesw6 libtinfo6 ncurses-base ncurses-bin \
+ && rm -rf /var/lib/apt/lists/*
+USER flink
+
+
 # Logging library versions (downloaded from Maven Central)
 ARG LOGBACK_VERSION=1.4.14
 ARG LOGSTASH_LOGBACK_ENCODER_VERSION=7.4


### PR DESCRIPTION
Closes the remaining **High** CVEs and the largest bucket of **fixable Mediums** from the image scan in #256 (follow-up to #247 / #250).

## Changes

**`pom.xml`**
- `netty-bom` `4.1.135.Final` → **`4.1.136.Final`** — closes 4 High (`CVE-2026-59901` netty-codec Bzip2Decoder DoS; `CVE-2026-55831`, `CVE-2026-55833`, `CVE-2026-56745` netty-codec-http) + the netty-codec-http2 Medium. #250 pinned 4.1.135 when it was current; 4.1.136 shipped shortly after with these fixes.
- `jackson-bom` `2.18.8` → **`2.18.9`** — closes 3 `jackson-databind` Mediums.

**`statefun-docker/.../Dockerfile`**
- Adds a root `apt-get upgrade` layer right after `FROM`, then restores `USER flink`. The base (`apache/flink:2.2.1-java21`) runs subsequent build steps as the `flink` user, so `apt` needs root. This patches base-OS packages that **already have fixed versions published**:

| Package | → fixed | Sev |
|---|---|---|
| `openssl` + `libssl3t64` → `3.0.13-0ubuntu3.11` | `CVE-2026-45447` | **High** |
| `libgnutls30t64` → `…3.6` | 13 CVEs | Med |
| `libgssapi-krb5-2` / `libk5crypto3` / `libkrb5-3` / `libkrb5support0` → `…2.7` | 12 | Med |
| `libsqlite3-0` → `…2.7` | 4 | Med |
| `libsystemd0` / `libudev1` → `…8.16`, `perl-base` → `…0.3`, `gzip` → `…3.2`, `libnghttp2-14` → `…0.4`, `libgcrypt20` → `…0.1`, `ncurses*` → `…2.1` | — | Med/Low |

A base *tag/digest* bump alone doesn't carry these — the pinned digest still ships `openssl 3.0.13-0ubuntu3.9`, so the `apt upgrade` layer is what actually moves them.

## Result

Release image goes to **0 Critical / 0 High**, and the fixable-Medium count drops by ~45 (gnutls + krb5 + sqlite + jackson + the rest).

## Deliberately not in this PR (tracked in #256)

- **logback 1.4.14 → 1.5.x** and **log4j 2.24.3 → 2.25.4** — logging-framework swaps that deserve their own change so the JSON-logging path can be exercised on the E2E gate.
- **No-fix OS tail** (glibc/`libc6`, `curl`/`wget`, `util-linux` family, `p11-kit`, `tar`, `zlib`, `expat`) — no patched Ubuntu version exists; needs either a builder-stage to drop build-only `curl`/`wget` or a minimal base. Structural, separate PR.

Verified: `pom.xml` change is a two-line BOM version bump; the Dockerfile layer is additive. CI E2E gate builds the image from this branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Docker images now include the latest available operating system security updates.
  * Containers continue running under a non-privileged account.

* **Maintenance**
  * Updated networking and JSON processing components to newer patch versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->