### PR TITLE
fix(security): complete logback migration + bump logback/encoder (Mediums)

### DIFF
--- a/statefun-docker/src/main/docker/Dockerfile
+++ b/statefun-docker/src/main/docker/Dockerfile
@@ -24,15 +24,15 @@ USER flink
 
 
 # Logging library versions (downloaded from Maven Central)
-ARG LOGBACK_VERSION=1.4.14
-ARG LOGSTASH_LOGBACK_ENCODER_VERSION=7.4
+ARG LOGBACK_VERSION=1.5.19
+ARG LOGSTASH_LOGBACK_ENCODER_VERSION=8.0
 ARG SLF4J_VERSION=2.0.9
 
 ARG MAVEN_CENTRAL=https://repo1.maven.org/maven2
 
 # Remove unnecessary Flink libs
 RUN rm -rf ${FLINK_HOME}/lib/flink-table*jar \
-    && rm -rf ${FLINK_HOME}/lib/log4j-slf4j-impl*jar
+    && rm -rf ${FLINK_HOME}/lib/log4j-*.jar
 
 # Download logging JARs from Maven Central
 RUN curl -fSL "${MAVEN_CENTRAL}/ch/qos/logback/logback-classic/${LOGBACK_VERSION}/logback-classic-${LOGBACK_VERSION}.jar" \


### PR DESCRIPTION
Clears the remaining **fixable Medium** jar findings from the image scan in #256 (follow-up to #257). Single-file Dockerfile change.

## The log4j jars are already unused

The image switched Flink's logging to logback — it removes `log4j-slf4j-impl` (the SLF4J→log4j2 bridge) and adds `logback-classic` (which provides the SLF4J binding). So SLF4J binds to **logback**; nothing routes to log4j2. But the base's `log4j-api` / `log4j-core` / `log4j-1.2-api` / `log4j-layout-template-json` (2.24.3) jars were left in `FLINK_HOME/lib` as **unreferenced dead weight** — and Trivy flags them (`log4j-core` ×4, `log4j-1.2-api`, `log4j-layout-template-json` Mediums).

This is exactly [Flink's documented logback migration](https://nightlies.apache.org/flink/flink-docs-stable/docs/deployment/advanced/logging/#configuring-logback), which says to remove **all** log4j jars — the image did it half-way. Completing it is a no-op at runtime because those classes are never loaded once the binding is logback.

## Changes

- `rm ${FLINK_HOME}/lib/log4j-slf4j-impl*jar` → `rm ${FLINK_HOME}/lib/log4j-*.jar` — removes the whole log4j family, not just the bridge. Clears 6 Mediums, zero runtime impact.
- `LOGBACK_VERSION` `1.4.14` → **`1.5.19`** — clears the `logback-core` Mediums.
- `LOGSTASH_LOGBACK_ENCODER_VERSION` `7.4` → **`8.0`** — the encoder line matched to logback 1.5 (7.x targets logback 1.2/1.3; 8.x targets 1.3+/Java 11+).

## Result

Fixable-Medium jar findings → 0. The remaining Mediums are the **no-fix base-OS tail** (glibc, curl/wget, util-linux, p11-kit) with no patched Ubuntu version — structural, tracked in #256.

Verified: logback `1.5.19` + logstash-encoder `8.0` both resolve on Maven Central. CI E2E gate exercises the image (and, with #260, now scans it on the PR).