### PR TITLE
ci: publish the Trivy report to the run summary and as an artifact

### DIFF
--- a/.github/workflows/image-scan.yml
+++ b/.github/workflows/image-scan.yml
@@ -74,9 +74,30 @@ jobs:
         with:
           image-ref: statefun-scan:${{ github.sha }}
           format: table
+          output: trivy-report.txt
           exit-code: "1"
           severity: HIGH,CRITICAL
           ignore-unfixed: true
+
+      # Surface the report on the run's Summary page — no log digging needed.
+      - name: Publish report to run summary
+        if: always()
+        run: |
+          [ -s trivy-report.txt ] || exit 0
+          {
+            echo '## Trivy image scan report'
+            echo '```'
+            cat trivy-report.txt
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload report artifact
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: trivy-report
+          path: trivy-report.txt
+          if-no-files-found: ignore
 
       # Cron failures have no PR to surface them — open (or bump) a tracking
       # issue so the failure lands in email and stays visible until fixed.


### PR DESCRIPTION
Follow-up to #260/#261. The Trivy report was only visible inside the collapsed scan-step log. Now the scan writes `trivy-report.txt` and:

- **renders it on the run's Summary page** (`$GITHUB_STEP_SUMMARY`) — visible the moment you open the run, no log digging
- **uploads it as a `trivy-report` artifact** — downloadable from the run page

Both steps run `if: always()`, so the report is published precisely when it matters most — on a failing scan. With `output:` set the table goes to the file instead of stdout, so the summary/artifact is the canonical copy.