### PR TITLE
chore(release): bump version to 3.4.0-KZM-3.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -102,7 +102,7 @@
     </modules>
 
     <properties>
-        <revision>3.4.0-KZM-3.3</revision>
+        <revision>3.4.0-KZM-3.4</revision>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <java.version>21</java.version>


### PR DESCRIPTION
Version bump for the 3.4.0-KZM-3.4 release. Headline: Kafka record header support (PR #264) — SDK read/write API with typed values and null fidelity, opt-in per-topic forwardHeaders, testing toolkit, docs guide. Also carries everything since v3.4.0-KZM-3.3: image CVE fixes (netty 4.1.135, jackson 2.18.8, Flink 2.2.1, logback migration), Flink Operator 1.15 + flinkVersion v2_2, Trivy scanning in CI, dependency bumps. Quickstart example stays on 3.4.0-KZM-3.3 until the new artifacts are published (established post-release step).