### PR TITLE
ci: open a tracking issue when the weekly image CVE scan fails

### DIFF
--- a/.github/scripts/report_scan_failure.sh
+++ b/.github/scripts/report_scan_failure.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# Opens (or comments on) a tracking issue when the scheduled image CVE scan
+# fails. Called from image-scan.yml with GH_TOKEN, REPO and RUN_URL set.
+set -euo pipefail
+
+TITLE="Weekly image CVE scan failed"
+BODY="The scheduled Trivy scan of the release-branch image found fixable HIGH/CRITICAL CVEs (or the scan job errored).
+
+Run with the full report: ${RUN_URL}
+
+The scan uses the same gate config as the release workflows (\`HIGH,CRITICAL\` + \`ignore-unfixed\` + \`exit-code: 1\`), so the next release is blocked at the Trivy step until this is fixed."
+
+existing=$(gh issue list --repo "$REPO" --state open \
+  --search "in:title \"$TITLE\"" --json number --jq '.[0].number // empty')
+
+if [ -n "$existing" ]; then
+  gh issue comment "$existing" --repo "$REPO" --body "Still failing: ${RUN_URL}"
+else
+  gh issue create --repo "$REPO" --title "$TITLE" --body "$BODY" \
+    --label security 2>/dev/null \
+    || gh issue create --repo "$REPO" --title "$TITLE" --body "$BODY"
+fi

--- a/.github/workflows/image-scan.yml
+++ b/.github/workflows/image-scan.yml
@@ -36,6 +36,7 @@ on:
 
 permissions:
   contents: read
+  issues: write   # report_scan_failure.sh opens a tracking issue on cron failure
 
 concurrency:
   group: image-scan-${{ github.ref }}
@@ -76,3 +77,13 @@ jobs:
           exit-code: "1"
           severity: HIGH,CRITICAL
           ignore-unfixed: true
+
+      # Cron failures have no PR to surface them — open (or bump) a tracking
+      # issue so the failure lands in email and stays visible until fixed.
+      - name: Open tracking issue on scan failure
+        if: failure() && github.event_name == 'schedule'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: bash .github/scripts/report_scan_failure.sh


### PR DESCRIPTION
Follow-up to #260. The weekly cron scan's failure email is easy to lose; a cron failure also has no PR to surface it. This adds a failure step (schedule-triggered runs only) that opens a **"Weekly image CVE scan failed"** issue — or comments on the already-open one to avoid duplicates — linking to the run with the full Trivy report.

- Logic lives in `.github/scripts/report_scan_failure.sh` per repo convention
- Workflow gains `issues: write` (still `contents: read` otherwise)
- PR/push failures are unaffected — those are already visible where they happen