### PR TITLE
ci: scan the built image with Trivy on PRs and release pushes

### DIFF
--- a/.github/workflows/image-scan.yml
+++ b/.github/workflows/image-scan.yml
@@ -1,0 +1,78 @@
+# Builds the statefun-docker image and scans it with Trivy on every change that
+# can alter image contents. Same gate config as release.yml / docker-release.yml
+# (HIGH,CRITICAL + ignore-unfixed + exit-code 1), so a CVE that would block a
+# release fails here first — on the PR, not on release day. The weekly cron
+# re-scans the current release branch to catch newly disclosed CVEs.
+name: Image CVE Scan
+
+on:
+  push:
+    branches: [ release ]
+    paths:
+      - 'pom.xml'
+      - 'statefun-docker/**'
+      - 'statefun-flink/**'
+      - 'statefun-shaded/**'
+      - 'statefun-flink-runner/**'
+      - 'statefun-kafka-io/**'
+      - 'statefun-kinesis-io/**'
+      - 'statefun-sdk-embedded/**'
+      - '.github/workflows/image-scan.yml'
+  pull_request:
+    branches: [ release, master ]
+    paths:
+      - 'pom.xml'
+      - 'statefun-docker/**'
+      - 'statefun-flink/**'
+      - 'statefun-shaded/**'
+      - 'statefun-flink-runner/**'
+      - 'statefun-kafka-io/**'
+      - 'statefun-kinesis-io/**'
+      - 'statefun-sdk-embedded/**'
+      - '.github/workflows/image-scan.yml'
+  schedule:
+    - cron: '30 5 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: image-scan-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    name: Build image & Trivy scan
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          # Cron fires on the default branch; scan the release branch instead —
+          # that is the branch images are released from.
+          ref: ${{ github.event_name == 'schedule' && 'release' || github.ref }}
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+          cache: 'maven'
+
+      - name: Build image context
+        run: mvn package -pl :statefun-docker -am -B -DskipTests
+
+      - name: Build Docker image
+        run: docker build -t statefun-scan:${{ github.sha }} statefun-docker/target/docker
+
+      - name: Scan image for CVEs (Trivy)
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # master
+        with:
+          image-ref: statefun-scan:${{ github.sha }}
+          format: table
+          exit-code: "1"
+          severity: HIGH,CRITICAL
+          ignore-unfixed: true


### PR DESCRIPTION
Closes the verification gap left after #257: Trivy runs only in `release.yml` / `docker-release.yml` (tag- or dispatch-triggered), so the image's CVE state is never actually scanned until release day — where #257 made the scan an **enforcing gate** (`exit-code: 1`). A wrong "0 High" assumption would now fail a release at the last step.

## What this adds

A standalone `Image CVE Scan` workflow that:
- **builds the real image** (`mvn package -pl :statefun-docker -am` → `docker build` on `statefun-docker/target/docker`) — no registry push, nothing published
- **scans with the identical gate config** as the release workflows: `severity: HIGH,CRITICAL`, `ignore-unfixed: true`, `exit-code: 1`, same pinned `trivy-action` SHA
- triggers on **PRs and release pushes** touching anything that can change image contents (root `pom.xml`, `statefun-docker/**`, `statefun-flink/**`, shaded/runner/io modules, the workflow itself)
- runs a **weekly cron** (Mon 05:30 UTC) which checks out `release` explicitly (cron fires on the default branch) — catches newly disclosed CVEs between releases instead of on release day

## Effect

The first run on this PR doubles as the still-missing verification of #257's "0 Critical / 0 High" claim — the scan table lands in the job log.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated security scanning for the Docker image.
  * Scans run on relevant code changes, weekly, and on demand.
  * Builds fail when fixable high- or critical-severity vulnerabilities are detected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->