### PR TITLE
feat(kafka): Kafka record header support in remote SDK ingress and egress

### DIFF
--- a/docs/guides/kafka-headers.md
+++ b/docs/guides/kafka-headers.md
@@ -1,0 +1,193 @@
+# Kafka record headers
+
+Kafka records carry headers — key/value metadata pairs alongside the payload, commonly used for
+trace IDs, correlation IDs, schema hints, retry counters, or routing tags. StateFun Actors
+supports headers in **both directions** for remote functions built with `statefun-sdk-java`:
+
+- **Ingress → function**: a function invoked by a record from a Kafka ingress
+  (`io.statefun.kafka.v1/ingress`) reads the record's headers through `Message#headers()`.
+- **Function → egress**: a function attaches headers when building a `KafkaEgressMessage`; the
+  runtime writes them onto the produced Kafka record (`io.statefun.kafka.v1/egress`).
+
+Semantics match Kafka's own contract exactly:
+
+| Kafka rule | StateFun behavior |
+|---|---|
+| Duplicate header keys are allowed | Preserved, in original order |
+| Header **value** may be `null` (distinct from empty) | Preserved as `null` end-to-end |
+| Header **key** must not be `null` | A null key degrades to an empty key instead of failing |
+| Headers are raw bytes on the wire | Choose an encoding — see [Choosing an encoding](#choosing-an-encoding) |
+
+No configuration is needed — header support is always on and adds zero overhead to records
+without headers.
+
+## Reading headers in a function
+
+```java
+public CompletableFuture<Void> apply(Context context, Message message) {
+    for (MessageHeader header : message.headers()) {
+        switch (header.key()) {
+            case "trace-id" -> log.info("trace={}", header.valueAsUtf8String());
+            case "retry-count" -> handleRetry(header.valueAsInt());
+        }
+    }
+    // or stream-style:
+    Optional<String> traceId =
+        message.headers().stream()
+            .filter(h -> h.key().equals("trace-id"))
+            .map(MessageHeader::valueAsUtf8String)
+            .findFirst();
+    ...
+}
+```
+
+`Message#headers()` returns an immutable `List<MessageHeader>`:
+
+- headers appear in the order they were set on the Kafka record, duplicates included;
+- messages that did not originate from a Kafka ingress return an empty list (unless the sender
+  attached headers explicitly — see [Forwarding headers](#forwarding-headers-between-functions));
+- the list is computed lazily and cached — untouched headers cost nothing.
+
+### `MessageHeader` accessors
+
+| Accessor | Returns | For values written with |
+|---|---|---|
+| `key()` | `String` (never null) | — |
+| `hasValue()` | `false` when the Kafka header value was null | — |
+| `value()` | `Slice` (zero-copy), or `null` for a null-valued header | `withHeader(key, byte[]/Slice)` |
+| `valueAsUtf8String()` | `String` | `withUtf8Header(key, text)` |
+| `valueAsInt()` / `valueAsLong()` / `valueAsFloat()` / `valueAsDouble()` / `valueAsBoolean()` | boxed primitive | the matching primitive `withHeader` overload |
+| `valueAs(Type<T>)` | `T` | `withHeader(key, type, value)` |
+
+!!! note "Never throws"
+
+    Every accessor is production-safe: a null or undecodable value returns `null` — an exception
+    is never thrown inside a live function invocation because of malformed header bytes.
+
+## Writing headers to a Kafka egress
+
+```java
+context.send(
+    KafkaEgressMessage.forEgress(TypeName.typeNameFromString("example/notifications"))
+        .withTopic("example.notifications")
+        .withUtf8Key(orderId)
+        .withValue(payload)
+        .withUtf8Header("trace-id", traceId)     // UTF-8 text
+        .withHeader("payload-hash", hashBytes)   // raw bytes
+        .withHeader("retry-count", 10)           // binary int
+        .withHeader("replayed", true)            // binary boolean
+        .build());
+```
+
+### Builder overloads
+
+| Overload | Wire encoding |
+|---|---|
+| `withUtf8Header(String key, String value)` | UTF-8 text |
+| `withHeader(String key, byte[] value)` | raw bytes as given |
+| `withHeader(String key, Slice value)` | raw bytes as given (zero-copy) |
+| `withHeader(String key, Type<T> type, T value)` | the SDK type's serializer |
+| `withHeader(String key, int / long / float / double / boolean value)` | binary SDK `Types` encoding — shorthand for the `Type<T>` overload |
+
+Headers may repeat keys; they are written in call order.
+
+## Choosing an encoding
+
+Kafka headers are always raw bytes on the wire — there is no native "number" header type — so
+the choice is which encoding the *reader* expects:
+
+- **Binary (`withHeader(key, 10)` / `Type<T>` overload)** — a real binary number, decoded
+  losslessly by any StateFun SDK reader via `valueAsInt()` etc. Best between StateFun functions.
+- **UTF-8 text (`withUtf8Header(key, "10")`)** — readable by any Kafka consumer, `kcat`, Kafka
+  Connect, or UI tooling. Best when non-StateFun systems consume the topic.
+- **Raw bytes (`byte[]`/`Slice`)** — you own the encoding on both sides (e.g. hashes, protobuf).
+
+## Null semantics
+
+Kafka distinguishes a header with a **null value** from one with an **empty value**, and so does
+StateFun — a null value survives the full ingress → function → egress round-trip as null:
+
+```java
+// echoing headers preserves null-ness:
+message.headers().forEach(h -> egress.withHeader(h.key(), h.value())); // null value() → null header
+
+// reading:
+header.hasValue();   // false for a null-valued header
+header.value();      // null   — same contract as Kafka's own Header#value()
+header.valueAsInt(); // null   — no exception
+```
+
+Write-side null handling (never fails a send):
+
+| Input | Result on the produced record |
+|---|---|
+| null header *value* (any overload) | header present with a **null** value |
+| explicitly empty value (`new byte[0]`) | header present with an **empty** value |
+| null header *key* | key degrades to `""` (Kafka forbids null keys — failing inside the running job would be worse) |
+| null `Type<T>` object | treated as a null value |
+
+## Forwarding headers between functions
+
+Function-to-function messages can carry headers too — `MessageBuilder` has the same overload
+family, and the receiving function reads them with the same `Message#headers()` API:
+
+```java
+context.send(
+    MessageBuilder.forAddress(TARGET_FN, id)
+        .withValue("payload")
+        .withUtf8Header("trace-id", traceId)
+        .build());
+```
+
+`MessageBuilder.fromMessage(message)` preserves the original message's headers when re-targeting
+or forwarding, including null-valued ones.
+
+## Testing header-aware functions
+
+The SDK testing toolkit covers headers end-to-end — construct incoming messages with headers via
+`MessageBuilder`, and assert egress headers with `KafkaEgressCapture` (no protobuf hand-parsing):
+
+```java
+@Test
+void echoesTraceHeader() throws Exception {
+    Message message =
+        MessageBuilder.forAddress(SELF)
+            .withValue("payload")
+            .withUtf8Header("trace-id", "abc-123")
+            .withHeader("attempt", 3)
+            .build();
+    TestContext context = TestContext.forTarget(SELF);
+
+    functionUnderTest.apply(context, message).get();
+
+    KafkaEgressCapture record =
+        KafkaEgressCapture.of(context.getSentEgressMessages().get(0).message());
+    assertThat(record.topic()).isEqualTo("out");
+    assertThat(record.lastHeader("trace-id").orElseThrow().valueAsUtf8String())
+        .isEqualTo("abc-123");
+    assertThat(record.lastHeader("attempt").orElseThrow().valueAsInt()).isEqualTo(3);
+}
+```
+
+`KafkaEgressCapture` exposes `targetEgressId()`, `topic()`, `utf8Key()`, `value()`,
+`utf8Value()`, `headers()`, and `lastHeader(key)` (Kafka's last-wins semantics). Unlike the
+production paths it fails loudly: passing a non-Kafka egress message throws
+`IllegalArgumentException`, so a wiring mistake surfaces in the test, not in production.
+
+## Protocol and compatibility
+
+Header support is strictly additive at the protocol level:
+
+- `KafkaProducerRecord` (egress), `TypedValue.Metadata` (request-reply), and the internal ingress
+  envelope each gained a repeated header field with a `has_value` flag — the same idiom
+  `TypedValue` itself uses to distinguish empty from absent.
+- Remote functions built against **older SDKs** keep working against a runtime with header
+  support — they simply do not see headers.
+- A **new SDK** talking to an **older runtime** also keeps working — headers set on egress
+  messages are ignored by the old runtime, nothing fails.
+- Records without headers have unchanged wire size and no extra allocations on any path.
+
+!!! info "Kafka only"
+
+    Kinesis has no record-header concept, so `io.statefun.kinesis.v1` ingresses and egresses are
+    unaffected by this feature.

--- a/docs/guides/kafka-headers.md
+++ b/docs/guides/kafka-headers.md
@@ -18,8 +18,42 @@ Semantics match Kafka's own contract exactly:
 | Header **key** must not be `null` | A null key degrades to an empty key instead of failing |
 | Headers are raw bytes on the wire | Choose an encoding — see [Choosing an encoding](#choosing-an-encoding) |
 
-No configuration is needed — header support is always on and adds zero overhead to records
-without headers.
+Egress headers work out of the box. Ingress header **forwarding is opt-in**: headers cost payload
+bytes on every hop between the ingress and the remote function, so a topic only pays for them
+after opting in — see [Enabling header forwarding](#enabling-header-forwarding).
+
+## Enabling header forwarding
+
+Ingress headers are forwarded to remote functions only for topics that enable
+`forwardHeaders` (default `false`). The flag exists at two levels of the
+`io.statefun.kafka.v1/ingress` spec:
+
+```yaml
+kind: io.statefun.kafka.v1/ingress
+spec:
+  id: example/orders-in
+  address: kafka:9092
+  consumerGroupId: my-group
+  forwardHeaders: true        # ingress-level default for all topics below
+  topics:
+    - topic: orders
+      valueType: example/Order
+      targets:
+        - example/order-fn
+    - topic: audit-log
+      forwardHeaders: false   # per-topic override wins over the ingress-level value
+      valueType: example/AuditEntry
+      targets:
+        - example/audit-fn
+```
+
+The effective value per topic is resolved as: per-topic `forwardHeaders` if present, otherwise
+the ingress-level `forwardHeaders`, otherwise `false`. With a 20-topic ingress you set the policy
+once at ingress level and override individual topics in either direction.
+
+For a topic that has not opted in, record headers are never captured — no header bytes enter the
+runtime, the Flink shuffle, or the remote-function request, and `Message#headers()` returns an
+empty list. Records on opted-in topics without headers still add zero overhead.
 
 ## Reading headers in a function
 
@@ -44,8 +78,10 @@ public CompletableFuture<Void> apply(Context context, Message message) {
 `Message#headers()` returns an immutable `List<MessageHeader>`:
 
 - headers appear in the order they were set on the Kafka record, duplicates included;
-- messages that did not originate from a Kafka ingress return an empty list (unless the sender
-  attached headers explicitly — see [Forwarding headers](#forwarding-headers-between-functions));
+- messages from a topic that did not enable
+  [`forwardHeaders`](#enabling-header-forwarding), and messages that did not originate from a
+  Kafka ingress, return an empty list (unless the sender attached headers explicitly — see
+  [Forwarding headers](#forwarding-headers-between-functions));
 - the list is computed lazily and cached — untouched headers cost nothing.
 
 ### `MessageHeader` accessors
@@ -185,7 +221,10 @@ Header support is strictly additive at the protocol level:
   support — they simply do not see headers.
 - A **new SDK** talking to an **older runtime** also keeps working — headers set on egress
   messages are ignored by the old runtime, nothing fails.
-- Records without headers have unchanged wire size and no extra allocations on any path.
+- `forwardHeaders` is an additive YAML property — existing `module.yaml` files parse unchanged
+  and keep the default (off).
+- Records without headers — and all records on topics that did not opt in — have unchanged wire
+  size and no extra allocations on any path.
 
 !!! info "Kafka only"
 

--- a/docs/guides/kafka-io.md
+++ b/docs/guides/kafka-io.md
@@ -71,51 +71,6 @@ ctx.send(outbound);
 
 The runtime uses Flink transactions to deliver exactly once when paired with a transactional Kafka client and exactly-once Flink checkpointing.
 
-## Record headers
-
-Kafka record headers travel in both directions.
-
-**Reading ingress headers** — a function invoked by a record from a Kafka ingress can read the
-record's headers through `Message#headers()`. Duplicate keys are allowed and the original order is
-preserved; messages that did not originate from Kafka (e.g. function-to-function sends) return an
-empty list:
-
-```java
-for (MessageHeader header : message.headers()) {
-    if (header.key().equals("trace-id")) {
-        String traceId = header.valueAsUtf8String();
-    }
-}
-```
-
-**Setting egress headers** — attach headers when building a `KafkaEgressMessage`; the runtime
-copies them onto the produced Kafka record:
-
-```java
-KafkaEgressMessage.forEgress(TypeName.typeNameFromString("example/notifications"))
-    .withTopic("example.notifications")
-    .withKey(orderId)
-    .withValue(notificationPayload)
-    .withUtf8Header("trace-id", traceId)   // UTF-8 text, readable by any Kafka tool
-    .withHeader("payload-hash", hashBytes) // raw bytes
-    .withHeader("retry-count", 10)         // binary int (SDK Types encoding)
-    .build();
-```
-
-Primitive header values travel as real binary numbers and decode symmetrically on the read side —
-`header.valueAsInt()`, `valueAsLong()`, `valueAsDouble()`, `valueAsBoolean()` — returning `null`
-(never throwing) for null or undecodable values.
-
-Header semantics match Kafka's own: duplicate keys and ordering are preserved, and a **null**
-header value — which Kafka distinguishes from an empty one — stays null end-to-end
-(`MessageHeader#value()` returns `null`, mirroring Kafka's `Header#value()` contract). Header
-operations never throw on null input: a null value is carried as a null-valued header and a null
-key degrades to an empty key, so malformed metadata can never fail a production send or a
-function invocation.
-
-Header support is additive at the protocol level: remote functions built against older SDKs keep
-working unchanged, they simply do not see headers.
-
 ### At-least-once vs exactly-once
 
 | `deliverySemantic.type` | Trade-off |
@@ -126,6 +81,16 @@ working unchanged, they simply do not see headers.
 !!! warning "Transaction timeout"
 
     For `exactly-once`, set `transactionTimeoutMillis` higher than your Flink checkpoint interval, but lower than the Kafka broker's `transaction.max.timeout.ms` (default 15 min). 60 s is a good starting point for sub-minute checkpoint intervals.
+
+## Record headers
+
+Kafka record headers travel in both directions: functions read the headers of the record that
+triggered them via `Message#headers()` and attach headers to egress records via the
+`KafkaEgressMessage` builder. Semantics match Kafka's own — duplicate keys, ordering, and the
+null-vs-empty value distinction are all preserved, and header operations never throw on null
+input.
+
+See the dedicated guide: **[Kafka record headers](kafka-headers.md)**.
 
 ## Patterns
 

--- a/docs/guides/kafka-io.md
+++ b/docs/guides/kafka-io.md
@@ -101,6 +101,13 @@ KafkaEgressMessage.forEgress(TypeName.typeNameFromString("example/notifications"
     .build();
 ```
 
+Header semantics match Kafka's own: duplicate keys and ordering are preserved, and a **null**
+header value — which Kafka distinguishes from an empty one — stays null end-to-end
+(`MessageHeader#value()` returns `null`, mirroring Kafka's `Header#value()` contract). Header
+operations never throw on null input: a null value is carried as a null-valued header and a null
+key degrades to an empty key, so malformed metadata can never fail a production send or a
+function invocation.
+
 Header support is additive at the protocol level: remote functions built against older SDKs keep
 working unchanged, they simply do not see headers.
 

--- a/docs/guides/kafka-io.md
+++ b/docs/guides/kafka-io.md
@@ -71,6 +71,39 @@ ctx.send(outbound);
 
 The runtime uses Flink transactions to deliver exactly once when paired with a transactional Kafka client and exactly-once Flink checkpointing.
 
+## Record headers
+
+Kafka record headers travel in both directions.
+
+**Reading ingress headers** — a function invoked by a record from a Kafka ingress can read the
+record's headers through `Message#headers()`. Duplicate keys are allowed and the original order is
+preserved; messages that did not originate from Kafka (e.g. function-to-function sends) return an
+empty list:
+
+```java
+for (MessageHeader header : message.headers()) {
+    if (header.key().equals("trace-id")) {
+        String traceId = header.valueAsUtf8String();
+    }
+}
+```
+
+**Setting egress headers** — attach headers when building a `KafkaEgressMessage`; the runtime
+copies them onto the produced Kafka record:
+
+```java
+KafkaEgressMessage.forEgress(TypeName.typeNameFromString("example/notifications"))
+    .withTopic("example.notifications")
+    .withKey(orderId)
+    .withValue(notificationPayload)
+    .withUtf8Header("trace-id", traceId)
+    .withHeader("payload-hash", hashBytes)
+    .build();
+```
+
+Header support is additive at the protocol level: remote functions built against older SDKs keep
+working unchanged, they simply do not see headers.
+
 ### At-least-once vs exactly-once
 
 | `deliverySemantic.type` | Trade-off |

--- a/docs/guides/kafka-io.md
+++ b/docs/guides/kafka-io.md
@@ -96,10 +96,15 @@ KafkaEgressMessage.forEgress(TypeName.typeNameFromString("example/notifications"
     .withTopic("example.notifications")
     .withKey(orderId)
     .withValue(notificationPayload)
-    .withUtf8Header("trace-id", traceId)
-    .withHeader("payload-hash", hashBytes)
+    .withUtf8Header("trace-id", traceId)   // UTF-8 text, readable by any Kafka tool
+    .withHeader("payload-hash", hashBytes) // raw bytes
+    .withHeader("retry-count", 10)         // binary int (SDK Types encoding)
     .build();
 ```
+
+Primitive header values travel as real binary numbers and decode symmetrically on the read side —
+`header.valueAsInt()`, `valueAsLong()`, `valueAsDouble()`, `valueAsBoolean()` — returning `null`
+(never throwing) for null or undecodable values.
 
 Header semantics match Kafka's own: duplicate keys and ordering are preserved, and a **null**
 header value — which Kafka distinguishes from an empty one — stays null end-to-end

--- a/docs/guides/kafka-io.md
+++ b/docs/guides/kafka-io.md
@@ -86,9 +86,10 @@ The runtime uses Flink transactions to deliver exactly once when paired with a t
 
 Kafka record headers travel in both directions: functions read the headers of the record that
 triggered them via `Message#headers()` and attach headers to egress records via the
-`KafkaEgressMessage` builder. Semantics match Kafka's own — duplicate keys, ordering, and the
-null-vs-empty value distinction are all preserved, and header operations never throw on null
-input.
+`KafkaEgressMessage` builder. Ingress header forwarding is opt-in per topic through the
+`forwardHeaders` spec property (default `false`, settable at ingress level with per-topic
+overrides). Semantics match Kafka's own — duplicate keys, ordering, and the null-vs-empty value
+distinction are all preserved, and header operations never throw on null input.
 
 See the dedicated guide: **[Kafka record headers](kafka-headers.md)**.
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -72,6 +72,7 @@ nav:
       - IoT fleet digital twins: examples/iot-fleet.md
   - Guides:
       - Kafka I/O: guides/kafka-io.md
+      - Kafka record headers: guides/kafka-headers.md
       - Kafka egress tuning: guides/kafka-egress-tuning.md
       - Kinesis I/O: guides/kinesis-io.md
       - Kubernetes deployment: guides/k8s-deployment.md

--- a/statefun-e2e-tests/statefun-e2e-k8s-native/remote-function/src/main/java/org/apache/flink/statefun/e2e/k8s/KafkaCounterFn.java
+++ b/statefun-e2e-tests/statefun-e2e-k8s-native/remote-function/src/main/java/org/apache/flink/statefun/e2e/k8s/KafkaCounterFn.java
@@ -58,9 +58,7 @@ public final class KafkaCounterFn implements StatefulFunction {
             .withTopic(RESULTS_TOPIC)
             .withUtf8Key(cmd.getId())
             .withValue(result.toByteArray());
-    for (MessageHeader header : message.headers()) {
-      egress.withHeader(header.key(), header.value());
-    }
+    message.headers().forEach(header -> egress.withHeader(header.key(), header.value()));
     egress.withUtf8Header(PROCESSED_BY_HEADER, PROCESSED_BY_VALUE);
     context.send(egress.build());
 

--- a/statefun-e2e-tests/statefun-e2e-k8s-native/remote-function/src/main/java/org/apache/flink/statefun/e2e/k8s/KafkaCounterFn.java
+++ b/statefun-e2e-tests/statefun-e2e-k8s-native/remote-function/src/main/java/org/apache/flink/statefun/e2e/k8s/KafkaCounterFn.java
@@ -11,11 +11,19 @@ import org.apache.flink.statefun.sdk.java.TypeName;
 import org.apache.flink.statefun.sdk.java.ValueSpec;
 import org.apache.flink.statefun.sdk.java.io.KafkaEgressMessage;
 import org.apache.flink.statefun.sdk.java.message.Message;
+import org.apache.flink.statefun.sdk.java.message.MessageHeader;
 import org.apache.flink.statefun.sdk.java.types.SimpleType;
 import org.apache.flink.statefun.sdk.java.types.Type;
 
-/** Counter function: consumes CounterCommand from Kafka, emits CounterResult to Kafka. */
+/**
+ * Counter function: consumes CounterCommand from Kafka, emits CounterResult to Kafka. Echoes all
+ * headers of the triggering Kafka record onto the result record and stamps a {@code processed-by}
+ * header, so the E2E can verify the full ingress→egress header round-trip.
+ */
 public final class KafkaCounterFn implements StatefulFunction {
+
+  static final String PROCESSED_BY_HEADER = "processed-by";
+  static final String PROCESSED_BY_VALUE = "counter-fn";
 
   static final TypeName FN_TYPE = TypeName.typeNameOf("counter.kafka", "fn");
   static final TypeName EGRESS_ID = TypeName.typeNameOf("counter", "kafka-results");
@@ -45,12 +53,16 @@ public final class KafkaCounterFn implements StatefulFunction {
     CounterResult result =
         CounterResult.newBuilder().setId(cmd.getId()).setTotal(newTotal).build();
 
-    context.send(
+    KafkaEgressMessage.Builder egress =
         KafkaEgressMessage.forEgress(EGRESS_ID)
             .withTopic(RESULTS_TOPIC)
             .withUtf8Key(cmd.getId())
-            .withValue(result.toByteArray())
-            .build());
+            .withValue(result.toByteArray());
+    for (MessageHeader header : message.headers()) {
+      egress.withHeader(header.key(), header.value());
+    }
+    egress.withUtf8Header(PROCESSED_BY_HEADER, PROCESSED_BY_VALUE);
+    context.send(egress.build());
 
     return context.done();
   }

--- a/statefun-e2e-tests/statefun-e2e-k8s-native/src/test/java/org/apache/flink/statefun/e2e/k8s/StateFunK8sE2E.java
+++ b/statefun-e2e-tests/statefun-e2e-k8s-native/src/test/java/org/apache/flink/statefun/e2e/k8s/StateFunK8sE2E.java
@@ -205,6 +205,7 @@ class StateFunK8sE2E {
         new ProducerRecord<>(COUNTER_COMMANDS_TOPIC, counterId, cmd.toByteArray());
     record.headers().add("trace-id", "trace-abc".getBytes(StandardCharsets.UTF_8));
     record.headers().add("bin-header", binaryHeaderValue);
+    record.headers().add("null-header", null);
     producer.send(record).get(10, TimeUnit.SECONDS);
     producer.flush();
     LOG.info("Sent CounterCommand with headers for id={}", counterId);
@@ -231,6 +232,11 @@ class StateFunK8sE2E {
               assertThat(headerValue(result, "processed-by"))
                   .as("header set by the function itself")
                   .isEqualTo("counter-fn".getBytes(StandardCharsets.UTF_8));
+
+              org.apache.kafka.common.header.Header nullEcho =
+                  result.headers().lastHeader("null-header");
+              assertThat(nullEcho).as("null-valued header is echoed, not dropped").isNotNull();
+              assertThat(nullEcho.value()).as("null header value stays null, not empty").isNull();
             });
   }
 

--- a/statefun-e2e-tests/statefun-e2e-k8s-native/src/test/java/org/apache/flink/statefun/e2e/k8s/StateFunK8sE2E.java
+++ b/statefun-e2e-tests/statefun-e2e-k8s-native/src/test/java/org/apache/flink/statefun/e2e/k8s/StateFunK8sE2E.java
@@ -196,6 +196,46 @@ class StateFunK8sE2E {
 
   @Test
   @Order(4)
+  void kafkaHeadersRoundTripThroughIngressAndEgress() throws Exception {
+    String counterId = "counter-hdr-" + UUID.randomUUID();
+    byte[] binaryHeaderValue = new byte[] {0x00, 0x01, (byte) 0xFF};
+
+    CounterCommand cmd = CounterCommand.newBuilder().setId(counterId).setDelta(2).build();
+    ProducerRecord<String, byte[]> record =
+        new ProducerRecord<>(COUNTER_COMMANDS_TOPIC, counterId, cmd.toByteArray());
+    record.headers().add("trace-id", "trace-abc".getBytes(StandardCharsets.UTF_8));
+    record.headers().add("bin-header", binaryHeaderValue);
+    producer.send(record).get(10, TimeUnit.SECONDS);
+    producer.flush();
+    LOG.info("Sent CounterCommand with headers for id={}", counterId);
+
+    await()
+        .atMost(E2eContext.POLL_TIMEOUT)
+        .pollInterval(E2eContext.POLL_INTERVAL)
+        .untilAsserted(
+            () -> {
+              List<ConsumerRecord<String, byte[]>> results =
+                  StreamSupport.stream(
+                          counterResultsConsumer.poll(Duration.ofSeconds(1)).spliterator(), false)
+                      .filter(r -> counterId.equals(parseCounterResult(r.value()).getId()))
+                      .collect(Collectors.toList());
+              assertThat(results).as("result record for id=%s", counterId).isNotEmpty();
+
+              ConsumerRecord<String, byte[]> result = results.get(0);
+              assertThat(headerValue(result, "trace-id"))
+                  .as("ingress header echoed by the function")
+                  .isEqualTo("trace-abc".getBytes(StandardCharsets.UTF_8));
+              assertThat(headerValue(result, "bin-header"))
+                  .as("binary ingress header echoed byte-exact")
+                  .isEqualTo(binaryHeaderValue);
+              assertThat(headerValue(result, "processed-by"))
+                  .as("header set by the function itself")
+                  .isEqualTo("counter-fn".getBytes(StandardCharsets.UTF_8));
+            });
+  }
+
+  @Test
+  @Order(5)
   void checkpointsWrittenToS3() {
     await()
         .atMost(E2eContext.POLL_TIMEOUT)
@@ -248,6 +288,11 @@ class StateFunK8sE2E {
                   .extracting(CounterResult::getTotal)
                   .contains(expectedTotal);
             });
+  }
+
+  private static byte[] headerValue(ConsumerRecord<String, byte[]> record, String key) {
+    org.apache.kafka.common.header.Header header = record.headers().lastHeader(key);
+    return header == null ? null : header.value();
   }
 
   private static CounterResult parseCounterResult(byte[] bytes) {

--- a/statefun-e2e-tests/statefun-e2e-k8s-native/src/test/resources/k8s/module-configmap.yaml
+++ b/statefun-e2e-tests/statefun-e2e-k8s-native/src/test/resources/k8s/module-configmap.yaml
@@ -59,6 +59,7 @@ data:
       topics:
         - topic: counter.commands
           valueType: io.github.kzmlabs.statefun.e2e/CounterCommand
+          forwardHeaders: true
           targets:
             - counter.kafka/fn
     ---

--- a/statefun-flink/statefun-flink-io-bundle/src/main/java/org/apache/flink/statefun/flink/io/common/AutoRoutableProtobufRouter.java
+++ b/statefun-flink/statefun-flink-io-bundle/src/main/java/org/apache/flink/statefun/flink/io/common/AutoRoutableProtobufRouter.java
@@ -49,15 +49,18 @@ public final class AutoRoutableProtobufRouter implements Router<Message> {
   }
 
   private static TypedValue typedValuePayload(String typeUrl, AutoRoutable routable) {
-    return TypedValue.newBuilder()
-        .setTypename(typeUrl)
-        .setHasValue(true)
-        .setValue(routable.getPayloadBytes())
-        .addAllMetadata(
-            routable.getHeadersList().stream()
-                .map(AutoRoutableProtobufRouter::toMetadata)
-                .toList())
-        .build();
+    final TypedValue.Builder payload =
+        TypedValue.newBuilder()
+            .setTypename(typeUrl)
+            .setHasValue(true)
+            .setValue(routable.getPayloadBytes());
+    if (routable.getHeadersCount() > 0) {
+      payload.addAllMetadata(
+          routable.getHeadersList().stream()
+              .map(AutoRoutableProtobufRouter::toMetadata)
+              .toList());
+    }
+    return payload.build();
   }
 
   private static TypedValue.Metadata toMetadata(Header header) {

--- a/statefun-flink/statefun-flink-io-bundle/src/main/java/org/apache/flink/statefun/flink/io/common/AutoRoutableProtobufRouter.java
+++ b/statefun-flink/statefun-flink-io-bundle/src/main/java/org/apache/flink/statefun/flink/io/common/AutoRoutableProtobufRouter.java
@@ -3,9 +3,9 @@
 
 package org.apache.flink.statefun.flink.io.common;
 
-import com.google.protobuf.ByteString;
 import com.google.protobuf.Message;
 import org.apache.flink.statefun.flink.io.generated.AutoRoutable;
+import org.apache.flink.statefun.flink.io.generated.Header;
 import org.apache.flink.statefun.flink.io.generated.RoutingConfig;
 import org.apache.flink.statefun.flink.io.generated.TargetFunctionType;
 import org.apache.flink.statefun.sdk.FunctionType;
@@ -29,11 +29,9 @@ public final class AutoRoutableProtobufRouter implements Router<Message> {
   public void route(Message message, Downstream<Message> downstream) {
     final AutoRoutable routable = asAutoRoutable(message);
     final RoutingConfig config = routable.getConfig();
+    final TypedValue payload = typedValuePayload(config.getTypeUrl(), routable);
     for (TargetFunctionType targetFunction : config.getTargetFunctionTypesList()) {
-      downstream.forward(
-          sdkFunctionType(targetFunction),
-          routable.getId(),
-          typedValuePayload(config.getTypeUrl(), routable.getPayloadBytes()));
+      downstream.forward(sdkFunctionType(targetFunction), routable.getId(), payload);
     }
   }
 
@@ -50,11 +48,16 @@ public final class AutoRoutableProtobufRouter implements Router<Message> {
     return new FunctionType(targetFunctionType.getNamespace(), targetFunctionType.getType());
   }
 
-  private static TypedValue typedValuePayload(String typeUrl, ByteString payloadBytes) {
-    return TypedValue.newBuilder()
-        .setTypename(typeUrl)
-        .setHasValue(true)
-        .setValue(payloadBytes)
-        .build();
+  private static TypedValue typedValuePayload(String typeUrl, AutoRoutable routable) {
+    final TypedValue.Builder payload =
+        TypedValue.newBuilder()
+            .setTypename(typeUrl)
+            .setHasValue(true)
+            .setValue(routable.getPayloadBytes());
+    for (Header header : routable.getHeadersList()) {
+      payload.addMetadata(
+          TypedValue.Metadata.newBuilder().setKey(header.getKey()).setValue(header.getValue()));
+    }
+    return payload.build();
   }
 }

--- a/statefun-flink/statefun-flink-io-bundle/src/main/java/org/apache/flink/statefun/flink/io/common/AutoRoutableProtobufRouter.java
+++ b/statefun-flink/statefun-flink-io-bundle/src/main/java/org/apache/flink/statefun/flink/io/common/AutoRoutableProtobufRouter.java
@@ -64,6 +64,7 @@ public final class AutoRoutableProtobufRouter implements Router<Message> {
     return TypedValue.Metadata.newBuilder()
         .setKey(header.getKey())
         .setValue(header.getValue())
+        .setHasValue(header.getHasValue())
         .build();
   }
 }

--- a/statefun-flink/statefun-flink-io-bundle/src/main/java/org/apache/flink/statefun/flink/io/common/AutoRoutableProtobufRouter.java
+++ b/statefun-flink/statefun-flink-io-bundle/src/main/java/org/apache/flink/statefun/flink/io/common/AutoRoutableProtobufRouter.java
@@ -30,9 +30,9 @@ public final class AutoRoutableProtobufRouter implements Router<Message> {
     final AutoRoutable routable = asAutoRoutable(message);
     final RoutingConfig config = routable.getConfig();
     final TypedValue payload = typedValuePayload(config.getTypeUrl(), routable);
-    for (TargetFunctionType targetFunction : config.getTargetFunctionTypesList()) {
-      downstream.forward(sdkFunctionType(targetFunction), routable.getId(), payload);
-    }
+    config
+        .getTargetFunctionTypesList()
+        .forEach(target -> downstream.forward(sdkFunctionType(target), routable.getId(), payload));
   }
 
   private static AutoRoutable asAutoRoutable(Message message) {
@@ -49,15 +49,21 @@ public final class AutoRoutableProtobufRouter implements Router<Message> {
   }
 
   private static TypedValue typedValuePayload(String typeUrl, AutoRoutable routable) {
-    final TypedValue.Builder payload =
-        TypedValue.newBuilder()
-            .setTypename(typeUrl)
-            .setHasValue(true)
-            .setValue(routable.getPayloadBytes());
-    for (Header header : routable.getHeadersList()) {
-      payload.addMetadata(
-          TypedValue.Metadata.newBuilder().setKey(header.getKey()).setValue(header.getValue()));
-    }
-    return payload.build();
+    return TypedValue.newBuilder()
+        .setTypename(typeUrl)
+        .setHasValue(true)
+        .setValue(routable.getPayloadBytes())
+        .addAllMetadata(
+            routable.getHeadersList().stream()
+                .map(AutoRoutableProtobufRouter::toMetadata)
+                .toList())
+        .build();
+  }
+
+  private static TypedValue.Metadata toMetadata(Header header) {
+    return TypedValue.Metadata.newBuilder()
+        .setKey(header.getKey())
+        .setValue(header.getValue())
+        .build();
   }
 }

--- a/statefun-flink/statefun-flink-io-bundle/src/main/java/org/apache/flink/statefun/flink/io/kafka/binders/egress/v1/GenericKafkaEgressSerializer.java
+++ b/statefun-flink/statefun-flink-io-bundle/src/main/java/org/apache/flink/statefun/flink/io/kafka/binders/egress/v1/GenericKafkaEgressSerializer.java
@@ -54,9 +54,10 @@ public final class GenericKafkaEgressSerializer implements KafkaEgressSerializer
       producerRecord =
           new ProducerRecord<>(topic, key.getBytes(StandardCharsets.UTF_8), valueBytes);
     }
-    for (KafkaProducerRecord.Header header : protobufProducerRecord.getHeadersList()) {
-      producerRecord.headers().add(header.getKey(), header.getValue().toByteArray());
-    }
+    protobufProducerRecord
+        .getHeadersList()
+        .forEach(
+            header -> producerRecord.headers().add(header.getKey(), header.getValue().toByteArray()));
     return producerRecord;
   }
 }

--- a/statefun-flink/statefun-flink-io-bundle/src/main/java/org/apache/flink/statefun/flink/io/kafka/binders/egress/v1/GenericKafkaEgressSerializer.java
+++ b/statefun-flink/statefun-flink-io-bundle/src/main/java/org/apache/flink/statefun/flink/io/kafka/binders/egress/v1/GenericKafkaEgressSerializer.java
@@ -57,7 +57,12 @@ public final class GenericKafkaEgressSerializer implements KafkaEgressSerializer
     protobufProducerRecord
         .getHeadersList()
         .forEach(
-            header -> producerRecord.headers().add(header.getKey(), header.getValue().toByteArray()));
+            header ->
+                producerRecord
+                    .headers()
+                    .add(
+                        header.getKey(),
+                        header.getHasValue() ? header.getValue().toByteArray() : null));
     return producerRecord;
   }
 }

--- a/statefun-flink/statefun-flink-io-bundle/src/main/java/org/apache/flink/statefun/flink/io/kafka/binders/egress/v1/GenericKafkaEgressSerializer.java
+++ b/statefun-flink/statefun-flink-io-bundle/src/main/java/org/apache/flink/statefun/flink/io/kafka/binders/egress/v1/GenericKafkaEgressSerializer.java
@@ -54,15 +54,17 @@ public final class GenericKafkaEgressSerializer implements KafkaEgressSerializer
       producerRecord =
           new ProducerRecord<>(topic, key.getBytes(StandardCharsets.UTF_8), valueBytes);
     }
-    protobufProducerRecord
-        .getHeadersList()
-        .forEach(
-            header ->
-                producerRecord
-                    .headers()
-                    .add(
-                        header.getKey(),
-                        header.getHasValue() ? header.getValue().toByteArray() : null));
+    if (protobufProducerRecord.getHeadersCount() > 0) {
+      protobufProducerRecord
+          .getHeadersList()
+          .forEach(
+              header ->
+                  producerRecord
+                      .headers()
+                      .add(
+                          header.getKey(),
+                          header.getHasValue() ? header.getValue().toByteArray() : null));
+    }
     return producerRecord;
   }
 }

--- a/statefun-flink/statefun-flink-io-bundle/src/main/java/org/apache/flink/statefun/flink/io/kafka/binders/egress/v1/GenericKafkaEgressSerializer.java
+++ b/statefun-flink/statefun-flink-io-bundle/src/main/java/org/apache/flink/statefun/flink/io/kafka/binders/egress/v1/GenericKafkaEgressSerializer.java
@@ -47,10 +47,16 @@ public final class GenericKafkaEgressSerializer implements KafkaEgressSerializer
     final String topic = protobufProducerRecord.getTopic();
     final byte[] valueBytes = protobufProducerRecord.getValueBytes().toByteArray();
 
+    final ProducerRecord<byte[], byte[]> producerRecord;
     if (key == null || key.isEmpty()) {
-      return new ProducerRecord<>(topic, valueBytes);
+      producerRecord = new ProducerRecord<>(topic, valueBytes);
     } else {
-      return new ProducerRecord<>(topic, key.getBytes(StandardCharsets.UTF_8), valueBytes);
+      producerRecord =
+          new ProducerRecord<>(topic, key.getBytes(StandardCharsets.UTF_8), valueBytes);
     }
+    for (KafkaProducerRecord.Header header : protobufProducerRecord.getHeadersList()) {
+      producerRecord.headers().add(header.getKey(), header.getValue().toByteArray());
+    }
+    return producerRecord;
   }
 }

--- a/statefun-flink/statefun-flink-io-bundle/src/main/java/org/apache/flink/statefun/flink/io/kafka/binders/ingress/v1/RoutableKafkaIngressBinderV1.java
+++ b/statefun-flink/statefun-flink-io-bundle/src/main/java/org/apache/flink/statefun/flink/io/kafka/binders/ingress/v1/RoutableKafkaIngressBinderV1.java
@@ -27,9 +27,11 @@ import org.apache.flink.statefun.sdk.spi.StatefulFunctionModule;
  *   id: com.foo.bar/my-ingress                                       (typename)
  *   address: kafka-broker:9092                                       (string, optional)
  *   consumerGroupId: my-group-id                                     (string, optional)
+ *   forwardHeaders: true                                             (boolean, optional, default false)
  *   topics:                                                          (array)
  *   - topic: topic-1                                                 (string)
  *     valueType: com.foo.bar/my-type-1                               (typename)
+ *     forwardHeaders: false                                          (boolean, optional, overrides ingress-level)
  *     targets:                                                       (array)
  *       - com.mycomp.foo/function-1                                  (typename)
  *       - ...

--- a/statefun-flink/statefun-flink-io-bundle/src/main/java/org/apache/flink/statefun/flink/io/kafka/binders/ingress/v1/RoutableKafkaIngressDeserializer.java
+++ b/statefun-flink/statefun-flink-io-bundle/src/main/java/org/apache/flink/statefun/flink/io/kafka/binders/ingress/v1/RoutableKafkaIngressDeserializer.java
@@ -40,15 +40,19 @@ public final class RoutableKafkaIngressDeserializer
       throw new IllegalStateException(
           "Consumed a record from topic [" + topic + "], but no routing config was specified.");
     }
-    return AutoRoutable.newBuilder()
-        .setConfig(routingConfig)
-        .setId(id)
-        .setPayloadBytes(MoreByteStrings.wrap(payload))
-        .addAllHeaders(
-            StreamSupport.stream(input.headers().spliterator(), false)
-                .map(RoutableKafkaIngressDeserializer::toProtoHeader)
-                .toList())
-        .build();
+    final AutoRoutable.Builder routable =
+        AutoRoutable.newBuilder()
+            .setConfig(routingConfig)
+            .setId(id)
+            .setPayloadBytes(MoreByteStrings.wrap(payload));
+    // guard keeps the per-record hot path allocation-free for the common header-less case
+    if (input.headers().iterator().hasNext()) {
+      routable.addAllHeaders(
+          StreamSupport.stream(input.headers().spliterator(), false)
+              .map(RoutableKafkaIngressDeserializer::toProtoHeader)
+              .toList());
+    }
+    return routable.build();
   }
 
   private static Header toProtoHeader(org.apache.kafka.common.header.Header header) {

--- a/statefun-flink/statefun-flink-io-bundle/src/main/java/org/apache/flink/statefun/flink/io/kafka/binders/ingress/v1/RoutableKafkaIngressDeserializer.java
+++ b/statefun-flink/statefun-flink-io-bundle/src/main/java/org/apache/flink/statefun/flink/io/kafka/binders/ingress/v1/RoutableKafkaIngressDeserializer.java
@@ -2,7 +2,6 @@
 // Copyright 2014 The Apache Software Foundation
 package org.apache.flink.statefun.flink.io.kafka.binders.ingress.v1;
 
-import com.google.protobuf.ByteString;
 import com.google.protobuf.Message;
 import com.google.protobuf.MoreByteStrings;
 import java.nio.charset.StandardCharsets;
@@ -53,11 +52,13 @@ public final class RoutableKafkaIngressDeserializer
   }
 
   private static Header toProtoHeader(org.apache.kafka.common.header.Header header) {
+    final String key = header.key();
     final byte[] value = header.value();
-    return Header.newBuilder()
-        .setKey(header.key())
-        .setValue(value == null ? ByteString.EMPTY : MoreByteStrings.wrap(value))
-        .build();
+    final Header.Builder proto = Header.newBuilder().setKey(key == null ? "" : key);
+    if (value != null) {
+      proto.setValue(MoreByteStrings.wrap(value)).setHasValue(true);
+    }
+    return proto.build();
   }
 
   private byte[] requireNonNullKey(byte[] key) {

--- a/statefun-flink/statefun-flink-io-bundle/src/main/java/org/apache/flink/statefun/flink/io/kafka/binders/ingress/v1/RoutableKafkaIngressDeserializer.java
+++ b/statefun-flink/statefun-flink-io-bundle/src/main/java/org/apache/flink/statefun/flink/io/kafka/binders/ingress/v1/RoutableKafkaIngressDeserializer.java
@@ -7,6 +7,7 @@ import com.google.protobuf.Message;
 import com.google.protobuf.MoreByteStrings;
 import java.nio.charset.StandardCharsets;
 import java.util.Map;
+import java.util.stream.StreamSupport;
 import org.apache.flink.statefun.flink.io.generated.AutoRoutable;
 import org.apache.flink.statefun.flink.io.generated.Header;
 import org.apache.flink.statefun.flink.io.generated.RoutingConfig;
@@ -40,20 +41,23 @@ public final class RoutableKafkaIngressDeserializer
       throw new IllegalStateException(
           "Consumed a record from topic [" + topic + "], but no routing config was specified.");
     }
-    final AutoRoutable.Builder routable =
-        AutoRoutable.newBuilder()
-            .setConfig(routingConfig)
-            .setId(id)
-            .setPayloadBytes(MoreByteStrings.wrap(payload));
-    for (org.apache.kafka.common.header.Header header : input.headers()) {
-      final byte[] headerValue = header.value();
-      routable.addHeaders(
-          Header.newBuilder()
-              .setKey(header.key())
-              .setValue(
-                  headerValue == null ? ByteString.EMPTY : MoreByteStrings.wrap(headerValue)));
-    }
-    return routable.build();
+    return AutoRoutable.newBuilder()
+        .setConfig(routingConfig)
+        .setId(id)
+        .setPayloadBytes(MoreByteStrings.wrap(payload))
+        .addAllHeaders(
+            StreamSupport.stream(input.headers().spliterator(), false)
+                .map(RoutableKafkaIngressDeserializer::toProtoHeader)
+                .toList())
+        .build();
+  }
+
+  private static Header toProtoHeader(org.apache.kafka.common.header.Header header) {
+    final byte[] value = header.value();
+    return Header.newBuilder()
+        .setKey(header.key())
+        .setValue(value == null ? ByteString.EMPTY : MoreByteStrings.wrap(value))
+        .build();
   }
 
   private byte[] requireNonNullKey(byte[] key) {

--- a/statefun-flink/statefun-flink-io-bundle/src/main/java/org/apache/flink/statefun/flink/io/kafka/binders/ingress/v1/RoutableKafkaIngressDeserializer.java
+++ b/statefun-flink/statefun-flink-io-bundle/src/main/java/org/apache/flink/statefun/flink/io/kafka/binders/ingress/v1/RoutableKafkaIngressDeserializer.java
@@ -2,11 +2,13 @@
 // Copyright 2014 The Apache Software Foundation
 package org.apache.flink.statefun.flink.io.kafka.binders.ingress.v1;
 
+import com.google.protobuf.ByteString;
 import com.google.protobuf.Message;
 import com.google.protobuf.MoreByteStrings;
 import java.nio.charset.StandardCharsets;
 import java.util.Map;
 import org.apache.flink.statefun.flink.io.generated.AutoRoutable;
+import org.apache.flink.statefun.flink.io.generated.Header;
 import org.apache.flink.statefun.flink.io.generated.RoutingConfig;
 import org.apache.flink.statefun.sdk.TypeName;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
@@ -38,11 +40,20 @@ public final class RoutableKafkaIngressDeserializer
       throw new IllegalStateException(
           "Consumed a record from topic [" + topic + "], but no routing config was specified.");
     }
-    return AutoRoutable.newBuilder()
-        .setConfig(routingConfig)
-        .setId(id)
-        .setPayloadBytes(MoreByteStrings.wrap(payload))
-        .build();
+    final AutoRoutable.Builder routable =
+        AutoRoutable.newBuilder()
+            .setConfig(routingConfig)
+            .setId(id)
+            .setPayloadBytes(MoreByteStrings.wrap(payload));
+    for (org.apache.kafka.common.header.Header header : input.headers()) {
+      final byte[] headerValue = header.value();
+      routable.addHeaders(
+          Header.newBuilder()
+              .setKey(header.key())
+              .setValue(
+                  headerValue == null ? ByteString.EMPTY : MoreByteStrings.wrap(headerValue)));
+    }
+    return routable.build();
   }
 
   private byte[] requireNonNullKey(byte[] key) {

--- a/statefun-flink/statefun-flink-io-bundle/src/main/java/org/apache/flink/statefun/flink/io/kafka/binders/ingress/v1/RoutableKafkaIngressDeserializer.java
+++ b/statefun-flink/statefun-flink-io-bundle/src/main/java/org/apache/flink/statefun/flink/io/kafka/binders/ingress/v1/RoutableKafkaIngressDeserializer.java
@@ -6,6 +6,7 @@ import com.google.protobuf.Message;
 import com.google.protobuf.MoreByteStrings;
 import java.nio.charset.StandardCharsets;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.StreamSupport;
 import org.apache.flink.statefun.flink.io.generated.AutoRoutable;
 import org.apache.flink.statefun.flink.io.generated.Header;
@@ -19,13 +20,17 @@ public final class RoutableKafkaIngressDeserializer
   private static final long serialVersionUID = 1L;
 
   private final Map<String, RoutingConfig> routingConfigs;
+  private final Set<String> forwardHeaderTopics;
 
-  public RoutableKafkaIngressDeserializer(Map<String, RoutingConfig> routingConfigs) {
+  public RoutableKafkaIngressDeserializer(
+      Map<String, RoutingConfig> routingConfigs, Set<String> forwardHeaderTopics) {
     if (routingConfigs == null || routingConfigs.isEmpty()) {
       throw new IllegalArgumentException(
           "Routing config for routable Kafka ingress cannot be empty.");
     }
     this.routingConfigs = routingConfigs;
+    this.forwardHeaderTopics =
+        forwardHeaderTopics == null ? Set.of() : Set.copyOf(forwardHeaderTopics);
   }
 
   @Override
@@ -45,8 +50,9 @@ public final class RoutableKafkaIngressDeserializer
             .setConfig(routingConfig)
             .setId(id)
             .setPayloadBytes(MoreByteStrings.wrap(payload));
+    // headers are captured only for topics that opted in via forwardHeaders; the second
     // guard keeps the per-record hot path allocation-free for the common header-less case
-    if (input.headers().iterator().hasNext()) {
+    if (forwardHeaderTopics.contains(topic) && input.headers().iterator().hasNext()) {
       routable.addAllHeaders(
           StreamSupport.stream(input.headers().spliterator(), false)
               .map(RoutableKafkaIngressDeserializer::toProtoHeader)

--- a/statefun-flink/statefun-flink-io-bundle/src/main/java/org/apache/flink/statefun/flink/io/kafka/binders/ingress/v1/RoutableKafkaIngressSpec.java
+++ b/statefun-flink/statefun-flink-io-bundle/src/main/java/org/apache/flink/statefun/flink/io/kafka/binders/ingress/v1/RoutableKafkaIngressSpec.java
@@ -16,6 +16,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Properties;
+import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonCreator;
@@ -45,7 +46,8 @@ final class RoutableKafkaIngressSpec {
   private final IngressIdentifier<Message> id;
   private final Optional<String> kafkaAddress;
   private final Optional<String> consumerGroupId;
-  private final Map<String, RoutingConfig> topicRoutings;
+  private final Map<String, TopicRouting> topicRoutings;
+  private final boolean forwardHeaders;
   private final KafkaIngressAutoResetPosition autoOffsetResetPosition;
   private final KafkaIngressStartupPosition startupPosition;
   private final Properties properties;
@@ -54,7 +56,8 @@ final class RoutableKafkaIngressSpec {
       IngressIdentifier<Message> id,
       Optional<String> kafkaAddress,
       Optional<String> consumerGroupId,
-      Map<String, RoutingConfig> topicRoutings,
+      Map<String, TopicRouting> topicRoutings,
+      boolean forwardHeaders,
       KafkaIngressAutoResetPosition autoOffsetResetPosition,
       KafkaIngressStartupPosition startupPosition,
       Properties properties) {
@@ -62,6 +65,7 @@ final class RoutableKafkaIngressSpec {
     this.kafkaAddress = kafkaAddress;
     this.consumerGroupId = consumerGroupId;
     this.topicRoutings = topicRoutings;
+    this.forwardHeaders = forwardHeaders;
     this.autoOffsetResetPosition = autoOffsetResetPosition;
     this.startupPosition = startupPosition;
     this.properties = properties;
@@ -80,9 +84,46 @@ final class RoutableKafkaIngressSpec {
     builder.withStartupPosition(startupPosition);
     builder.withProperties(properties);
     KafkaIngressBuilderApiExtension.withDeserializer(
-        builder, new RoutableKafkaIngressDeserializer(topicRoutings));
+        builder,
+        new RoutableKafkaIngressDeserializer(routingConfigsByTopic(), forwardHeaderTopics()));
 
     return builder.build();
+  }
+
+  private Map<String, RoutingConfig> routingConfigsByTopic() {
+    return topicRoutings.entrySet().stream()
+        .collect(Collectors.toMap(Map.Entry::getKey, entry -> entry.getValue().config()));
+  }
+
+  Set<String> forwardHeaderTopics() {
+    return topicRoutings.entrySet().stream()
+        .filter(entry -> entry.getValue().forwardsHeaders(forwardHeaders))
+        .map(Map.Entry::getKey)
+        .collect(Collectors.toUnmodifiableSet());
+  }
+
+  /**
+   * A topic routing entry: the routing config plus the topic's optional {@code forwardHeaders}
+   * override. The effective per-topic value is the override when present, otherwise the
+   * ingress-level {@code forwardHeaders} default (which itself defaults to false — header
+   * forwarding is strictly opt-in).
+   */
+  static final class TopicRouting {
+    private final RoutingConfig config;
+    private final Boolean forwardHeadersOverride;
+
+    TopicRouting(RoutingConfig config, Boolean forwardHeadersOverride) {
+      this.config = Objects.requireNonNull(config);
+      this.forwardHeadersOverride = forwardHeadersOverride;
+    }
+
+    RoutingConfig config() {
+      return config;
+    }
+
+    boolean forwardsHeaders(boolean ingressDefault) {
+      return forwardHeadersOverride != null ? forwardHeadersOverride : ingressDefault;
+    }
   }
 
   @JsonPOJOBuilder
@@ -92,7 +133,8 @@ final class RoutableKafkaIngressSpec {
 
     private Optional<String> kafkaAddress = Optional.empty();
     private Optional<String> consumerGroupId = Optional.empty();
-    private Map<String, RoutingConfig> topicRoutings = new HashMap<>();
+    private Map<String, TopicRouting> topicRoutings = new HashMap<>();
+    private boolean forwardHeaders = false;
     private KafkaIngressAutoResetPosition autoOffsetResetPosition =
         KafkaIngressAutoResetPosition.LATEST;
     private KafkaIngressStartupPosition startupPosition = KafkaIngressStartupPosition.fromLatest();
@@ -121,8 +163,14 @@ final class RoutableKafkaIngressSpec {
 
     @JsonProperty("topics")
     @JsonDeserialize(using = TopicRoutingsJsonDeserializer.class)
-    public Builder withTopicRoutings(Map<String, RoutingConfig> topicRoutings) {
+    public Builder withTopicRoutings(Map<String, TopicRouting> topicRoutings) {
       this.topicRoutings = Objects.requireNonNull(topicRoutings);
+      return this;
+    }
+
+    @JsonProperty("forwardHeaders")
+    public Builder withForwardHeaders(boolean forwardHeaders) {
+      this.forwardHeaders = forwardHeaders;
       return this;
     }
 
@@ -154,6 +202,7 @@ final class RoutableKafkaIngressSpec {
           kafkaAddress,
           consumerGroupId,
           topicRoutings,
+          forwardHeaders,
           autoOffsetResetPosition,
           startupPosition,
           properties);
@@ -161,22 +210,29 @@ final class RoutableKafkaIngressSpec {
   }
 
   private static class TopicRoutingsJsonDeserializer
-      extends JsonDeserializer<Map<String, RoutingConfig>> {
+      extends JsonDeserializer<Map<String, TopicRouting>> {
     @Override
-    public Map<String, RoutingConfig> deserialize(
+    public Map<String, TopicRouting> deserialize(
         JsonParser jsonParser, DeserializationContext deserializationContext) throws IOException {
       final ObjectNode[] routingJsonNodes = jsonParser.readValueAs(ObjectNode[].class);
 
-      final Map<String, RoutingConfig> result = new HashMap<>(routingJsonNodes.length);
+      final Map<String, TopicRouting> result = new HashMap<>(routingJsonNodes.length);
       for (ObjectNode routingJsonNode : routingJsonNodes) {
         final RoutingConfig routingConfig =
             RoutingConfig.newBuilder()
                 .setTypeUrl(routingJsonNode.get("valueType").textValue())
                 .addAllTargetFunctionTypes(parseTargetFunctions(routingJsonNode))
                 .build();
-        result.put(routingJsonNode.get("topic").asText(), routingConfig);
+        result.put(
+            routingJsonNode.get("topic").asText(),
+            new TopicRouting(routingConfig, parseForwardHeadersOverride(routingJsonNode)));
       }
       return result;
+    }
+
+    private static Boolean parseForwardHeadersOverride(ObjectNode routingJsonNode) {
+      final JsonNode overrideNode = routingJsonNode.get("forwardHeaders");
+      return overrideNode == null || overrideNode.isNull() ? null : overrideNode.asBoolean();
     }
   }
 

--- a/statefun-flink/statefun-flink-io-bundle/src/test/java/org/apache/flink/statefun/flink/io/common/AutoRoutableProtobufRouterTest.java
+++ b/statefun-flink/statefun-flink-io-bundle/src/test/java/org/apache/flink/statefun/flink/io/common/AutoRoutableProtobufRouterTest.java
@@ -57,6 +57,7 @@ class AutoRoutableProtobufRouterTest {
     AutoRoutable routable =
         routableBuilder(TARGET_A)
             .addHeaders(header("trace-id", "abc-123"))
+            .addHeaders(Header.newBuilder().setKey("null-valued"))
             .addHeaders(header("trace-id", "def-456"))
             .build();
     CapturingDownstream downstream = new CapturingDownstream();
@@ -64,11 +65,15 @@ class AutoRoutableProtobufRouterTest {
     router.route(routable, downstream);
 
     TypedValue typedValue = (TypedValue) downstream.payloads.get(0);
-    assertThat(typedValue.getMetadataCount()).isEqualTo(2);
+    assertThat(typedValue.getMetadataCount()).isEqualTo(3);
     assertThat(typedValue.getMetadata(0).getKey()).isEqualTo("trace-id");
+    assertThat(typedValue.getMetadata(0).getHasValue()).isTrue();
     assertThat(typedValue.getMetadata(0).getValue().toStringUtf8()).isEqualTo("abc-123");
-    assertThat(typedValue.getMetadata(1).getKey()).isEqualTo("trace-id");
-    assertThat(typedValue.getMetadata(1).getValue().toStringUtf8()).isEqualTo("def-456");
+    assertThat(typedValue.getMetadata(1).getKey()).isEqualTo("null-valued");
+    assertThat(typedValue.getMetadata(1).getHasValue()).isFalse();
+    assertThat(typedValue.getMetadata(2).getKey()).isEqualTo("trace-id");
+    assertThat(typedValue.getMetadata(2).getHasValue()).isTrue();
+    assertThat(typedValue.getMetadata(2).getValue().toStringUtf8()).isEqualTo("def-456");
   }
 
   @Test
@@ -93,7 +98,11 @@ class AutoRoutableProtobufRouterTest {
   }
 
   private static Header header(String key, String utf8Value) {
-    return Header.newBuilder().setKey(key).setValue(ByteString.copyFromUtf8(utf8Value)).build();
+    return Header.newBuilder()
+        .setKey(key)
+        .setValue(ByteString.copyFromUtf8(utf8Value))
+        .setHasValue(true)
+        .build();
   }
 
   private static final class CapturingDownstream implements Router.Downstream<Message> {

--- a/statefun-flink/statefun-flink-io-bundle/src/test/java/org/apache/flink/statefun/flink/io/common/AutoRoutableProtobufRouterTest.java
+++ b/statefun-flink/statefun-flink-io-bundle/src/test/java/org/apache/flink/statefun/flink/io/common/AutoRoutableProtobufRouterTest.java
@@ -1,0 +1,114 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Kzmlabs
+package org.apache.flink.statefun.flink.io.common;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.protobuf.ByteString;
+import com.google.protobuf.Message;
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.flink.statefun.flink.io.generated.AutoRoutable;
+import org.apache.flink.statefun.flink.io.generated.Header;
+import org.apache.flink.statefun.flink.io.generated.RoutingConfig;
+import org.apache.flink.statefun.flink.io.generated.TargetFunctionType;
+import org.apache.flink.statefun.sdk.Address;
+import org.apache.flink.statefun.sdk.io.Router;
+import org.apache.flink.statefun.sdk.metrics.Metrics;
+import org.apache.flink.statefun.sdk.reqreply.generated.TypedValue;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Pins the AutoRoutable → TypedValue conversion contract of {@link AutoRoutableProtobufRouter}:
+ * the payload is forwarded to every configured target, and ingested transport headers are carried
+ * over as {@code TypedValue.metadata} so they reach remote functions unchanged.
+ */
+class AutoRoutableProtobufRouterTest {
+
+  private static final String TYPE_URL = "com.googleapis/com.mycomp.foo.OrderMessage";
+  private static final TargetFunctionType TARGET_A =
+      TargetFunctionType.newBuilder().setNamespace("ns").setType("fn-a").build();
+  private static final TargetFunctionType TARGET_B =
+      TargetFunctionType.newBuilder().setNamespace("ns").setType("fn-b").build();
+
+  private final AutoRoutableProtobufRouter router = new AutoRoutableProtobufRouter();
+
+  @Test
+  void forwardsPayloadToEveryConfiguredTarget() {
+    AutoRoutable routable = routableBuilder(TARGET_A, TARGET_B).build();
+    CapturingDownstream downstream = new CapturingDownstream();
+
+    router.route(routable, downstream);
+
+    assertThat(downstream.addresses)
+        .containsExactly(
+            new Address(new org.apache.flink.statefun.sdk.FunctionType("ns", "fn-a"), "id-1"),
+            new Address(new org.apache.flink.statefun.sdk.FunctionType("ns", "fn-b"), "id-1"));
+    for (Message forwarded : downstream.payloads) {
+      TypedValue typedValue = (TypedValue) forwarded;
+      assertThat(typedValue.getTypename()).isEqualTo(TYPE_URL);
+      assertThat(typedValue.getHasValue()).isTrue();
+      assertThat(typedValue.getValue().toStringUtf8()).isEqualTo("payload");
+    }
+  }
+
+  @Test
+  void carriesIngestedHeadersAsTypedValueMetadata() {
+    AutoRoutable routable =
+        routableBuilder(TARGET_A)
+            .addHeaders(header("trace-id", "abc-123"))
+            .addHeaders(header("trace-id", "def-456"))
+            .build();
+    CapturingDownstream downstream = new CapturingDownstream();
+
+    router.route(routable, downstream);
+
+    TypedValue typedValue = (TypedValue) downstream.payloads.get(0);
+    assertThat(typedValue.getMetadataCount()).isEqualTo(2);
+    assertThat(typedValue.getMetadata(0).getKey()).isEqualTo("trace-id");
+    assertThat(typedValue.getMetadata(0).getValue().toStringUtf8()).isEqualTo("abc-123");
+    assertThat(typedValue.getMetadata(1).getKey()).isEqualTo("trace-id");
+    assertThat(typedValue.getMetadata(1).getValue().toStringUtf8()).isEqualTo("def-456");
+  }
+
+  @Test
+  void routableWithoutHeadersProducesNoMetadata() {
+    CapturingDownstream downstream = new CapturingDownstream();
+
+    router.route(routableBuilder(TARGET_A).build(), downstream);
+
+    TypedValue typedValue = (TypedValue) downstream.payloads.get(0);
+    assertThat(typedValue.getMetadataCount()).isZero();
+  }
+
+  private static AutoRoutable.Builder routableBuilder(TargetFunctionType... targets) {
+    RoutingConfig.Builder config = RoutingConfig.newBuilder().setTypeUrl(TYPE_URL);
+    for (TargetFunctionType target : targets) {
+      config.addTargetFunctionTypes(target);
+    }
+    return AutoRoutable.newBuilder()
+        .setConfig(config)
+        .setId("id-1")
+        .setPayloadBytes(ByteString.copyFromUtf8("payload"));
+  }
+
+  private static Header header(String key, String utf8Value) {
+    return Header.newBuilder().setKey(key).setValue(ByteString.copyFromUtf8(utf8Value)).build();
+  }
+
+  private static final class CapturingDownstream implements Router.Downstream<Message> {
+    final List<Address> addresses = new ArrayList<>();
+    final List<Message> payloads = new ArrayList<>();
+
+    @Override
+    public void forward(Address to, Message message) {
+      addresses.add(to);
+      payloads.add(message);
+    }
+
+    @Override
+    public Metrics metrics() {
+      throw new UnsupportedOperationException("not used in this test");
+    }
+  }
+}

--- a/statefun-flink/statefun-flink-io-bundle/src/test/java/org/apache/flink/statefun/flink/io/kafka/binders/egress/v1/GenericKafkaEgressSerializerTest.java
+++ b/statefun-flink/statefun-flink-io-bundle/src/test/java/org/apache/flink/statefun/flink/io/kafka/binders/egress/v1/GenericKafkaEgressSerializerTest.java
@@ -66,6 +66,24 @@ class GenericKafkaEgressSerializerTest {
   }
 
   @Test
+  void nullValuedProtoHeaderIsProducedAsNullKafkaHeaderValue() {
+    KafkaProducerRecord rec =
+        KafkaProducerRecord.newBuilder()
+            .setTopic("topic-A")
+            .setValueBytes(ByteString.copyFromUtf8("v"))
+            .addHeaders(KafkaProducerRecord.Header.newBuilder().setKey("null-valued"))
+            .addHeaders(
+                KafkaProducerRecord.Header.newBuilder().setKey("explicit-empty").setHasValue(true))
+            .build();
+
+    ProducerRecord<byte[], byte[]> record =
+        serializer.serialize(TypedValueUtil.packProtobufMessage(rec));
+
+    assertThat(record.headers().lastHeader("null-valued").value()).isNull();
+    assertThat(record.headers().lastHeader("explicit-empty").value()).isEmpty();
+  }
+
+  @Test
   void recordWithoutProtoHeadersProducesNoKafkaHeaders() {
     TypedValue input = packAsKafkaRecord("topic-A", "k", "v".getBytes(StandardCharsets.UTF_8));
 
@@ -118,6 +136,7 @@ class GenericKafkaEgressSerializerTest {
     return KafkaProducerRecord.Header.newBuilder()
         .setKey(key)
         .setValue(ByteString.copyFromUtf8(utf8Value))
+        .setHasValue(true)
         .build();
   }
 

--- a/statefun-flink/statefun-flink-io-bundle/src/test/java/org/apache/flink/statefun/flink/io/kafka/binders/egress/v1/GenericKafkaEgressSerializerTest.java
+++ b/statefun-flink/statefun-flink-io-bundle/src/test/java/org/apache/flink/statefun/flink/io/kafka/binders/egress/v1/GenericKafkaEgressSerializerTest.java
@@ -41,6 +41,40 @@ class GenericKafkaEgressSerializerTest {
   }
 
   @Test
+  void copiesProtoHeadersOntoProducerRecordInOrder() {
+    KafkaProducerRecord rec =
+        KafkaProducerRecord.newBuilder()
+            .setTopic("topic-A")
+            .setKey("key-1")
+            .setValueBytes(ByteString.copyFromUtf8("v"))
+            .addHeaders(header("trace-id", "abc-123"))
+            .addHeaders(header("origin", "fn"))
+            .addHeaders(header("trace-id", "def-456"))
+            .build();
+
+    ProducerRecord<byte[], byte[]> record =
+        serializer.serialize(TypedValueUtil.packProtobufMessage(rec));
+
+    org.apache.kafka.common.header.Header[] headers = record.headers().toArray();
+    assertThat(headers).hasSize(3);
+    assertThat(headers[0].key()).isEqualTo("trace-id");
+    assertThat(headers[0].value()).isEqualTo("abc-123".getBytes(StandardCharsets.UTF_8));
+    assertThat(headers[1].key()).isEqualTo("origin");
+    assertThat(headers[1].value()).isEqualTo("fn".getBytes(StandardCharsets.UTF_8));
+    assertThat(headers[2].key()).isEqualTo("trace-id");
+    assertThat(headers[2].value()).isEqualTo("def-456".getBytes(StandardCharsets.UTF_8));
+  }
+
+  @Test
+  void recordWithoutProtoHeadersProducesNoKafkaHeaders() {
+    TypedValue input = packAsKafkaRecord("topic-A", "k", "v".getBytes(StandardCharsets.UTF_8));
+
+    ProducerRecord<byte[], byte[]> record = serializer.serialize(input);
+
+    assertThat(record.headers().toArray()).isEmpty();
+  }
+
+  @Test
   void rejectsTypedValueOfWrongProtobufType() {
     // TypedValue carrying a message that is NOT a KafkaProducerRecord.
     TypedValue notAKafkaRecord =
@@ -78,6 +112,13 @@ class GenericKafkaEgressSerializerTest {
             .readObject();
 
     assertThat(copy).isInstanceOf(GenericKafkaEgressSerializer.class);
+  }
+
+  private static KafkaProducerRecord.Header header(String key, String utf8Value) {
+    return KafkaProducerRecord.Header.newBuilder()
+        .setKey(key)
+        .setValue(ByteString.copyFromUtf8(utf8Value))
+        .build();
   }
 
   private static TypedValue packAsKafkaRecord(String topic, String key, byte[] value) {

--- a/statefun-flink/statefun-flink-io-bundle/src/test/java/org/apache/flink/statefun/flink/io/kafka/binders/ingress/v1/RoutableKafkaIngressDeserializerTest.java
+++ b/statefun-flink/statefun-flink-io-bundle/src/test/java/org/apache/flink/statefun/flink/io/kafka/binders/ingress/v1/RoutableKafkaIngressDeserializerTest.java
@@ -73,10 +73,13 @@ class RoutableKafkaIngressDeserializerTest {
 
     assertThat(routable.getHeadersCount()).isEqualTo(3);
     assertThat(routable.getHeaders(0).getKey()).isEqualTo("trace-id");
+    assertThat(routable.getHeaders(0).getHasValue()).isTrue();
     assertThat(routable.getHeaders(0).getValue().toStringUtf8()).isEqualTo("abc-123");
     assertThat(routable.getHeaders(1).getKey()).isEqualTo("empty-header");
+    assertThat(routable.getHeaders(1).getHasValue()).isFalse();
     assertThat(routable.getHeaders(1).getValue().isEmpty()).isTrue();
     assertThat(routable.getHeaders(2).getKey()).isEqualTo("trace-id");
+    assertThat(routable.getHeaders(2).getHasValue()).isTrue();
     assertThat(routable.getHeaders(2).getValue().toStringUtf8()).isEqualTo("def-456");
   }
 

--- a/statefun-flink/statefun-flink-io-bundle/src/test/java/org/apache/flink/statefun/flink/io/kafka/binders/ingress/v1/RoutableKafkaIngressDeserializerTest.java
+++ b/statefun-flink/statefun-flink-io-bundle/src/test/java/org/apache/flink/statefun/flink/io/kafka/binders/ingress/v1/RoutableKafkaIngressDeserializerTest.java
@@ -9,6 +9,7 @@ import com.google.protobuf.Message;
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
 import org.apache.flink.statefun.flink.io.generated.AutoRoutable;
 import org.apache.flink.statefun.flink.io.generated.RoutingConfig;
 import org.apache.flink.statefun.flink.io.generated.TargetFunctionType;
@@ -39,7 +40,8 @@ class RoutableKafkaIngressDeserializerTest {
   @BeforeEach
   void setUp() {
     deserializer =
-        new RoutableKafkaIngressDeserializer(routingMap(ORDERS_TOPIC, ORDERS_ROUTING));
+        new RoutableKafkaIngressDeserializer(
+            routingMap(ORDERS_TOPIC, ORDERS_ROUTING), Set.of(ORDERS_TOPIC));
   }
 
   @Test
@@ -92,6 +94,22 @@ class RoutableKafkaIngressDeserializerTest {
             "p".getBytes(StandardCharsets.UTF_8));
 
     final AutoRoutable routable = (AutoRoutable) deserializer.deserialize(record);
+
+    assertThat(routable.getHeadersCount()).isZero();
+  }
+
+  @Test
+  void headersAreIgnoredWhenTopicHasNotOptedIntoForwarding() {
+    final RoutableKafkaIngressDeserializer optedOut =
+        new RoutableKafkaIngressDeserializer(routingMap(ORDERS_TOPIC, ORDERS_ROUTING), Set.of());
+    final ConsumerRecord<byte[], byte[]> record =
+        consumerRecord(
+            ORDERS_TOPIC,
+            "pk-7".getBytes(StandardCharsets.UTF_8),
+            "p".getBytes(StandardCharsets.UTF_8));
+    record.headers().add("trace-id", "abc-123".getBytes(StandardCharsets.UTF_8));
+
+    final AutoRoutable routable = (AutoRoutable) optedOut.deserialize(record);
 
     assertThat(routable.getHeadersCount()).isZero();
   }

--- a/statefun-flink/statefun-flink-io-bundle/src/test/java/org/apache/flink/statefun/flink/io/kafka/binders/ingress/v1/RoutableKafkaIngressDeserializerTest.java
+++ b/statefun-flink/statefun-flink-io-bundle/src/test/java/org/apache/flink/statefun/flink/io/kafka/binders/ingress/v1/RoutableKafkaIngressDeserializerTest.java
@@ -59,6 +59,41 @@ class RoutableKafkaIngressDeserializerTest {
   }
 
   @Test
+  void capturesRecordHeadersInOrderIncludingNullValues() {
+    final ConsumerRecord<byte[], byte[]> record =
+        consumerRecord(
+            ORDERS_TOPIC,
+            "pk-7".getBytes(StandardCharsets.UTF_8),
+            "p".getBytes(StandardCharsets.UTF_8));
+    record.headers().add("trace-id", "abc-123".getBytes(StandardCharsets.UTF_8));
+    record.headers().add("empty-header", null);
+    record.headers().add("trace-id", "def-456".getBytes(StandardCharsets.UTF_8));
+
+    final AutoRoutable routable = (AutoRoutable) deserializer.deserialize(record);
+
+    assertThat(routable.getHeadersCount()).isEqualTo(3);
+    assertThat(routable.getHeaders(0).getKey()).isEqualTo("trace-id");
+    assertThat(routable.getHeaders(0).getValue().toStringUtf8()).isEqualTo("abc-123");
+    assertThat(routable.getHeaders(1).getKey()).isEqualTo("empty-header");
+    assertThat(routable.getHeaders(1).getValue().isEmpty()).isTrue();
+    assertThat(routable.getHeaders(2).getKey()).isEqualTo("trace-id");
+    assertThat(routable.getHeaders(2).getValue().toStringUtf8()).isEqualTo("def-456");
+  }
+
+  @Test
+  void recordWithoutHeadersProducesEmptyHeaderList() {
+    final ConsumerRecord<byte[], byte[]> record =
+        consumerRecord(
+            ORDERS_TOPIC,
+            "pk".getBytes(StandardCharsets.UTF_8),
+            "p".getBytes(StandardCharsets.UTF_8));
+
+    final AutoRoutable routable = (AutoRoutable) deserializer.deserialize(record);
+
+    assertThat(routable.getHeadersCount()).isZero();
+  }
+
+  @Test
   void throwsWhenTopicIsNotInRoutingMap() {
     final ConsumerRecord<byte[], byte[]> record =
         consumerRecord(

--- a/statefun-flink/statefun-flink-io-bundle/src/test/java/org/apache/flink/statefun/flink/io/kafka/binders/ingress/v1/RoutableKafkaIngressSpecTest.java
+++ b/statefun-flink/statefun-flink-io-bundle/src/test/java/org/apache/flink/statefun/flink/io/kafka/binders/ingress/v1/RoutableKafkaIngressSpecTest.java
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Kzmlabs
+package org.apache.flink.statefun.flink.io.kafka.binders.ingress.v1;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.JsonNode;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import org.apache.flink.statefun.flink.common.json.StateFunObjectMapper;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Pins the two-level {@code forwardHeaders} resolution contract of {@link
+ * RoutableKafkaIngressSpec}: header forwarding is opt-in (default off), an ingress-level value
+ * applies to all topics, and a per-topic value overrides the ingress-level one in either
+ * direction.
+ */
+class RoutableKafkaIngressSpecTest {
+
+  private static final ObjectMapper YAML_MAPPER = new ObjectMapper(new YAMLFactory());
+  private static final ObjectMapper SPEC_MAPPER = StateFunObjectMapper.create();
+
+  @Test
+  void headerForwardingIsOffByDefault() throws Exception {
+    RoutableKafkaIngressSpec spec = parseSpec(specYaml("", "", ""));
+
+    assertThat(spec.forwardHeaderTopics()).isEmpty();
+  }
+
+  @Test
+  void ingressLevelForwardHeadersAppliesToAllTopics() throws Exception {
+    RoutableKafkaIngressSpec spec = parseSpec(specYaml("forwardHeaders: true", "", ""));
+
+    assertThat(spec.forwardHeaderTopics()).containsExactlyInAnyOrder("topic-1", "topic-2");
+  }
+
+  @Test
+  void perTopicOverrideDisablesForwardingDespiteIngressDefault() throws Exception {
+    RoutableKafkaIngressSpec spec =
+        parseSpec(specYaml("forwardHeaders: true", "forwardHeaders: false", ""));
+
+    assertThat(spec.forwardHeaderTopics()).containsExactly("topic-2");
+  }
+
+  @Test
+  void perTopicOverrideEnablesForwardingForThatTopicOnly() throws Exception {
+    RoutableKafkaIngressSpec spec = parseSpec(specYaml("", "", "forwardHeaders: true"));
+
+    assertThat(spec.forwardHeaderTopics()).containsExactly("topic-2");
+  }
+
+  private static RoutableKafkaIngressSpec parseSpec(String yaml) throws Exception {
+    JsonNode specNode = YAML_MAPPER.readTree(yaml);
+    return SPEC_MAPPER.treeToValue(specNode, RoutableKafkaIngressSpec.class);
+  }
+
+  private static String specYaml(
+      String ingressLevelLine, String topic1Line, String topic2Line) {
+    return String.join(
+        "\n",
+        "id: com.foo.bar/test-ingress",
+        "address: kafka-broker:9092",
+        ingressLevelLine,
+        "topics:",
+        "  - topic: topic-1",
+        "    valueType: com.googleapis/com.mycomp.foo.MessageA",
+        "    " + topic1Line,
+        "    targets:",
+        "      - com.mycomp.foo/function-1",
+        "  - topic: topic-2",
+        "    valueType: com.googleapis/com.mycomp.foo.MessageB",
+        "    " + topic2Line,
+        "    targets:",
+        "      - com.mycomp.foo/function-2");
+  }
+}

--- a/statefun-flink/statefun-flink-io/src/main/protobuf/routable.proto
+++ b/statefun-flink/statefun-flink-io/src/main/protobuf/routable.proto
@@ -19,6 +19,9 @@ message AutoRoutable {
 message Header {
     string key = 1;
     bytes value = 2;
+    // has_value=false means the ingested transport header had a null value
+    // (legal in Kafka), as opposed to an explicitly empty one.
+    bool has_value = 3;
 }
 
 message RoutingConfig {

--- a/statefun-flink/statefun-flink-io/src/main/protobuf/routable.proto
+++ b/statefun-flink/statefun-flink-io/src/main/protobuf/routable.proto
@@ -11,6 +11,14 @@ message AutoRoutable {
     RoutingConfig config = 1;
     string id = 2;
     bytes payload_bytes = 3;
+    // Transport-level headers of the ingested record (e.g. Kafka record headers).
+    // Duplicate keys are allowed and order is preserved.
+    repeated Header headers = 4;
+}
+
+message Header {
+    string key = 1;
+    bytes value = 2;
 }
 
 message RoutingConfig {

--- a/statefun-sdk-java/src/main/java/org/apache/flink/statefun/sdk/java/io/KafkaEgressMessage.java
+++ b/statefun-sdk-java/src/main/java/org/apache/flink/statefun/sdk/java/io/KafkaEgressMessage.java
@@ -14,6 +14,7 @@ import org.apache.flink.statefun.sdk.java.slice.Slice;
 import org.apache.flink.statefun.sdk.java.slice.SliceProtobufUtil;
 import org.apache.flink.statefun.sdk.java.types.Type;
 import org.apache.flink.statefun.sdk.java.types.TypeSerializer;
+import org.apache.flink.statefun.sdk.java.types.Types;
 import org.apache.flink.statefun.sdk.reqreply.generated.TypedValue;
 import org.apache.flink.statefun.sdk.shaded.com.google.protobuf.ByteString;
 
@@ -119,6 +120,28 @@ public final class KafkaEgressMessage {
       }
       TypeSerializer<T> serializer = type.typeSerializer();
       return withHeader(key, serializer.serialize(value));
+    }
+
+    /**
+     * Primitive convenience overloads transfer the actual binary number (the SDK {@code Types}
+     * encoding), equivalent to {@code withHeader(key, Types.integerType(), value)} — no text
+     * round-trip. Read back with the matching {@code MessageHeader#valueAsInt()}-style accessor.
+     * For text headers readable by generic Kafka tooling, use {@link #withUtf8Header}.
+     */
+    public Builder withHeader(String key, int value) {
+      return withHeader(key, Types.integerType(), value);
+    }
+
+    public Builder withHeader(String key, long value) {
+      return withHeader(key, Types.longType(), value);
+    }
+
+    public Builder withHeader(String key, double value) {
+      return withHeader(key, Types.doubleType(), value);
+    }
+
+    public Builder withHeader(String key, boolean value) {
+      return withHeader(key, Types.booleanType(), value);
     }
 
     private Builder addHeader(String key, ByteString valueOrNull) {

--- a/statefun-sdk-java/src/main/java/org/apache/flink/statefun/sdk/java/io/KafkaEgressMessage.java
+++ b/statefun-sdk-java/src/main/java/org/apache/flink/statefun/sdk/java/io/KafkaEgressMessage.java
@@ -96,36 +96,41 @@ public final class KafkaEgressMessage {
     }
 
     /**
-     * Header values are null-tolerant: Kafka permits headers without a value, so a {@code null}
-     * value is carried as empty bytes (protobuf cannot represent null) instead of failing the
-     * build. Header keys must be non-null, matching Kafka's own contract.
+     * Header inserts never fail: headers are metadata and must not corrupt a production send. A
+     * null value is preserved as a null-valued Kafka header ({@code has_value=false}), which Kafka
+     * legally supports; a null key degrades to an empty key (Kafka itself forbids null keys, so
+     * passing one through would fail at produce time inside the running job).
      */
     public Builder withUtf8Header(String key, String value) {
-      return addHeader(key, value == null ? ByteString.EMPTY : ByteString.copyFromUtf8(value));
+      return addHeader(key, value == null ? null : ByteString.copyFromUtf8(value));
     }
 
     public Builder withHeader(String key, byte[] value) {
-      return addHeader(key, value == null ? ByteString.EMPTY : ByteString.copyFrom(value));
+      return addHeader(key, value == null ? null : ByteString.copyFrom(value));
     }
 
     public Builder withHeader(String key, Slice value) {
-      return addHeader(key, value == null ? ByteString.EMPTY : SliceProtobufUtil.asByteString(value));
+      return addHeader(key, value == null ? null : SliceProtobufUtil.asByteString(value));
     }
 
     public <T> Builder withHeader(String key, Type<T> type, T value) {
-      if (value == null) {
-        return addHeader(key, ByteString.EMPTY);
+      if (type == null || value == null) {
+        return addHeader(key, null);
       }
       TypeSerializer<T> serializer = type.typeSerializer();
       return withHeader(key, serializer.serialize(value));
     }
 
-    private Builder addHeader(String key, ByteString value) {
-      Objects.requireNonNull(key);
+    private Builder addHeader(String key, ByteString valueOrNull) {
       if (headers == null) {
         headers = new ArrayList<>();
       }
-      headers.add(KafkaProducerRecord.Header.newBuilder().setKey(key).setValue(value).build());
+      KafkaProducerRecord.Header.Builder header =
+          KafkaProducerRecord.Header.newBuilder().setKey(key == null ? "" : key);
+      if (valueOrNull != null) {
+        header.setValue(valueOrNull).setHasValue(true);
+      }
+      headers.add(header.build());
       return this;
     }
 

--- a/statefun-sdk-java/src/main/java/org/apache/flink/statefun/sdk/java/io/KafkaEgressMessage.java
+++ b/statefun-sdk-java/src/main/java/org/apache/flink/statefun/sdk/java/io/KafkaEgressMessage.java
@@ -2,6 +2,8 @@
 // Copyright 2014 The Apache Software Foundation
 package org.apache.flink.statefun.sdk.java.io;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Objects;
 import org.apache.flink.statefun.sdk.egress.generated.KafkaProducerRecord;
 import org.apache.flink.statefun.sdk.java.ApiExtension;
@@ -31,6 +33,7 @@ public final class KafkaEgressMessage {
     private ByteString targetTopic;
     private ByteString keyBytes;
     private ByteString value;
+    private List<KafkaProducerRecord.Header> headers;
 
     private Builder(TypeName targetEgressId) {
       this.targetEgressId = targetEgressId;
@@ -92,6 +95,30 @@ public final class KafkaEgressMessage {
       return this;
     }
 
+    public Builder withUtf8Header(String key, String value) {
+      Objects.requireNonNull(value);
+      return addHeader(key, ByteString.copyFromUtf8(value));
+    }
+
+    public Builder withHeader(String key, byte[] value) {
+      Objects.requireNonNull(value);
+      return addHeader(key, ByteString.copyFrom(value));
+    }
+
+    public Builder withHeader(String key, Slice value) {
+      Objects.requireNonNull(value);
+      return addHeader(key, SliceProtobufUtil.asByteString(value));
+    }
+
+    private Builder addHeader(String key, ByteString value) {
+      Objects.requireNonNull(key);
+      if (headers == null) {
+        headers = new ArrayList<>();
+      }
+      headers.add(KafkaProducerRecord.Header.newBuilder().setKey(key).setValue(value).build());
+      return this;
+    }
+
     public EgressMessage build() {
       if (targetTopic == null) {
         throw new IllegalStateException("A Kafka record requires a target topic.");
@@ -103,6 +130,9 @@ public final class KafkaEgressMessage {
           KafkaProducerRecord.newBuilder().setTopicBytes(targetTopic).setValueBytes(value);
       if (keyBytes != null) {
         builder.setKeyBytes(keyBytes);
+      }
+      if (headers != null) {
+        builder.addAllHeaders(headers);
       }
       KafkaProducerRecord record = builder.build();
       TypedValue typedValue =

--- a/statefun-sdk-java/src/main/java/org/apache/flink/statefun/sdk/java/io/KafkaEgressMessage.java
+++ b/statefun-sdk-java/src/main/java/org/apache/flink/statefun/sdk/java/io/KafkaEgressMessage.java
@@ -95,22 +95,27 @@ public final class KafkaEgressMessage {
       return this;
     }
 
+    /**
+     * Header values are null-tolerant: Kafka permits headers without a value, so a {@code null}
+     * value is carried as empty bytes (protobuf cannot represent null) instead of failing the
+     * build. Header keys must be non-null, matching Kafka's own contract.
+     */
     public Builder withUtf8Header(String key, String value) {
-      Objects.requireNonNull(value);
-      return addHeader(key, ByteString.copyFromUtf8(value));
+      return addHeader(key, value == null ? ByteString.EMPTY : ByteString.copyFromUtf8(value));
     }
 
     public Builder withHeader(String key, byte[] value) {
-      Objects.requireNonNull(value);
-      return addHeader(key, ByteString.copyFrom(value));
+      return addHeader(key, value == null ? ByteString.EMPTY : ByteString.copyFrom(value));
     }
 
     public Builder withHeader(String key, Slice value) {
-      Objects.requireNonNull(value);
-      return addHeader(key, SliceProtobufUtil.asByteString(value));
+      return addHeader(key, value == null ? ByteString.EMPTY : SliceProtobufUtil.asByteString(value));
     }
 
     public <T> Builder withHeader(String key, Type<T> type, T value) {
+      if (value == null) {
+        return addHeader(key, ByteString.EMPTY);
+      }
       TypeSerializer<T> serializer = type.typeSerializer();
       return withHeader(key, serializer.serialize(value));
     }

--- a/statefun-sdk-java/src/main/java/org/apache/flink/statefun/sdk/java/io/KafkaEgressMessage.java
+++ b/statefun-sdk-java/src/main/java/org/apache/flink/statefun/sdk/java/io/KafkaEgressMessage.java
@@ -110,6 +110,11 @@ public final class KafkaEgressMessage {
       return addHeader(key, SliceProtobufUtil.asByteString(value));
     }
 
+    public <T> Builder withHeader(String key, Type<T> type, T value) {
+      TypeSerializer<T> serializer = type.typeSerializer();
+      return withHeader(key, serializer.serialize(value));
+    }
+
     private Builder addHeader(String key, ByteString value) {
       Objects.requireNonNull(key);
       if (headers == null) {

--- a/statefun-sdk-java/src/main/java/org/apache/flink/statefun/sdk/java/io/KafkaEgressMessage.java
+++ b/statefun-sdk-java/src/main/java/org/apache/flink/statefun/sdk/java/io/KafkaEgressMessage.java
@@ -136,6 +136,10 @@ public final class KafkaEgressMessage {
       return withHeader(key, Types.longType(), value);
     }
 
+    public Builder withHeader(String key, float value) {
+      return withHeader(key, Types.floatType(), value);
+    }
+
     public Builder withHeader(String key, double value) {
       return withHeader(key, Types.doubleType(), value);
     }

--- a/statefun-sdk-java/src/main/java/org/apache/flink/statefun/sdk/java/message/Message.java
+++ b/statefun-sdk-java/src/main/java/org/apache/flink/statefun/sdk/java/message/Message.java
@@ -3,6 +3,8 @@
 
 package org.apache.flink.statefun.sdk.java.message;
 
+import java.util.Collections;
+import java.util.List;
 import org.apache.flink.statefun.sdk.java.Address;
 import org.apache.flink.statefun.sdk.java.TypeName;
 import org.apache.flink.statefun.sdk.java.slice.Slice;
@@ -10,6 +12,15 @@ import org.apache.flink.statefun.sdk.java.types.Type;
 
 public interface Message {
   Address targetAddress();
+
+  /**
+   * Transport-level headers attached to this message. For messages delivered from a Kafka
+   * ingress, these are the headers of the consumed Kafka record. Messages without headers (for
+   * example function-to-function messages) return an empty list.
+   */
+  default List<MessageHeader> headers() {
+    return Collections.emptyList();
+  }
 
   boolean isLong();
 

--- a/statefun-sdk-java/src/main/java/org/apache/flink/statefun/sdk/java/message/MessageBuilder.java
+++ b/statefun-sdk-java/src/main/java/org/apache/flink/statefun/sdk/java/message/MessageBuilder.java
@@ -75,6 +75,61 @@ public final class MessageBuilder {
     return withTargetAddress(new Address(typeName, id));
   }
 
+  /**
+   * Attaches a transport-level header to the built message, readable via {@link
+   * Message#headers()} — the primary way to construct header-carrying messages in tests. Same
+   * never-throw contract as the Kafka egress builder: a null value is preserved as a null-valued
+   * header, a null key degrades to an empty key.
+   */
+  public MessageBuilder withUtf8Header(String key, String value) {
+    return addHeader(key, value == null ? null : ByteString.copyFromUtf8(value));
+  }
+
+  public MessageBuilder withHeader(String key, byte[] value) {
+    return addHeader(key, value == null ? null : ByteString.copyFrom(value));
+  }
+
+  public MessageBuilder withHeader(String key, Slice value) {
+    return addHeader(key, value == null ? null : SliceProtobufUtil.asByteString(value));
+  }
+
+  public <T> MessageBuilder withHeader(String key, Type<T> type, T value) {
+    if (type == null || value == null) {
+      return addHeader(key, null);
+    }
+    return withHeader(key, type.typeSerializer().serialize(value));
+  }
+
+  public MessageBuilder withHeader(String key, int value) {
+    return withHeader(key, Types.integerType(), value);
+  }
+
+  public MessageBuilder withHeader(String key, long value) {
+    return withHeader(key, Types.longType(), value);
+  }
+
+  public MessageBuilder withHeader(String key, float value) {
+    return withHeader(key, Types.floatType(), value);
+  }
+
+  public MessageBuilder withHeader(String key, double value) {
+    return withHeader(key, Types.doubleType(), value);
+  }
+
+  public MessageBuilder withHeader(String key, boolean value) {
+    return withHeader(key, Types.booleanType(), value);
+  }
+
+  private MessageBuilder addHeader(String key, ByteString valueOrNull) {
+    TypedValue.Metadata.Builder metadata =
+        TypedValue.Metadata.newBuilder().setKey(key == null ? "" : key);
+    if (valueOrNull != null) {
+      metadata.setValue(valueOrNull).setHasValue(true);
+    }
+    builder.addMetadata(metadata);
+    return this;
+  }
+
   public <T> MessageBuilder withCustomType(Type<T> customType, T element) {
     Objects.requireNonNull(customType);
     Objects.requireNonNull(element);
@@ -94,9 +149,20 @@ public final class MessageBuilder {
   private static TypedValue.Builder typedValueBuilder(Message message) {
     ByteString typenameBytes = ApiExtension.typeNameByteString(message.valueTypeName());
     ByteString valueBytes = SliceProtobufUtil.asByteString(message.rawValue());
-    return TypedValue.newBuilder()
-        .setTypenameBytes(typenameBytes)
-        .setHasValue(true)
-        .setValue(valueBytes);
+    TypedValue.Builder typedValue =
+        TypedValue.newBuilder()
+            .setTypenameBytes(typenameBytes)
+            .setHasValue(true)
+            .setValue(valueBytes);
+    message.headers().forEach(header -> typedValue.addMetadata(asMetadata(header)));
+    return typedValue;
+  }
+
+  private static TypedValue.Metadata asMetadata(MessageHeader header) {
+    TypedValue.Metadata.Builder metadata = TypedValue.Metadata.newBuilder().setKey(header.key());
+    if (header.hasValue()) {
+      metadata.setValue(SliceProtobufUtil.asByteString(header.value())).setHasValue(true);
+    }
+    return metadata.build();
   }
 }

--- a/statefun-sdk-java/src/main/java/org/apache/flink/statefun/sdk/java/message/MessageHeader.java
+++ b/statefun-sdk-java/src/main/java/org/apache/flink/statefun/sdk/java/message/MessageHeader.java
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Kzmlabs
+package org.apache.flink.statefun.sdk.java.message;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Objects;
+import org.apache.flink.statefun.sdk.java.slice.Slice;
+
+/**
+ * A single transport-level header attached to an incoming {@link Message}, e.g. a Kafka record
+ * header of the record that produced this message. Header keys are not unique: multiple headers
+ * may share the same key, and their original order is preserved.
+ */
+public final class MessageHeader {
+  private final String key;
+  private final Slice value;
+
+  public MessageHeader(String key, Slice value) {
+    this.key = Objects.requireNonNull(key);
+    this.value = Objects.requireNonNull(value);
+  }
+
+  public String key() {
+    return key;
+  }
+
+  public Slice value() {
+    return value;
+  }
+
+  public String valueAsUtf8String() {
+    return new String(value.toByteArray(), StandardCharsets.UTF_8);
+  }
+
+  @Override
+  public String toString() {
+    return "MessageHeader{key='" + key + "', value=" + value.readableBytes() + " bytes}";
+  }
+}

--- a/statefun-sdk-java/src/main/java/org/apache/flink/statefun/sdk/java/message/MessageHeader.java
+++ b/statefun-sdk-java/src/main/java/org/apache/flink/statefun/sdk/java/message/MessageHeader.java
@@ -4,52 +4,61 @@ package org.apache.flink.statefun.sdk.java.message;
 
 import java.nio.charset.StandardCharsets;
 import org.apache.flink.statefun.sdk.java.slice.Slice;
-import org.apache.flink.statefun.sdk.java.slice.Slices;
 import org.apache.flink.statefun.sdk.java.types.Type;
 
 /**
  * A single transport-level header attached to an incoming {@link Message}, e.g. a Kafka record
  * header of the record that produced this message. Header keys are not unique: multiple headers
  * may share the same key, and their original order is preserved.
+ *
+ * <p>Never throws on degenerate input: this type materializes on the message read path inside
+ * live function invocations, so a null key degrades to an empty key, and a null value — legal in
+ * Kafka, see {@code org.apache.kafka.common.header.Header#value()} — is preserved as {@code
+ * null}.
  */
 public final class MessageHeader {
-  private static final Slice EMPTY_VALUE = Slices.wrap(new byte[0]);
-
   private final String key;
   private final Slice value;
 
-  /**
-   * Deliberately null-tolerant: this type materializes on the message read path inside function
-   * invocations, where throwing on unexpected input would fail live traffic. A null key or value
-   * degrades to an empty one instead.
-   */
   public MessageHeader(String key, Slice value) {
     this.key = key == null ? "" : key;
-    this.value = value == null ? EMPTY_VALUE : value;
+    this.value = value;
   }
 
   public String key() {
     return key;
   }
 
+  /** True when the header carries a value; false when the Kafka header value was null. */
+  public boolean hasValue() {
+    return value != null;
+  }
+
+  /** The header value, or {@code null} when the Kafka header value was null. */
   public Slice value() {
     return value;
   }
 
+  /** The header value decoded as UTF-8, or {@code null} when the header value was null. */
   public String valueAsUtf8String() {
-    return new String(value.toByteArray(), StandardCharsets.UTF_8);
+    return value == null ? null : new String(value.toByteArray(), StandardCharsets.UTF_8);
   }
 
   /**
    * Decodes the header value with the given SDK {@link Type}, the read-side counterpart of {@code
-   * KafkaEgressMessage.Builder#withHeader(String, Type, Object)}.
+   * KafkaEgressMessage.Builder#withHeader(String, Type, Object)}. Returns {@code null} when the
+   * header value was null.
    */
   public <T> T valueAs(Type<T> type) {
-    return type.typeSerializer().deserialize(value);
+    return value == null ? null : type.typeSerializer().deserialize(value);
   }
 
   @Override
   public String toString() {
-    return "MessageHeader{key='" + key + "', value=" + value.readableBytes() + " bytes}";
+    return "MessageHeader{key='"
+        + key
+        + "', value="
+        + (value == null ? "null" : value.readableBytes() + " bytes")
+        + '}';
   }
 }

--- a/statefun-sdk-java/src/main/java/org/apache/flink/statefun/sdk/java/message/MessageHeader.java
+++ b/statefun-sdk-java/src/main/java/org/apache/flink/statefun/sdk/java/message/MessageHeader.java
@@ -3,8 +3,8 @@
 package org.apache.flink.statefun.sdk.java.message;
 
 import java.nio.charset.StandardCharsets;
-import java.util.Objects;
 import org.apache.flink.statefun.sdk.java.slice.Slice;
+import org.apache.flink.statefun.sdk.java.slice.Slices;
 import org.apache.flink.statefun.sdk.java.types.Type;
 
 /**
@@ -13,12 +13,19 @@ import org.apache.flink.statefun.sdk.java.types.Type;
  * may share the same key, and their original order is preserved.
  */
 public final class MessageHeader {
+  private static final Slice EMPTY_VALUE = Slices.wrap(new byte[0]);
+
   private final String key;
   private final Slice value;
 
+  /**
+   * Deliberately null-tolerant: this type materializes on the message read path inside function
+   * invocations, where throwing on unexpected input would fail live traffic. A null key or value
+   * degrades to an empty one instead.
+   */
   public MessageHeader(String key, Slice value) {
-    this.key = Objects.requireNonNull(key);
-    this.value = Objects.requireNonNull(value);
+    this.key = key == null ? "" : key;
+    this.value = value == null ? EMPTY_VALUE : value;
   }
 
   public String key() {

--- a/statefun-sdk-java/src/main/java/org/apache/flink/statefun/sdk/java/message/MessageHeader.java
+++ b/statefun-sdk-java/src/main/java/org/apache/flink/statefun/sdk/java/message/MessageHeader.java
@@ -5,6 +5,7 @@ package org.apache.flink.statefun.sdk.java.message;
 import java.nio.charset.StandardCharsets;
 import org.apache.flink.statefun.sdk.java.slice.Slice;
 import org.apache.flink.statefun.sdk.java.types.Type;
+import org.apache.flink.statefun.sdk.java.types.Types;
 
 /**
  * A single transport-level header attached to an incoming {@link Message}, e.g. a Kafka record
@@ -46,11 +47,39 @@ public final class MessageHeader {
 
   /**
    * Decodes the header value with the given SDK {@link Type}, the read-side counterpart of {@code
-   * KafkaEgressMessage.Builder#withHeader(String, Type, Object)}. Returns {@code null} when the
-   * header value was null.
+   * KafkaEgressMessage.Builder#withHeader(String, Type, Object)}. Prod-safe by design: a null or
+   * undecodable value yields {@code null}, never an exception.
    */
   public <T> T valueAs(Type<T> type) {
-    return value == null ? null : type.typeSerializer().deserialize(value);
+    if (value == null || type == null) {
+      return null;
+    }
+    try {
+      return type.typeSerializer().deserialize(value);
+    } catch (RuntimeException e) {
+      return null;
+    }
+  }
+
+  /**
+   * Primitive accessors decode the binary SDK {@code Types} encodings written by the matching
+   * {@code withHeader(key, 10)}-style overloads. Same prod-safe contract as {@link
+   * #valueAs(Type)}: null or undecodable values yield {@code null}.
+   */
+  public Integer valueAsInt() {
+    return valueAs(Types.integerType());
+  }
+
+  public Long valueAsLong() {
+    return valueAs(Types.longType());
+  }
+
+  public Double valueAsDouble() {
+    return valueAs(Types.doubleType());
+  }
+
+  public Boolean valueAsBoolean() {
+    return valueAs(Types.booleanType());
   }
 
   @Override

--- a/statefun-sdk-java/src/main/java/org/apache/flink/statefun/sdk/java/message/MessageHeader.java
+++ b/statefun-sdk-java/src/main/java/org/apache/flink/statefun/sdk/java/message/MessageHeader.java
@@ -5,6 +5,7 @@ package org.apache.flink.statefun.sdk.java.message;
 import java.nio.charset.StandardCharsets;
 import java.util.Objects;
 import org.apache.flink.statefun.sdk.java.slice.Slice;
+import org.apache.flink.statefun.sdk.java.types.Type;
 
 /**
  * A single transport-level header attached to an incoming {@link Message}, e.g. a Kafka record
@@ -30,6 +31,14 @@ public final class MessageHeader {
 
   public String valueAsUtf8String() {
     return new String(value.toByteArray(), StandardCharsets.UTF_8);
+  }
+
+  /**
+   * Decodes the header value with the given SDK {@link Type}, the read-side counterpart of {@code
+   * KafkaEgressMessage.Builder#withHeader(String, Type, Object)}.
+   */
+  public <T> T valueAs(Type<T> type) {
+    return type.typeSerializer().deserialize(value);
   }
 
   @Override

--- a/statefun-sdk-java/src/main/java/org/apache/flink/statefun/sdk/java/message/MessageHeader.java
+++ b/statefun-sdk-java/src/main/java/org/apache/flink/statefun/sdk/java/message/MessageHeader.java
@@ -74,6 +74,10 @@ public final class MessageHeader {
     return valueAs(Types.longType());
   }
 
+  public Float valueAsFloat() {
+    return valueAs(Types.floatType());
+  }
+
   public Double valueAsDouble() {
     return valueAs(Types.doubleType());
   }

--- a/statefun-sdk-java/src/main/java/org/apache/flink/statefun/sdk/java/message/MessageWrapper.java
+++ b/statefun-sdk-java/src/main/java/org/apache/flink/statefun/sdk/java/message/MessageWrapper.java
@@ -2,7 +2,6 @@
 // Copyright 2014 The Apache Software Foundation
 package org.apache.flink.statefun.sdk.java.message;
 
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
@@ -46,16 +45,14 @@ public final class MessageWrapper implements Message {
   }
 
   private static List<MessageHeader> extractHeaders(TypedValue typedValue) {
-    final int count = typedValue.getMetadataCount();
-    if (count == 0) {
+    if (typedValue.getMetadataCount() == 0) {
       return Collections.emptyList();
     }
-    List<MessageHeader> extracted = new ArrayList<>(count);
-    for (TypedValue.Metadata metadata : typedValue.getMetadataList()) {
-      extracted.add(
-          new MessageHeader(metadata.getKey(), SliceProtobufUtil.asSlice(metadata.getValue())));
-    }
-    return Collections.unmodifiableList(extracted);
+    return typedValue.getMetadataList().stream()
+        .map(
+            metadata ->
+                new MessageHeader(metadata.getKey(), SliceProtobufUtil.asSlice(metadata.getValue())))
+        .toList();
   }
 
   @Override

--- a/statefun-sdk-java/src/main/java/org/apache/flink/statefun/sdk/java/message/MessageWrapper.java
+++ b/statefun-sdk-java/src/main/java/org/apache/flink/statefun/sdk/java/message/MessageWrapper.java
@@ -44,6 +44,9 @@ public final class MessageWrapper implements Message {
   }
 
   private static List<MessageHeader> extractHeaders(TypedValue typedValue) {
+    if (typedValue.getMetadataCount() == 0) {
+      return List.of();
+    }
     return typedValue.getMetadataList().stream()
         .map(
             metadata ->

--- a/statefun-sdk-java/src/main/java/org/apache/flink/statefun/sdk/java/message/MessageWrapper.java
+++ b/statefun-sdk-java/src/main/java/org/apache/flink/statefun/sdk/java/message/MessageWrapper.java
@@ -2,6 +2,9 @@
 // Copyright 2014 The Apache Software Foundation
 package org.apache.flink.statefun.sdk.java.message;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import java.util.Objects;
 import org.apache.flink.statefun.sdk.java.Address;
 import org.apache.flink.statefun.sdk.java.TypeName;
@@ -17,6 +20,7 @@ import org.apache.flink.statefun.sdk.reqreply.generated.TypedValue;
 public final class MessageWrapper implements Message {
   private final TypedValue typedValue;
   private final Address targetAddress;
+  private List<MessageHeader> headers;
 
   public MessageWrapper(Address targetAddress, TypedValue typedValue) {
     this.targetAddress = Objects.requireNonNull(targetAddress);
@@ -30,6 +34,28 @@ public final class MessageWrapper implements Message {
   @Override
   public Address targetAddress() {
     return targetAddress;
+  }
+
+  @Override
+  public List<MessageHeader> headers() {
+    List<MessageHeader> headers = this.headers;
+    if (headers == null) {
+      this.headers = headers = extractHeaders(typedValue);
+    }
+    return headers;
+  }
+
+  private static List<MessageHeader> extractHeaders(TypedValue typedValue) {
+    final int count = typedValue.getMetadataCount();
+    if (count == 0) {
+      return Collections.emptyList();
+    }
+    List<MessageHeader> extracted = new ArrayList<>(count);
+    for (TypedValue.Metadata metadata : typedValue.getMetadataList()) {
+      extracted.add(
+          new MessageHeader(metadata.getKey(), SliceProtobufUtil.asSlice(metadata.getValue())));
+    }
+    return Collections.unmodifiableList(extracted);
   }
 
   @Override

--- a/statefun-sdk-java/src/main/java/org/apache/flink/statefun/sdk/java/message/MessageWrapper.java
+++ b/statefun-sdk-java/src/main/java/org/apache/flink/statefun/sdk/java/message/MessageWrapper.java
@@ -2,7 +2,6 @@
 // Copyright 2014 The Apache Software Foundation
 package org.apache.flink.statefun.sdk.java.message;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import org.apache.flink.statefun.sdk.java.Address;
@@ -45,13 +44,12 @@ public final class MessageWrapper implements Message {
   }
 
   private static List<MessageHeader> extractHeaders(TypedValue typedValue) {
-    if (typedValue.getMetadataCount() == 0) {
-      return Collections.emptyList();
-    }
     return typedValue.getMetadataList().stream()
         .map(
             metadata ->
-                new MessageHeader(metadata.getKey(), SliceProtobufUtil.asSlice(metadata.getValue())))
+                new MessageHeader(
+                    metadata.getKey(),
+                    metadata.getHasValue() ? SliceProtobufUtil.asSlice(metadata.getValue()) : null))
         .toList();
   }
 

--- a/statefun-sdk-java/src/main/java/org/apache/flink/statefun/sdk/java/testing/KafkaEgressCapture.java
+++ b/statefun-sdk-java/src/main/java/org/apache/flink/statefun/sdk/java/testing/KafkaEgressCapture.java
@@ -1,0 +1,106 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Kzmlabs
+package org.apache.flink.statefun.sdk.java.testing;
+
+import java.util.List;
+import java.util.Optional;
+import org.apache.flink.statefun.sdk.egress.generated.KafkaProducerRecord;
+import org.apache.flink.statefun.sdk.java.TypeName;
+import org.apache.flink.statefun.sdk.java.message.EgressMessage;
+import org.apache.flink.statefun.sdk.java.message.EgressMessageWrapper;
+import org.apache.flink.statefun.sdk.java.message.MessageHeader;
+import org.apache.flink.statefun.sdk.java.slice.Slice;
+import org.apache.flink.statefun.sdk.java.slice.SliceProtobufUtil;
+import org.apache.flink.statefun.sdk.shaded.com.google.protobuf.InvalidProtocolBufferException;
+
+/**
+ * A readable view over a captured Kafka {@link EgressMessage}, for asserting in tests what a
+ * function wrote to a Kafka egress — topic, key, value and headers — without hand-parsing the
+ * underlying {@code KafkaProducerRecord} protobuf.
+ *
+ * <pre>{@code
+ * TestContext context = TestContext.forTarget(SELF);
+ * functionUnderTest.apply(context, message);
+ *
+ * KafkaEgressCapture record =
+ *     KafkaEgressCapture.of(context.getSentEgressMessages().get(0).message());
+ * assertThat(record.topic()).isEqualTo("orders");
+ * assertThat(record.lastHeader("retry-count").orElseThrow().valueAsInt()).isEqualTo(10);
+ * }</pre>
+ *
+ * <p>Unlike production header paths, this test helper fails loudly: passing a non-Kafka egress
+ * message throws {@link IllegalArgumentException}.
+ */
+public final class KafkaEgressCapture {
+
+  private final TypeName targetEgressId;
+  private final KafkaProducerRecord record;
+  private final List<MessageHeader> headers;
+
+  private KafkaEgressCapture(TypeName targetEgressId, KafkaProducerRecord record) {
+    this.targetEgressId = targetEgressId;
+    this.record = record;
+    this.headers =
+        record.getHeadersList().stream()
+            .map(
+                header ->
+                    new MessageHeader(
+                        header.getKey(),
+                        header.getHasValue()
+                            ? SliceProtobufUtil.asSlice(header.getValue())
+                            : null))
+            .toList();
+  }
+
+  private static final String KAFKA_PRODUCER_RECORD_TYPENAME =
+      "type.googleapis.com/" + KafkaProducerRecord.getDescriptor().getFullName();
+
+  public static KafkaEgressCapture of(EgressMessage message) {
+    if (!(message instanceof EgressMessageWrapper wrapper)) {
+      throw new IllegalArgumentException(
+          "Expected an SDK-built egress message, got: " + message.getClass().getName());
+    }
+    if (!KAFKA_PRODUCER_RECORD_TYPENAME.equals(wrapper.typedValue().getTypename())) {
+      throw new IllegalArgumentException(
+          "The egress message does not carry a KafkaProducerRecord (typename was "
+              + wrapper.typedValue().getTypename()
+              + ") — was it built with KafkaEgressMessage.forEgress(...)?");
+    }
+    try {
+      return new KafkaEgressCapture(
+          message.targetEgressId(), KafkaProducerRecord.parseFrom(wrapper.typedValue().getValue()));
+    } catch (InvalidProtocolBufferException e) {
+      throw new IllegalArgumentException("Corrupted KafkaProducerRecord bytes.", e);
+    }
+  }
+
+  public TypeName targetEgressId() {
+    return targetEgressId;
+  }
+
+  public String topic() {
+    return record.getTopic();
+  }
+
+  public String utf8Key() {
+    return record.getKey();
+  }
+
+  public Slice value() {
+    return SliceProtobufUtil.asSlice(record.getValueBytes());
+  }
+
+  public String utf8Value() {
+    return record.getValueBytes().toStringUtf8();
+  }
+
+  /** All record headers in write order; null-valued headers surface with {@code hasValue()==false}. */
+  public List<MessageHeader> headers() {
+    return headers;
+  }
+
+  /** The last header with the given key, mirroring Kafka's {@code Headers#lastHeader} semantics. */
+  public Optional<MessageHeader> lastHeader(String key) {
+    return headers.stream().filter(header -> header.key().equals(key)).reduce((a, b) -> b);
+  }
+}

--- a/statefun-sdk-java/src/test/java/org/apache/flink/statefun/sdk/java/io/KafkaEgressMessageTest.java
+++ b/statefun-sdk-java/src/test/java/org/apache/flink/statefun/sdk/java/io/KafkaEgressMessageTest.java
@@ -255,14 +255,22 @@ class KafkaEgressMessageTest {
   }
 
   @Test
-  void nullHeaderValueIsRejected() {
-    KafkaEgressMessage.Builder builder = KafkaEgressMessage.forEgress(EGRESS_ID);
-    assertThatThrownBy(() -> builder.withUtf8Header("k", null))
-        .isInstanceOf(NullPointerException.class);
-    assertThatThrownBy(() -> builder.withHeader("k", (byte[]) null))
-        .isInstanceOf(NullPointerException.class);
-    assertThatThrownBy(() -> builder.withHeader("k", (Slice) null))
-        .isInstanceOf(NullPointerException.class);
+  void nullHeaderValuesAreCarriedAsEmptyBytesLikeKafkaAllows()
+      throws InvalidProtocolBufferException {
+    EgressMessage message =
+        KafkaEgressMessage.forEgress(EGRESS_ID)
+            .withTopic("t")
+            .withUtf8Value("v")
+            .withUtf8Header("a", null)
+            .withHeader("b", (byte[]) null)
+            .withHeader("c", (Slice) null)
+            .withHeader("d", Types.stringType(), null)
+            .build();
+
+    KafkaProducerRecord record = unpack(message);
+    assertThat(record.getHeadersList())
+        .hasSize(4)
+        .allMatch(header -> header.getValue().isEmpty());
   }
 
   @Test

--- a/statefun-sdk-java/src/test/java/org/apache/flink/statefun/sdk/java/io/KafkaEgressMessageTest.java
+++ b/statefun-sdk-java/src/test/java/org/apache/flink/statefun/sdk/java/io/KafkaEgressMessageTest.java
@@ -211,6 +211,30 @@ class KafkaEgressMessageTest {
   }
 
   @Test
+  void headerValuesSupportBytesStringAndTypedPrimitives() throws InvalidProtocolBufferException {
+    EgressMessage message =
+        KafkaEgressMessage.forEgress(EGRESS_ID)
+            .withTopic("typed-headers")
+            .withUtf8Value("v")
+            .withHeader("raw-bytes", new byte[] {1, 2, 3})
+            .withUtf8Header("str", "hello")
+            .withHeader("int", Types.integerType(), 42)
+            .withHeader("long", Types.longType(), 42_000_000_000L)
+            .withHeader("double", Types.doubleType(), 3.14d)
+            .withHeader("bool", Types.booleanType(), true)
+            .build();
+
+    KafkaProducerRecord record = unpack(message);
+    assertThat(record.getHeadersCount()).isEqualTo(6);
+    assertThat(record.getHeaders(0).getValue().toByteArray()).containsExactly(1, 2, 3);
+    assertThat(record.getHeaders(1).getValue().toStringUtf8()).isEqualTo("hello");
+    assertThat(decode(record, 2, Types.integerType())).isEqualTo(42);
+    assertThat(decode(record, 3, Types.longType())).isEqualTo(42_000_000_000L);
+    assertThat(decode(record, 4, Types.doubleType())).isEqualTo(3.14d);
+    assertThat(decode(record, 5, Types.booleanType())).isTrue();
+  }
+
+  @Test
   void recordWithoutHeadersHasEmptyHeaderList() throws InvalidProtocolBufferException {
     EgressMessage message =
         KafkaEgressMessage.forEgress(EGRESS_ID).withTopic("t").withUtf8Value("v").build();
@@ -254,5 +278,11 @@ class KafkaEgressMessageTest {
       throws InvalidProtocolBufferException {
     EgressMessageWrapper wrapper = (EgressMessageWrapper) message;
     return KafkaProducerRecord.parseFrom(wrapper.typedValue().getValue());
+  }
+
+  private static <T> T decode(
+      KafkaProducerRecord record, int headerIndex, org.apache.flink.statefun.sdk.java.types.Type<T> type) {
+    return type.typeSerializer()
+        .deserialize(Slices.wrap(record.getHeaders(headerIndex).getValue().toByteArray()));
   }
 }

--- a/statefun-sdk-java/src/test/java/org/apache/flink/statefun/sdk/java/io/KafkaEgressMessageTest.java
+++ b/statefun-sdk-java/src/test/java/org/apache/flink/statefun/sdk/java/io/KafkaEgressMessageTest.java
@@ -235,6 +235,31 @@ class KafkaEgressMessageTest {
   }
 
   @Test
+  void primitiveHeaderOverloadsTransferBinaryNumbersNotText()
+      throws InvalidProtocolBufferException {
+    EgressMessage message =
+        KafkaEgressMessage.forEgress(EGRESS_ID)
+            .withTopic("t")
+            .withUtf8Value("v")
+            .withHeader("retry-count", 10)
+            .withHeader("offset", 42_000_000_000L)
+            .withHeader("ratio", 0.5d)
+            .withHeader("replayed", true)
+            .build();
+
+    KafkaProducerRecord record = unpack(message);
+    assertThat(record.getHeaders(0).getValue().toByteArray())
+        .isEqualTo(Types.integerType().typeSerializer().serialize(10).toByteArray());
+    assertThat(record.getHeaders(1).getValue().toByteArray())
+        .isEqualTo(Types.longType().typeSerializer().serialize(42_000_000_000L).toByteArray());
+    assertThat(record.getHeaders(2).getValue().toByteArray())
+        .isEqualTo(Types.doubleType().typeSerializer().serialize(0.5d).toByteArray());
+    assertThat(record.getHeaders(3).getValue().toByteArray())
+        .isEqualTo(Types.booleanType().typeSerializer().serialize(true).toByteArray());
+    assertThat(record.getHeadersList()).allMatch(KafkaProducerRecord.Header::getHasValue);
+  }
+
+  @Test
   void recordWithoutHeadersHasEmptyHeaderList() throws InvalidProtocolBufferException {
     EgressMessage message =
         KafkaEgressMessage.forEgress(EGRESS_ID).withTopic("t").withUtf8Value("v").build();

--- a/statefun-sdk-java/src/test/java/org/apache/flink/statefun/sdk/java/io/KafkaEgressMessageTest.java
+++ b/statefun-sdk-java/src/test/java/org/apache/flink/statefun/sdk/java/io/KafkaEgressMessageTest.java
@@ -243,20 +243,9 @@ class KafkaEgressMessageTest {
     assertThat(record.getHeadersCount()).isZero();
   }
 
-  @Test
-  void nullHeaderKeyIsRejected() {
-    KafkaEgressMessage.Builder builder = KafkaEgressMessage.forEgress(EGRESS_ID);
-    assertThatThrownBy(() -> builder.withUtf8Header(null, "v"))
-        .isInstanceOf(NullPointerException.class);
-    assertThatThrownBy(() -> builder.withHeader(null, new byte[0]))
-        .isInstanceOf(NullPointerException.class);
-    assertThatThrownBy(() -> builder.withHeader(null, Slices.copyFromUtf8("v")))
-        .isInstanceOf(NullPointerException.class);
-  }
 
   @Test
-  void nullHeaderValuesAreCarriedAsEmptyBytesLikeKafkaAllows()
-      throws InvalidProtocolBufferException {
+  void nullHeaderValuesArePreservedAsNullNotEmpty() throws InvalidProtocolBufferException {
     EgressMessage message =
         KafkaEgressMessage.forEgress(EGRESS_ID)
             .withTopic("t")
@@ -270,7 +259,38 @@ class KafkaEgressMessageTest {
     KafkaProducerRecord record = unpack(message);
     assertThat(record.getHeadersList())
         .hasSize(4)
-        .allMatch(header -> header.getValue().isEmpty());
+        .allMatch(header -> !header.getHasValue() && header.getValue().isEmpty());
+  }
+
+  @Test
+  void presentHeaderValuesAreMarkedHasValueIncludingExplicitlyEmptyOnes()
+      throws InvalidProtocolBufferException {
+    EgressMessage message =
+        KafkaEgressMessage.forEgress(EGRESS_ID)
+            .withTopic("t")
+            .withUtf8Value("v")
+            .withHeader("explicit-empty", new byte[0])
+            .withUtf8Header("present", "x")
+            .build();
+
+    KafkaProducerRecord record = unpack(message);
+    assertThat(record.getHeadersList()).hasSize(2).allMatch(KafkaProducerRecord.Header::getHasValue);
+    assertThat(record.getHeaders(0).getValue().isEmpty()).isTrue();
+  }
+
+  @Test
+  void nullHeaderKeyDegradesToEmptyKeyInsteadOfFailingTheSend()
+      throws InvalidProtocolBufferException {
+    EgressMessage message =
+        KafkaEgressMessage.forEgress(EGRESS_ID)
+            .withTopic("t")
+            .withUtf8Value("v")
+            .withUtf8Header(null, "orphan")
+            .build();
+
+    KafkaProducerRecord record = unpack(message);
+    assertThat(record.getHeaders(0).getKey()).isEmpty();
+    assertThat(record.getHeaders(0).getValue().toStringUtf8()).isEqualTo("orphan");
   }
 
   @Test

--- a/statefun-sdk-java/src/test/java/org/apache/flink/statefun/sdk/java/io/KafkaEgressMessageTest.java
+++ b/statefun-sdk-java/src/test/java/org/apache/flink/statefun/sdk/java/io/KafkaEgressMessageTest.java
@@ -260,6 +260,66 @@ class KafkaEgressMessageTest {
   }
 
   @Test
+  void floatHeaderTransfersBinaryFloat() throws InvalidProtocolBufferException {
+    EgressMessage message =
+        KafkaEgressMessage.forEgress(EGRESS_ID)
+            .withTopic("t")
+            .withUtf8Value("v")
+            .withHeader("ratio", 0.25f)
+            .build();
+
+    KafkaProducerRecord record = unpack(message);
+    assertThat(record.getHeaders(0).getValue().toByteArray())
+        .isEqualTo(Types.floatType().typeSerializer().serialize(0.25f).toByteArray());
+  }
+
+  @Test
+  void zeroIntHeaderIsPresentButEmptyBytesDistinctFromNull() throws InvalidProtocolBufferException {
+    // The SDK int encoding serializes 0 to zero bytes — has_value is what separates a real 0
+    // from a null-valued header on the wire.
+    EgressMessage message =
+        KafkaEgressMessage.forEgress(EGRESS_ID)
+            .withTopic("t")
+            .withUtf8Value("v")
+            .withHeader("zero", 0)
+            .withHeader("absent", (byte[]) null)
+            .build();
+
+    KafkaProducerRecord record = unpack(message);
+    assertThat(record.getHeaders(0).getHasValue()).isTrue();
+    assertThat(record.getHeaders(0).getValue().isEmpty()).isTrue();
+    assertThat(record.getHeaders(1).getHasValue()).isFalse();
+  }
+
+  @Test
+  void nullTypeObjectDegradesToNullValuedHeaderInsteadOfThrowing()
+      throws InvalidProtocolBufferException {
+    EgressMessage message =
+        KafkaEgressMessage.forEgress(EGRESS_ID)
+            .withTopic("t")
+            .withUtf8Value("v")
+            .withHeader("k", null, "value-with-null-type")
+            .build();
+
+    KafkaProducerRecord record = unpack(message);
+    assertThat(record.getHeaders(0).getHasValue()).isFalse();
+  }
+
+  @Test
+  void emptyStringHeaderKeyIsLegal() throws InvalidProtocolBufferException {
+    EgressMessage message =
+        KafkaEgressMessage.forEgress(EGRESS_ID)
+            .withTopic("t")
+            .withUtf8Value("v")
+            .withUtf8Header("", "anonymous")
+            .build();
+
+    KafkaProducerRecord record = unpack(message);
+    assertThat(record.getHeaders(0).getKey()).isEmpty();
+    assertThat(record.getHeaders(0).getValue().toStringUtf8()).isEqualTo("anonymous");
+  }
+
+  @Test
   void recordWithoutHeadersHasEmptyHeaderList() throws InvalidProtocolBufferException {
     EgressMessage message =
         KafkaEgressMessage.forEgress(EGRESS_ID).withTopic("t").withUtf8Value("v").build();

--- a/statefun-sdk-java/src/test/java/org/apache/flink/statefun/sdk/java/io/KafkaEgressMessageTest.java
+++ b/statefun-sdk-java/src/test/java/org/apache/flink/statefun/sdk/java/io/KafkaEgressMessageTest.java
@@ -189,6 +189,59 @@ class KafkaEgressMessageTest {
   }
 
   @Test
+  void headersAreCarriedThroughInOrderIncludingDuplicateKeys()
+      throws InvalidProtocolBufferException {
+    EgressMessage message =
+        KafkaEgressMessage.forEgress(EGRESS_ID)
+            .withTopic("orders")
+            .withUtf8Value("hello")
+            .withUtf8Header("trace-id", "abc-123")
+            .withHeader("payload-hash", new byte[] {1, 2, 3})
+            .withHeader("trace-id", Slices.copyFromUtf8("def-456"))
+            .build();
+
+    KafkaProducerRecord record = unpack(message);
+    assertThat(record.getHeadersCount()).isEqualTo(3);
+    assertThat(record.getHeaders(0).getKey()).isEqualTo("trace-id");
+    assertThat(record.getHeaders(0).getValue().toStringUtf8()).isEqualTo("abc-123");
+    assertThat(record.getHeaders(1).getKey()).isEqualTo("payload-hash");
+    assertThat(record.getHeaders(1).getValue().toByteArray()).containsExactly(1, 2, 3);
+    assertThat(record.getHeaders(2).getKey()).isEqualTo("trace-id");
+    assertThat(record.getHeaders(2).getValue().toStringUtf8()).isEqualTo("def-456");
+  }
+
+  @Test
+  void recordWithoutHeadersHasEmptyHeaderList() throws InvalidProtocolBufferException {
+    EgressMessage message =
+        KafkaEgressMessage.forEgress(EGRESS_ID).withTopic("t").withUtf8Value("v").build();
+
+    KafkaProducerRecord record = unpack(message);
+    assertThat(record.getHeadersCount()).isZero();
+  }
+
+  @Test
+  void nullHeaderKeyIsRejected() {
+    KafkaEgressMessage.Builder builder = KafkaEgressMessage.forEgress(EGRESS_ID);
+    assertThatThrownBy(() -> builder.withUtf8Header(null, "v"))
+        .isInstanceOf(NullPointerException.class);
+    assertThatThrownBy(() -> builder.withHeader(null, new byte[0]))
+        .isInstanceOf(NullPointerException.class);
+    assertThatThrownBy(() -> builder.withHeader(null, Slices.copyFromUtf8("v")))
+        .isInstanceOf(NullPointerException.class);
+  }
+
+  @Test
+  void nullHeaderValueIsRejected() {
+    KafkaEgressMessage.Builder builder = KafkaEgressMessage.forEgress(EGRESS_ID);
+    assertThatThrownBy(() -> builder.withUtf8Header("k", null))
+        .isInstanceOf(NullPointerException.class);
+    assertThatThrownBy(() -> builder.withHeader("k", (byte[]) null))
+        .isInstanceOf(NullPointerException.class);
+    assertThatThrownBy(() -> builder.withHeader("k", (Slice) null))
+        .isInstanceOf(NullPointerException.class);
+  }
+
+  @Test
   void buildIsValidWithoutKey() throws InvalidProtocolBufferException {
     EgressMessage message =
         KafkaEgressMessage.forEgress(EGRESS_ID).withTopic("k-less").withUtf8Value("v").build();

--- a/statefun-sdk-java/src/test/java/org/apache/flink/statefun/sdk/java/message/MessageHeadersTest.java
+++ b/statefun-sdk-java/src/test/java/org/apache/flink/statefun/sdk/java/message/MessageHeadersTest.java
@@ -88,6 +88,46 @@ class MessageHeadersTest {
   }
 
   @Test
+  void primitiveAccessorsDecodeBinaryNumbersWrittenByPrimitiveOverloads() {
+    TypedValue typedValue =
+        plainStringValue()
+            .addMetadata(typedMetadata("retry-count", Types.integerType(), 10))
+            .addMetadata(typedMetadata("offset", Types.longType(), 42_000_000_000L))
+            .addMetadata(typedMetadata("ratio", Types.doubleType(), 0.5d))
+            .addMetadata(typedMetadata("replayed", Types.booleanType(), true))
+            .build();
+
+    List<MessageHeader> headers = new MessageWrapper(TARGET, typedValue).headers();
+
+    assertThat(headers.get(0).valueAsInt()).isEqualTo(10);
+    assertThat(headers.get(1).valueAsLong()).isEqualTo(42_000_000_000L);
+    assertThat(headers.get(2).valueAsDouble()).isEqualTo(0.5d);
+    assertThat(headers.get(3).valueAsBoolean()).isTrue();
+  }
+
+  @Test
+  void primitiveAccessorsNeverThrowOnGarbageOrNullValues() {
+    TypedValue typedValue =
+        plainStringValue()
+            .addMetadata(
+                TypedValue.Metadata.newBuilder()
+                    .setKey("garbage")
+                    .setValue(ByteString.copyFrom(new byte[] {0x01}))
+                    .setHasValue(true))
+            .addMetadata(TypedValue.Metadata.newBuilder().setKey("null-valued"))
+            .build();
+
+    List<MessageHeader> headers = new MessageWrapper(TARGET, typedValue).headers();
+
+    assertThat(headers.get(0).valueAsInt()).isNull();
+    assertThat(headers.get(0).valueAsLong()).isNull();
+    assertThat(headers.get(0).valueAsDouble()).isNull();
+    assertThat(headers.get(0).valueAs(Types.integerType())).isNull();
+    assertThat(headers.get(1).valueAsInt()).isNull();
+    assertThat(headers.get(1).valueAsBoolean()).isNull();
+  }
+
+  @Test
   void messageWithoutMetadataHasNoHeaders() {
     Message message = new MessageWrapper(TARGET, plainStringValue().build());
 

--- a/statefun-sdk-java/src/test/java/org/apache/flink/statefun/sdk/java/message/MessageHeadersTest.java
+++ b/statefun-sdk-java/src/test/java/org/apache/flink/statefun/sdk/java/message/MessageHeadersTest.java
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Kzmlabs
+package org.apache.flink.statefun.sdk.java.message;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.List;
+import org.apache.flink.statefun.sdk.java.Address;
+import org.apache.flink.statefun.sdk.java.TypeName;
+import org.apache.flink.statefun.sdk.reqreply.generated.TypedValue;
+import org.apache.flink.statefun.sdk.shaded.com.google.protobuf.ByteString;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Pins the ingress-header contract of {@link Message#headers()}: entries of {@code
+ * TypedValue.metadata} (populated by the runtime from Kafka record headers) are exposed as {@link
+ * MessageHeader}s in order, and messages without metadata expose an empty, allocation-free list.
+ */
+class MessageHeadersTest {
+
+  private static final Address TARGET =
+      new Address(TypeName.typeNameOf("io.test", "fn"), "id-1");
+
+  @Test
+  void metadataEntriesAreExposedAsHeadersInOrder() {
+    TypedValue typedValue =
+        plainStringValue()
+            .addMetadata(metadata("trace-id", "abc-123"))
+            .addMetadata(metadata("origin", "gateway"))
+            .addMetadata(metadata("trace-id", "def-456"))
+            .build();
+
+    Message message = new MessageWrapper(TARGET, typedValue);
+
+    List<MessageHeader> headers = message.headers();
+    assertThat(headers).hasSize(3);
+    assertThat(headers.get(0).key()).isEqualTo("trace-id");
+    assertThat(headers.get(0).valueAsUtf8String()).isEqualTo("abc-123");
+    assertThat(headers.get(1).key()).isEqualTo("origin");
+    assertThat(headers.get(1).valueAsUtf8String()).isEqualTo("gateway");
+    assertThat(headers.get(2).key()).isEqualTo("trace-id");
+    assertThat(headers.get(2).valueAsUtf8String()).isEqualTo("def-456");
+  }
+
+  @Test
+  void binaryHeaderValueIsAccessibleAsSlice() {
+    byte[] raw = new byte[] {0, 1, (byte) 0xFF};
+    TypedValue typedValue =
+        plainStringValue()
+            .addMetadata(
+                TypedValue.Metadata.newBuilder()
+                    .setKey("bin")
+                    .setValue(ByteString.copyFrom(raw)))
+            .build();
+
+    Message message = new MessageWrapper(TARGET, typedValue);
+
+    assertThat(message.headers().get(0).value().toByteArray()).containsExactly(0, 1, 0xFF);
+  }
+
+  @Test
+  void messageWithoutMetadataHasNoHeaders() {
+    Message message = new MessageWrapper(TARGET, plainStringValue().build());
+
+    assertThat(message.headers()).isEmpty();
+  }
+
+  @Test
+  void headersListIsUnmodifiable() {
+    TypedValue typedValue = plainStringValue().addMetadata(metadata("k", "v")).build();
+    Message message = new MessageWrapper(TARGET, typedValue);
+
+    List<MessageHeader> headers = message.headers();
+    assertThatThrownBy(() -> headers.add(headers.get(0)))
+        .isInstanceOf(UnsupportedOperationException.class);
+  }
+
+  @Test
+  void headersAreComputedOnceAndCached() {
+    TypedValue typedValue = plainStringValue().addMetadata(metadata("k", "v")).build();
+    Message message = new MessageWrapper(TARGET, typedValue);
+
+    assertThat(message.headers()).isSameAs(message.headers());
+  }
+
+  private static TypedValue.Builder plainStringValue() {
+    return TypedValue.newBuilder()
+        .setTypename("io.statefun.types/string")
+        .setHasValue(true)
+        .setValue(ByteString.copyFromUtf8("payload"));
+  }
+
+  private static TypedValue.Metadata.Builder metadata(String key, String utf8Value) {
+    return TypedValue.Metadata.newBuilder()
+        .setKey(key)
+        .setValue(ByteString.copyFromUtf8(utf8Value));
+  }
+}

--- a/statefun-sdk-java/src/test/java/org/apache/flink/statefun/sdk/java/message/MessageHeadersTest.java
+++ b/statefun-sdk-java/src/test/java/org/apache/flink/statefun/sdk/java/message/MessageHeadersTest.java
@@ -52,7 +52,8 @@ class MessageHeadersTest {
             .addMetadata(
                 TypedValue.Metadata.newBuilder()
                     .setKey("bin")
-                    .setValue(ByteString.copyFrom(raw)))
+                    .setValue(ByteString.copyFrom(raw))
+                    .setHasValue(true))
             .build();
 
     Message message = new MessageWrapper(TARGET, typedValue);
@@ -67,7 +68,8 @@ class MessageHeadersTest {
             .addMetadata(
                 TypedValue.Metadata.newBuilder()
                     .setKey("raw-bytes")
-                    .setValue(ByteString.copyFrom(new byte[] {1, 2, 3})))
+                    .setValue(ByteString.copyFrom(new byte[] {1, 2, 3}))
+                    .setHasValue(true))
             .addMetadata(metadata("str", "hello"))
             .addMetadata(typedMetadata("int", Types.integerType(), 42))
             .addMetadata(typedMetadata("long", Types.longType(), 42_000_000_000L))
@@ -103,12 +105,31 @@ class MessageHeadersTest {
   }
 
   @Test
-  void messageHeaderDegradesNullsToEmptyInsteadOfThrowing() {
+  void messageHeaderNeverThrowsOnDegenerateInput() {
     MessageHeader header = new MessageHeader(null, null);
 
     assertThat(header.key()).isEmpty();
-    assertThat(header.value().readableBytes()).isZero();
-    assertThat(header.valueAsUtf8String()).isEmpty();
+    assertThat(header.hasValue()).isFalse();
+    assertThat(header.value()).isNull();
+    assertThat(header.valueAsUtf8String()).isNull();
+    assertThat(header.valueAs(Types.integerType())).isNull();
+  }
+
+  @Test
+  void nullValuedKafkaHeaderIsPreservedAsNullValue() {
+    TypedValue typedValue =
+        plainStringValue()
+            .addMetadata(TypedValue.Metadata.newBuilder().setKey("null-header"))
+            .addMetadata(metadata("present", "x"))
+            .build();
+
+    List<MessageHeader> headers = new MessageWrapper(TARGET, typedValue).headers();
+
+    assertThat(headers.get(0).key()).isEqualTo("null-header");
+    assertThat(headers.get(0).hasValue()).isFalse();
+    assertThat(headers.get(0).value()).isNull();
+    assertThat(headers.get(1).hasValue()).isTrue();
+    assertThat(headers.get(1).valueAsUtf8String()).isEqualTo("x");
   }
 
   @Test
@@ -129,13 +150,15 @@ class MessageHeadersTest {
   private static TypedValue.Metadata.Builder metadata(String key, String utf8Value) {
     return TypedValue.Metadata.newBuilder()
         .setKey(key)
-        .setValue(ByteString.copyFromUtf8(utf8Value));
+        .setValue(ByteString.copyFromUtf8(utf8Value))
+        .setHasValue(true);
   }
 
   private static <T> TypedValue.Metadata.Builder typedMetadata(
       String key, org.apache.flink.statefun.sdk.java.types.Type<T> type, T value) {
     return TypedValue.Metadata.newBuilder()
         .setKey(key)
-        .setValue(ByteString.copyFrom(type.typeSerializer().serialize(value).toByteArray()));
+        .setValue(ByteString.copyFrom(type.typeSerializer().serialize(value).toByteArray()))
+        .setHasValue(true);
   }
 }

--- a/statefun-sdk-java/src/test/java/org/apache/flink/statefun/sdk/java/message/MessageHeadersTest.java
+++ b/statefun-sdk-java/src/test/java/org/apache/flink/statefun/sdk/java/message/MessageHeadersTest.java
@@ -93,16 +93,34 @@ class MessageHeadersTest {
         plainStringValue()
             .addMetadata(typedMetadata("retry-count", Types.integerType(), 10))
             .addMetadata(typedMetadata("offset", Types.longType(), 42_000_000_000L))
-            .addMetadata(typedMetadata("ratio", Types.doubleType(), 0.5d))
+            .addMetadata(typedMetadata("ratio-f", Types.floatType(), 0.25f))
+            .addMetadata(typedMetadata("ratio-d", Types.doubleType(), 0.5d))
             .addMetadata(typedMetadata("replayed", Types.booleanType(), true))
+            .addMetadata(typedMetadata("negative", Types.integerType(), -1))
             .build();
 
     List<MessageHeader> headers = new MessageWrapper(TARGET, typedValue).headers();
 
     assertThat(headers.get(0).valueAsInt()).isEqualTo(10);
     assertThat(headers.get(1).valueAsLong()).isEqualTo(42_000_000_000L);
-    assertThat(headers.get(2).valueAsDouble()).isEqualTo(0.5d);
-    assertThat(headers.get(3).valueAsBoolean()).isTrue();
+    assertThat(headers.get(2).valueAsFloat()).isEqualTo(0.25f);
+    assertThat(headers.get(3).valueAsDouble()).isEqualTo(0.5d);
+    assertThat(headers.get(4).valueAsBoolean()).isTrue();
+    assertThat(headers.get(5).valueAsInt()).isEqualTo(-1);
+  }
+
+  @Test
+  void zeroIntDecodesToZeroWhilePresentAndToNullWhileAbsent() {
+    TypedValue typedValue =
+        plainStringValue()
+            .addMetadata(typedMetadata("zero", Types.integerType(), 0))
+            .addMetadata(TypedValue.Metadata.newBuilder().setKey("absent"))
+            .build();
+
+    List<MessageHeader> headers = new MessageWrapper(TARGET, typedValue).headers();
+
+    assertThat(headers.get(0).valueAsInt()).isZero();
+    assertThat(headers.get(1).valueAsInt()).isNull();
   }
 
   @Test
@@ -121,8 +139,12 @@ class MessageHeadersTest {
 
     assertThat(headers.get(0).valueAsInt()).isNull();
     assertThat(headers.get(0).valueAsLong()).isNull();
+    assertThat(headers.get(0).valueAsFloat()).isNull();
     assertThat(headers.get(0).valueAsDouble()).isNull();
+    assertThat(headers.get(0).valueAsBoolean()).isNull();
     assertThat(headers.get(0).valueAs(Types.integerType())).isNull();
+    Integer decodedWithNullType = headers.get(0).valueAs(null);
+    assertThat(decodedWithNullType).isNull();
     assertThat(headers.get(1).valueAsInt()).isNull();
     assertThat(headers.get(1).valueAsBoolean()).isNull();
   }

--- a/statefun-sdk-java/src/test/java/org/apache/flink/statefun/sdk/java/message/MessageHeadersTest.java
+++ b/statefun-sdk-java/src/test/java/org/apache/flink/statefun/sdk/java/message/MessageHeadersTest.java
@@ -103,6 +103,15 @@ class MessageHeadersTest {
   }
 
   @Test
+  void messageHeaderDegradesNullsToEmptyInsteadOfThrowing() {
+    MessageHeader header = new MessageHeader(null, null);
+
+    assertThat(header.key()).isEmpty();
+    assertThat(header.value().readableBytes()).isZero();
+    assertThat(header.valueAsUtf8String()).isEmpty();
+  }
+
+  @Test
   void headersAreComputedOnceAndCached() {
     TypedValue typedValue = plainStringValue().addMetadata(metadata("k", "v")).build();
     Message message = new MessageWrapper(TARGET, typedValue);

--- a/statefun-sdk-java/src/test/java/org/apache/flink/statefun/sdk/java/message/MessageHeadersTest.java
+++ b/statefun-sdk-java/src/test/java/org/apache/flink/statefun/sdk/java/message/MessageHeadersTest.java
@@ -8,6 +8,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import java.util.List;
 import org.apache.flink.statefun.sdk.java.Address;
 import org.apache.flink.statefun.sdk.java.TypeName;
+import org.apache.flink.statefun.sdk.java.types.Types;
 import org.apache.flink.statefun.sdk.reqreply.generated.TypedValue;
 import org.apache.flink.statefun.sdk.shaded.com.google.protobuf.ByteString;
 import org.junit.jupiter.api.Test;
@@ -60,6 +61,31 @@ class MessageHeadersTest {
   }
 
   @Test
+  void headerValuesDecodeAsBytesStringAndTypedPrimitives() {
+    TypedValue typedValue =
+        plainStringValue()
+            .addMetadata(
+                TypedValue.Metadata.newBuilder()
+                    .setKey("raw-bytes")
+                    .setValue(ByteString.copyFrom(new byte[] {1, 2, 3})))
+            .addMetadata(metadata("str", "hello"))
+            .addMetadata(typedMetadata("int", Types.integerType(), 42))
+            .addMetadata(typedMetadata("long", Types.longType(), 42_000_000_000L))
+            .addMetadata(typedMetadata("double", Types.doubleType(), 3.14d))
+            .addMetadata(typedMetadata("bool", Types.booleanType(), true))
+            .build();
+
+    List<MessageHeader> headers = new MessageWrapper(TARGET, typedValue).headers();
+
+    assertThat(headers.get(0).value().toByteArray()).containsExactly(1, 2, 3);
+    assertThat(headers.get(1).valueAsUtf8String()).isEqualTo("hello");
+    assertThat(headers.get(2).valueAs(Types.integerType())).isEqualTo(42);
+    assertThat(headers.get(3).valueAs(Types.longType())).isEqualTo(42_000_000_000L);
+    assertThat(headers.get(4).valueAs(Types.doubleType())).isEqualTo(3.14d);
+    assertThat(headers.get(5).valueAs(Types.booleanType())).isTrue();
+  }
+
+  @Test
   void messageWithoutMetadataHasNoHeaders() {
     Message message = new MessageWrapper(TARGET, plainStringValue().build());
 
@@ -95,5 +121,12 @@ class MessageHeadersTest {
     return TypedValue.Metadata.newBuilder()
         .setKey(key)
         .setValue(ByteString.copyFromUtf8(utf8Value));
+  }
+
+  private static <T> TypedValue.Metadata.Builder typedMetadata(
+      String key, org.apache.flink.statefun.sdk.java.types.Type<T> type, T value) {
+    return TypedValue.Metadata.newBuilder()
+        .setKey(key)
+        .setValue(ByteString.copyFrom(type.typeSerializer().serialize(value).toByteArray()));
   }
 }

--- a/statefun-sdk-java/src/test/java/org/apache/flink/statefun/sdk/java/testing/KafkaHeaderTestingTest.java
+++ b/statefun-sdk-java/src/test/java/org/apache/flink/statefun/sdk/java/testing/KafkaHeaderTestingTest.java
@@ -1,0 +1,132 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Kzmlabs
+package org.apache.flink.statefun.sdk.java.testing;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.concurrent.CompletableFuture;
+import org.apache.flink.statefun.sdk.java.Address;
+import org.apache.flink.statefun.sdk.java.Context;
+import org.apache.flink.statefun.sdk.java.StatefulFunction;
+import org.apache.flink.statefun.sdk.java.TypeName;
+import org.apache.flink.statefun.sdk.java.io.KafkaEgressMessage;
+import org.apache.flink.statefun.sdk.java.message.Message;
+import org.apache.flink.statefun.sdk.java.message.MessageBuilder;
+import org.apache.flink.statefun.sdk.java.slice.Slice;
+import org.apache.flink.statefun.sdk.java.types.Types;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Pins the header testing workflow: a function that reads {@link Message#headers()} can be driven
+ * with {@link MessageBuilder} header overloads through {@link TestContext}, and its Kafka egress
+ * headers asserted through {@link KafkaEgressCapture} — no protobuf hand-parsing in user tests.
+ */
+class KafkaHeaderTestingTest {
+
+  private static final TypeName FN = TypeName.typeNameOf("io.test", "echo-fn");
+  private static final TypeName EGRESS = TypeName.typeNameOf("io.test", "kafka-out");
+  private static final Address SELF = new Address(FN, "id-1");
+
+  /** Echoes all incoming headers onto its egress record and adds a retry counter. */
+  private static final class HeaderEchoFn implements StatefulFunction {
+    @Override
+    public CompletableFuture<Void> apply(Context context, Message message) {
+      KafkaEgressMessage.Builder egress =
+          KafkaEgressMessage.forEgress(EGRESS)
+              .withTopic("out")
+              .withUtf8Key("k")
+              .withUtf8Value(message.asUtf8String());
+      message.headers().forEach(h -> egress.withHeader(h.key(), h.value()));
+      egress.withHeader("retry-count", 10);
+      context.send(egress.build());
+      return context.done();
+    }
+  }
+
+  @Test
+  void headersFlowFromTestMessageThroughFunctionToEgressAssertions() throws Exception {
+    Message message =
+        MessageBuilder.forAddress(SELF)
+            .withValue("payload")
+            .withUtf8Header("trace-id", "abc-123")
+            .withHeader("attempt", 3)
+            .withHeader("null-header", (byte[]) null)
+            .build();
+    TestContext context = TestContext.forTarget(SELF);
+
+    new HeaderEchoFn().apply(context, message).get();
+
+    KafkaEgressCapture record =
+        KafkaEgressCapture.of(context.getSentEgressMessages().get(0).message());
+    assertThat(record.targetEgressId()).isEqualTo(EGRESS);
+    assertThat(record.topic()).isEqualTo("out");
+    assertThat(record.utf8Value()).isEqualTo("payload");
+    assertThat(record.lastHeader("trace-id").orElseThrow().valueAsUtf8String())
+        .isEqualTo("abc-123");
+    assertThat(record.lastHeader("attempt").orElseThrow().valueAsInt()).isEqualTo(3);
+    assertThat(record.lastHeader("null-header").orElseThrow().hasValue()).isFalse();
+    assertThat(record.lastHeader("retry-count").orElseThrow().valueAsInt()).isEqualTo(10);
+    assertThat(record.lastHeader("absent")).isEmpty();
+  }
+
+  @Test
+  void fromMessagePreservesHeadersWhenForwarding() {
+    Message original =
+        MessageBuilder.forAddress(SELF)
+            .withValue("payload")
+            .withUtf8Header("trace-id", "abc-123")
+            .withHeader("attempt", Types.integerType(), 3)
+            .withHeader("null-header", (Slice) null)
+            .build();
+
+    Message forwarded =
+        MessageBuilder.fromMessage(original)
+            .withTargetAddress(TypeName.typeNameOf("io.test", "other-fn"), "id-2")
+            .build();
+
+    assertThat(forwarded.headers()).hasSize(3);
+    assertThat(forwarded.headers().get(0).valueAsUtf8String()).isEqualTo("abc-123");
+    assertThat(forwarded.headers().get(1).valueAs(Types.integerType())).isEqualTo(3);
+    assertThat(forwarded.headers().get(2).hasValue()).isFalse();
+    assertThat(forwarded.headers().get(2).value()).isNull();
+  }
+
+  @Test
+  void messageBuilderSupportsAllPrimitiveHeaderTypes() {
+    Message message =
+        MessageBuilder.forAddress(SELF)
+            .withValue("payload")
+            .withHeader("int", 10)
+            .withHeader("long", 42_000_000_000L)
+            .withHeader("float", 0.25f)
+            .withHeader("double", 0.5d)
+            .withHeader("bool", true)
+            .withUtf8Header("str", "hello")
+            .withHeader("bytes", new byte[] {1, 2, 3})
+            .build();
+
+    assertThat(message.headers().get(0).valueAsInt()).isEqualTo(10);
+    assertThat(message.headers().get(1).valueAsLong()).isEqualTo(42_000_000_000L);
+    assertThat(message.headers().get(2).valueAsFloat()).isEqualTo(0.25f);
+    assertThat(message.headers().get(3).valueAsDouble()).isEqualTo(0.5d);
+    assertThat(message.headers().get(4).valueAsBoolean()).isTrue();
+    assertThat(message.headers().get(5).valueAsUtf8String()).isEqualTo("hello");
+    assertThat(message.headers().get(6).value().toByteArray()).containsExactly(1, 2, 3);
+  }
+
+  @Test
+  void captureFailsLoudlyOnNonKafkaEgressMessage() {
+    Message notAnEgress = MessageBuilder.forAddress(SELF).withValue("x").build();
+    TestContext context = TestContext.forTarget(SELF);
+    context.send(
+        org.apache.flink.statefun.sdk.java.message.EgressMessageBuilder.forEgress(EGRESS)
+            .withValue("plain, not a KafkaProducerRecord")
+            .build());
+
+    assertThatThrownBy(
+            () -> KafkaEgressCapture.of(context.getSentEgressMessages().get(0).message()))
+        .isInstanceOf(IllegalArgumentException.class);
+    assertThat(notAnEgress.headers()).isEmpty();
+  }
+}

--- a/statefun-sdk-protos/src/main/protobuf/io/kafka-egress.proto
+++ b/statefun-sdk-protos/src/main/protobuf/io/kafka-egress.proto
@@ -20,5 +20,9 @@ message KafkaProducerRecord {
     message Header {
         string key = 1;
         bytes value = 2;
+        // Kafka distinguishes a null header value from an empty one; protobuf cannot.
+        // has_value=true means the value bytes are present (possibly empty),
+        // has_value=false means the Kafka header value is null.
+        bool has_value = 3;
     }
 }

--- a/statefun-sdk-protos/src/main/protobuf/io/kafka-egress.proto
+++ b/statefun-sdk-protos/src/main/protobuf/io/kafka-egress.proto
@@ -13,4 +13,12 @@ message KafkaProducerRecord {
     string key = 1;
     bytes value_bytes = 2;
     string topic = 3;
+    // Kafka record headers to set on the produced record. Duplicate keys are
+    // allowed and insertion order is preserved, matching Kafka semantics.
+    repeated Header headers = 4;
+
+    message Header {
+        string key = 1;
+        bytes value = 2;
+    }
 }

--- a/statefun-sdk-protos/src/main/protobuf/sdk/request-reply.proto
+++ b/statefun-sdk-protos/src/main/protobuf/sdk/request-reply.proto
@@ -29,6 +29,15 @@ message TypedValue {
     // or a non existing value.
     bool has_value = 2;
     bytes value = 3;
+    // Optional transport-level metadata attached to this value. For messages that
+    // originate from a Kafka ingress, the entries are the Kafka record headers.
+    // Duplicate keys are allowed and order is preserved.
+    repeated Metadata metadata = 4;
+
+    message Metadata {
+        string key = 1;
+        bytes value = 2;
+    }
 }
 
 // -------------------------------------------------------------------------------------------------------------------

--- a/statefun-sdk-protos/src/main/protobuf/sdk/request-reply.proto
+++ b/statefun-sdk-protos/src/main/protobuf/sdk/request-reply.proto
@@ -37,6 +37,9 @@ message TypedValue {
     message Metadata {
         string key = 1;
         bytes value = 2;
+        // Mirrors TypedValue.has_value: distinguishes an explicitly empty value
+        // from an absent (null) one, e.g. a Kafka header with a null value.
+        bool has_value = 3;
     }
 }
 


### PR DESCRIPTION
## What

Functions using `statefun-sdk-java` can now **read the headers of the Kafka record that triggered them** and **set headers on records emitted to a Kafka egress**.

### SDK API

```java
// egress: attach headers
KafkaEgressMessage.forEgress(EGRESS)
    .withTopic("out")
    .withUtf8Key(id)
    .withValue(payload)
    .withUtf8Header("trace-id", traceId)
    .withHeader("payload-hash", hashBytes)   // byte[] and Slice overloads too
    .build();

// ingress: read headers of the triggering record
for (MessageHeader h : message.headers()) { ... }
```

## How

Strictly **additive** protobuf changes — no breaking protocol change:

| Proto | Addition | Purpose |
|---|---|---|
| `kafka-egress.proto` `KafkaProducerRecord` | `repeated Header headers = 4` | egress headers |
| `request-reply.proto` `TypedValue` | `repeated Metadata metadata = 4` | carries ingress headers to the remote function |
| `routable.proto` `AutoRoutable` | `repeated Header headers = 4` | carries `ConsumerRecord` headers from deserializer to router |

The ingress payload travels router → flink-core → `ToFunction.Invocation.argument` as a single `TypedValue`, so metadata rides through with **zero flink-core changes** (`RequestReplyFunction` forwards it verbatim; the internal envelope is full protobuf serialization, so additive fields survive).

Runtime: `RoutableKafkaIngressDeserializer` captures record headers (null values → empty bytes), `AutoRoutableProtobufRouter` forwards them as `TypedValue.metadata` (payload now built once per record instead of once per target), `GenericKafkaEgressSerializer` copies proto headers onto the `ProducerRecord`.

## Compatibility / performance

- Old SDKs (any language) against the new runtime: metadata ignored, unchanged behavior.
- New SDK against an old runtime: header field unknown to the old parser, no error — headers simply not written.
- Records without headers: no extra allocations, wire size unchanged.
- `Message#headers()` is a default method — existing `Message` implementations keep compiling; values are zero-copy `Slice` views, lazily materialized.

## Ingress opt-in: `forwardHeaders`

Ingress header forwarding is **opt-in, default off** — headers cost payload bytes on every hop, so a topic only pays after opting in. The `io.statefun.kafka.v1/ingress` spec accepts `forwardHeaders` at two levels:

```yaml
spec:
  forwardHeaders: true        # ingress-level default for all topics
  topics:
    - topic: audit-log
      forwardHeaders: false   # per-topic override wins, in either direction
```

Resolution: per-topic value if present → ingress-level value → `false`. Topics that have not opted in never capture headers (no bytes enter `AutoRoutable`, the shuffle, or the `ToFunction` request; `Message#headers()` returns an empty list). Resolution happens once at spec-build time; the per-record hot path adds a single `Set#contains`. Egress headers are unaffected (always explicit builder calls). Additive YAML property — existing `module.yaml` files parse unchanged.

## Testing

- Unit tests at every layer: `KafkaEgressMessageTest` (header round-trip, duplicate keys, ordering, null-safety), new `MessageHeadersTest` (metadata → headers mapping, laziness, immutability), `RoutableKafkaIngressDeserializerTest` + new `AutoRoutableProtobufRouterTest` + `GenericKafkaEgressSerializerTest` (runtime plumbing incl. null header values and the no-header fast path).
- New K8s E2E test `kafkaHeadersRoundTripThroughIngressAndEgress`: produces a `CounterCommand` with UTF-8 and binary headers, `KafkaCounterFn` echoes them and stamps `processed-by`, the test asserts byte-exact headers on the consumed result record.
- Docs: `docs/guides/kafka-io.md` gains a "Record headers" section.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added end-to-end Kafka record header support (ingress, routing, SDK message headers, and egress).
  * Preserves insertion order and duplicate keys, including distinct handling of null vs empty header values.
  * Introduced `Message#headers()` and `MessageHeader` for safe header access, plus new SDK builder APIs to attach Kafka headers.
* **Documentation**
  * Added a “Kafka record headers” guide and navigation entry.
* **Tests**
  * Added unit and end-to-end coverage for header round-tripping, ordering, and null semantics.
* **Compatibility**
  * Messages without headers continue to work unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
