### PR TITLE
docs: announce Kafka record headers (article + comparison updates)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,50 @@ All notable changes to **StateFun Actors by Kzmlabs** are documented in this fil
 
 ## [Unreleased]
 
+## [3.4.0-KZM-3.4] - 2026-07-24
+
+Feature release. Headline: **Kafka record headers, end-to-end** — the
+Stateful Functions programming model can finally read and write Kafka
+headers, a gap upstream never closed. Also carries the accumulated
+security and platform work since KZM-3.3.
+
+### Added
+
+- **Kafka record header support for remote functions** (`statefun-sdk-java`):
+  - **Read**: `Message#headers()` exposes the headers of the Kafka record
+    that invoked the function — order and duplicate keys preserved; values
+    accessible as zero-copy `Slice`, UTF-8 text, SDK-typed primitives
+    (`valueAsInt()`/`valueAsLong()`/`valueAsFloat()`/`valueAsDouble()`/
+    `valueAsBoolean()`), or any `Type<T>` via `valueAs`.
+  - **Write**: `KafkaEgressMessage.Builder` gains the full header overload
+    family — `withUtf8Header`, raw `byte[]`/`Slice`, `Type<T>`, and binary
+    primitive shorthands (`withHeader("retry-count", 10)` transfers a real
+    binary int, not text).
+  - **Kafka-exact null semantics**: a null header value — which Kafka
+    distinguishes from an empty one — survives the full
+    ingress → function → egress round-trip as null, carried by an explicit
+    `has_value` flag (the `TypedValue` idiom). Header operations never
+    throw on production paths: null values are preserved, null keys degrade
+    to empty keys, undecodable values read as `null`.
+  - **Opt-in per topic**: ingress header forwarding is off by default;
+    enable with `forwardHeaders` at ingress level and/or per topic
+    (per-topic overrides win). Topics that have not opted in never capture
+    header bytes; header-less records add zero overhead on any path.
+  - **Function-to-function headers**: `MessageBuilder` carries the same
+    header API, and `MessageBuilder.fromMessage` now preserves headers
+    when forwarding.
+  - **Testing toolkit**: construct header-carrying messages with
+    `MessageBuilder`, assert egress output with the new
+    `testing.KafkaEgressCapture` (topic/key/value/headers, Kafka last-wins
+    `lastHeader`).
+  - **Protocol**: strictly additive protobuf fields
+    (`KafkaProducerRecord.headers`, `TypedValue.metadata`, ingress envelope
+    headers). Old SDKs interoperate with the new runtime and vice versa —
+    no lockstep upgrade, no savepoint impact. Validated by ~60 unit tests
+    and a K8s E2E round-trip asserting byte-exact UTF-8, binary, and
+    null-valued headers through a real cluster.
+  - New docs: [Kafka record headers guide](https://kzmlabs.github.io/flink-statefun/guides/kafka-headers/).
+
 ### Changed
 
 - **Flink Kubernetes Operator 1.11 → 1.15** — the K8s E2E release gate, the

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Full migration notes: **[Differences from Apache StateFun](https://kzmlabs.githu
     <dependency>
       <groupId>io.github.kzmlabs.flinkstatefun</groupId>
       <artifactId>statefun-bom</artifactId>
-      <version>3.4.0-KZM-3.3</version>
+      <version>3.4.0-KZM-3.4</version>
       <type>pom</type>
       <scope>import</scope>
     </dependency>
@@ -105,7 +105,7 @@ spec:
 ```bash
 docker run --rm -p 8081:8081 \
   -v $(pwd)/module.yaml:/opt/flink/conf/module.yaml \
-  ghcr.io/kzmlabs/flink-statefun:3.4.0-KZM-3.3
+  ghcr.io/kzmlabs/flink-statefun:3.4.0-KZM-3.4
 ```
 
 Full walkthrough → **[Quickstart guide](https://kzmlabs.github.io/flink-statefun/quickstart/)**.
@@ -148,14 +148,15 @@ JobManager and TaskManager logging is configured via `spec.logConfiguration.logb
 
 | Kzmlabs version | Apache StateFun base | Flink | Java | Status |
 |---|---|---|---|---|
-| `3.4.0-KZM-3.3` | 3.4.0 | 2.2.0 | 21 | Latest |
+| `3.4.0-KZM-3.4` | 3.4.0 | 2.2.1 | 21 | Latest |
+| `3.4.0-KZM-3.3` | 3.4.0 | 2.2.0 | 21 | Stable |
 | `3.4.0-KZM-3.1` | 3.4.0 | 2.2.0 | 21 | Stable |
 | `3.4.0-KZM-3.0` | 3.4.0 | 2.2.0 | 21 | Stable |
 
 Releases are signed via Sigstore keyless attestation. Verify with:
 
 ```bash
-gh attestation verify oci://ghcr.io/kzmlabs/flink-statefun:3.4.0-KZM-3.3 --owner kzmlabs
+gh attestation verify oci://ghcr.io/kzmlabs/flink-statefun:3.4.0-KZM-3.4 --owner kzmlabs
 ```
 
 ## Branch model

--- a/README.md
+++ b/README.md
@@ -36,12 +36,13 @@ Apache Stateful Functions stopped releasing in October 2024 at 3.4.0, locked to 
 
 > **Update — May 2026:** Apache has filed [FLIP-569: Sunset the Stateful Functions sub-project](https://cwiki.apache.org/confluence/display/FLINK/FLIP-569%3A+Sunset+the+Stateful+Functions+%28StateFun%29+Sub-project), formalising the end of upstream maintenance and naming "fork the repository" as one of the migration paths. This fork was already active before the proposal landed; FLIP-569 confirms the read from October 2024 that picking the project up was worth doing.
 
-| | Apache StateFun 3.4.0 | StateFun Actors KZM-3.3 |
+| | Apache StateFun 3.4.0 | StateFun Actors KZM-3.4 |
 |---|---|---|
 | **Flink runtime** | 1.16.2 | **2.2.1** |
 | **Java baseline** | 11 | **21** |
 | **Maven group** | `org.apache.flink` | `io.github.kzmlabs.flinkstatefun` |
 | **Kinesis I/O** | Flink 1.x consumer | **Restored** on Flink 2.x source/sink |
+| **Kafka record headers** | Not supported | **End-to-end** — read on ingress, write on egress, opt-in per topic |
 | **K8s release gate** | None | **Mandatory** kind + Flink Operator + LocalStack |
 | **Active CI** | Inactive after 3.4.0 | Dependabot, CodeQL, Scorecard, Trivy |
 | **Release cadence** | Dormant | Active (Maven Central + GHCR) |

--- a/docs/articles/flink-operator-1.15-upgrade.md
+++ b/docs/articles/flink-operator-1.15-upgrade.md
@@ -1,0 +1,132 @@
+---
+title: Upgrading the Apache Flink Kubernetes Operator from 1.11 to 1.15 for Flink 2.2
+description: A practical walkthrough of upgrading the Apache Flink Kubernetes Operator from 1.11 to 1.15 to run Flink 2.2 — version compatibility, what changed across releases, the flinkVersion change, a conservative configuration audit, and validation.
+---
+
+# Upgrading the Apache Flink Kubernetes Operator from 1.11 to 1.15 for Flink 2.2
+
+*Published 2026-06-17 · by the kzmlabs maintainers*
+
+If you run Flink on Kubernetes through the [Flink Kubernetes Operator][operator-docs], the operator — not your image — decides which Flink version you can declare. You can ship a `flink:2.2.0` image, but if the operator is too old it won't accept `flinkVersion: v2_2`, so you pin down to whatever it knows and run a version mismatch on purpose.
+
+This is what it took to close that gap: moving the operator from **1.11 to 1.15**, switching `flinkVersion` to `v2_2`, and doing it without rewriting config that didn't need to change. The worked example is our own migration of [`kzmlabs/flink-statefun`][our-repo], the Stateful Functions continuation on Flink 2.x, but none of it is StateFun-specific — it applies to any Flink app deployed through the operator.
+
+## The operator gates your Flink version
+
+The operator validates the `flinkVersion` field on a `FlinkDeployment` against the versions it knows how to reconcile. Too old an operator and the newer value isn't recognized, so you pin down and run a mismatch.
+
+Support for each Flink version lands in a specific operator release, and each operator supports a rolling window of recent Flink minors. The releases between 1.11 and 1.15:
+
+| Operator | Released | Supported Flink versions | Notable additions |
+|---|---|---|---|
+| 1.11 | Mar 2025 | 1.17–1.20, 2.0 | Flink 2.0 (preview); `v1_18+` version-range config |
+| 1.12 | Jun 2025 | 1.17–1.20, 2.0 | `config.yaml` support; Flink 2.x config validation |
+| 1.13 | Sep 2025 | 1.19, 1.20, 2.0, 2.1 | **Flink 2.1**; structured-YAML `flinkConfiguration` |
+| 1.14 | Feb 2026 | 1.19, 1.20, 2.0, 2.1 | `FlinkBlueGreenDeployment` CRD (native blue/green) |
+| 1.15 | May 2026 | 1.19, 1.20, 2.0, 2.1, 2.2 | **Flink 2.2**; Logback option; bundled metric reporters |
+
+The *supported* column lists the actively supported (non-deprecated) `flinkVersion` values each release accepts — older versions stay accepted but deprecated. The gating facts: Flink 2.0 needs operator 1.11+, Flink 2.1 needs 1.13+, and Flink 2.2 needs 1.15+.
+
+Before 1.15, a Flink 2.2.0 image had to be declared `flinkVersion: v2_0`. That was the workaround being carried, and the reason for the upgrade.
+
+## What changed between 1.11 and 1.15
+
+Jumping from 1.11 to 1.15 crosses four releases. The changes most relevant to an upgrade:
+
+- **1.12** — the operator emits Kubernetes events when a job enters `FAILED` or restarts unexpectedly, controller errors are reported with more context, and Flink's `config.yaml` format is supported alongside validation of Flink 2.x configuration.
+- **1.13** — Flink 2.1 support, plus the option to write `flinkConfiguration` as structured YAML rather than flat strings; also a fix for a job-failure bug when upgrading from 1.12.
+- **1.14** — native blue/green deployments through a new `FlinkBlueGreenDeployment` custom resource: zero-downtime upgrades, savepoint-based state hand-off, and rollback. This introduces new cluster-scoped CRDs and RBAC, which a clean Helm chart install picks up automatically.
+- **1.15** — Flink 2.2 support, an optional Logback logging framework, metric reporters bundled into the Helm chart, and Kubernetes-native status `Conditions` on `FlinkDeployment`.
+
+## The upgrade
+
+The mechanical part is small. Bump the Helm release:
+
+```bash
+helm repo add --force-update flink-operator-repo \
+  "https://archive.apache.org/dist/flink/flink-kubernetes-operator-1.15.0/"
+helm repo update flink-operator-repo
+helm install flink-kubernetes-operator flink-operator-repo/flink-kubernetes-operator \
+  --namespace flink-operator --create-namespace --wait --timeout 5m \
+  --version "1.15.0" \
+  --set image.tag="1.15.0"
+```
+
+`--force-update` overwrites a stale version-specific repo URL left by an earlier run, and `--version` pins the chart so a repo/version mismatch fails loudly ("chart not found") instead of silently installing the wrong chart against your new `image.tag`.
+
+Then change the one field this is all about:
+
+```yaml
+# before
+spec:
+  image: ghcr.io/your-org/your-app:flink-2.2.0
+  flinkVersion: "v2_0"   # only because the operator capped here
+
+# after
+spec:
+  image: ghcr.io/your-org/your-app:flink-2.2.0
+  flinkVersion: "v2_2"   # now matches the runtime
+```
+
+The CRD `apiVersion` is unchanged — operator 1.15 still serves `flink.apache.org/v1beta1`, so there's no group/version rewrite in your manifests.
+
+## Auditing `flinkConfiguration` conservatively
+
+This is where upgrades go sideways. The temptation is to rewrite every `flinkConfiguration` key to match the latest docs. That's usually a mistake.
+
+`flinkVersion` drives the operator's reconciler behaviour, not the runtime's config parsing. Your `flinkConfiguration` map is handed to a Flink 2.2.0 process whether the operator label says `v2_0` or `v2_2`. If the job already ran on a 2.2.0 image, those keys were already being parsed by Flink 2.2, and they worked. Bumping `flinkVersion` doesn't change how the runtime reads them.
+
+That gives a low-risk rule: only remove or rename a key when you can prove it was removed, renamed, or rejected on the target Flink version. Keys that merely look redundant with defaults stay. Anything ambiguous stays and gets a note instead of a deletion.
+
+The asymmetry is the argument. Flink warns on unknown config keys and moves on, so a stale key is cosmetic — but a wrongly deleted key is a behaviour change. In our migration the audit changed exactly one thing of substance: `flinkVersion`. The checkpointing, state-backend, HA, and restart-strategy blocks already ran clean on 2.2.0, so they stayed — verified, not assumed.
+
+## Logging: the operator pod won't emit JSON without a custom image
+
+The JobManager and TaskManager can emit JSON cleanly, because they run your application image — you ship the encoder (for example `logstash-logback-encoder`) and point `spec.logConfiguration` at a JSON `logback-console.xml`. The operator upgrade doesn't touch that.
+
+The operator pod is different. Operator 1.15 can run on Logback through a new `logging.framework=logback` Helm value, but its base image ships Logback 1.2.x with no JSON encoder on the classpath, and Logback's built-in `JsonEncoder` only arrived in 1.5.x. JSON logs from the operator pod would mean building a custom operator image to add the encoder.
+
+We didn't. The operator is an infrastructure controller, not application output, and a custom image to reformat its logs is maintenance you pay again at every operator bump. We left it on the Log4j2 default and kept the application logs as JSON. If your log pipeline genuinely requires JSON from every pod, the custom-image route exists.
+
+## Verifying the upgrade
+
+Two checks, in order.
+
+The operator is healthy when the pod is fully ready and the chart and app versions agree — the latter being the detail that catches version skew:
+
+```bash
+kubectl get pods -n flink-operator
+# flink-kubernetes-operator-…  2/2  Running  0  …
+helm list -n flink-operator
+# CHART flink-kubernetes-operator-1.15.0   APP VERSION 1.15.0   STATUS deployed
+```
+
+The migration is real when a `FlinkDeployment` on `flinkVersion: v2_2` reaches `READY`:
+
+```bash
+kubectl get flinkdeployment -n my-app \
+  -o jsonpath='{.items[*].status.jobManagerDeploymentStatus}'
+# READY
+```
+
+Validate on a real cluster, not only in CI. Our end-to-end gate — operator 1.15.0, `flinkVersion: v2_2`, Kafka and Kinesis I/O against a kind cluster — passed 4/4.
+
+## What to remember
+
+- The operator gates `flinkVersion`. Running Flink 2.2 needs operator 1.15+; the image alone isn't enough.
+- The functional change is small: a Helm version bump and `flinkVersion: v2_0 → v2_2`. The CRD `apiVersion` (`v1beta1`) is unchanged.
+- Audit `flinkConfiguration` conservatively. `flinkVersion` is operator-side; the runtime already parses your keys. Don't delete what you can't prove is gone.
+- Pin and force-update the Helm install (`--version` and `--force-update`) so a stale repo can't install the wrong chart against your new image.
+- The operator pod won't give you JSON logs without a custom image; the JM/TM will.
+- Validate on a real cluster, not only in CI.
+
+## Where to find it
+
+- **Source:** [github.com/kzmlabs/flink-statefun][our-repo]
+- **Docs:** [kzmlabs.github.io/flink-statefun][docs] — including the [Kubernetes deployment guide][k8s-guide]
+- **Flink Kubernetes Operator:** [official docs][operator-docs]
+
+[our-repo]: https://github.com/kzmlabs/flink-statefun
+[docs]: https://kzmlabs.github.io/flink-statefun/
+[k8s-guide]: ../guides/k8s-deployment.md
+[operator-docs]: https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/

--- a/docs/articles/index.md
+++ b/docs/articles/index.md
@@ -9,5 +9,8 @@ Long-form notes from the maintainers — the design decisions, migration playboo
 
 ## Latest
 
+- [**Kafka record headers in Stateful Functions — closing a five-year-old gap**](kafka-record-headers.md)
+  End-to-end header support lands in KZM-3.4: trace propagation through function graphs, typed header values, Kafka-exact null semantics, per-topic opt-in — and the protocol trick that made it possible without touching the runtime's hot path. *2026-07-24*
+
 - [**We forked Apache Stateful Functions for Flink 2.x — here's why**](forking-statefun.md)
   Why the project exists, what we changed under the hood, what stayed the same for upstream users, and where this fits versus Kafka Streams, ksqlDB, and Akka. *2026-05-03*

--- a/docs/articles/kafka-record-headers.md
+++ b/docs/articles/kafka-record-headers.md
@@ -1,0 +1,140 @@
+---
+title: Kafka record headers in Stateful Functions — closing a five-year-old gap
+description: StateFun Actors 3.4.0-KZM-3.4 adds end-to-end Kafka record header support to the Stateful Functions programming model — trace propagation, typed values, Kafka-exact null semantics, and per-topic opt-in.
+---
+
+# Kafka record headers in Stateful Functions — closing a five-year-old gap
+
+*Published 2026-07-24 · by the kzmlabs maintainers*
+
+Apache Stateful Functions never supported Kafka record headers. Not on the way in — a function had no way to see the headers of the record that invoked it. Not on the way out — the egress builder had topic, key, and value, and nothing else. If your platform standardized on header-borne trace context, tenant tags, or schema hints, StateFun was a black hole in the middle of your pipeline: headers went in, and they never came out.
+
+[StateFun Actors 3.4.0-KZM-3.4](https://github.com/kzmlabs/flink-statefun/releases/tag/v3.4.0-KZM-3.4) closes that gap end-to-end for remote functions built with the Java SDK. This post covers what shipped, the design decisions worth knowing about — including one protocol trick that made the whole thing possible without touching the runtime's hot path — and how to adopt it in a running deployment.
+
+## What can StateFun functions do with Kafka headers now?
+
+Both directions, symmetric API.
+
+**Reading** — a function invoked by a Kafka record sees that record's headers:
+
+```java
+public CompletableFuture<Void> apply(Context context, Message message) {
+    for (MessageHeader header : message.headers()) {
+        switch (header.key()) {
+            case "traceparent" -> span.setParent(header.valueAsUtf8String());
+            case "retry-count" -> handleRetry(header.valueAsInt());
+        }
+    }
+    ...
+}
+```
+
+**Writing** — the egress builder attaches headers to the produced record:
+
+```java
+context.send(
+    KafkaEgressMessage.forEgress(NOTIFICATIONS)
+        .withTopic("notifications")
+        .withUtf8Key(orderId)
+        .withValue(payload)
+        .withUtf8Header("traceparent", traceContext)  // UTF-8 text
+        .withHeader("payload-hash", hashBytes)        // raw bytes
+        .withHeader("retry-count", 10)                // binary int — 10, not "10"
+        .build());
+```
+
+The obvious first use case is distributed tracing: a W3C `traceparent` header can now ride a record from your edge producer, through a StateFun function graph, and out to downstream consumers — the thing that was previously impossible without smuggling trace context inside every payload schema.
+
+## Why is "10, not \"10\"" worth a bullet point?
+
+Kafka headers are raw bytes on the wire — Kafka has no typed headers. Most frameworks make you pick between hand-stringifying numbers or hand-packing byte buffers. The SDK gives you three explicit encodings and never guesses:
+
+- `withUtf8Header(key, text)` — plain text, readable by any Kafka consumer, `kcat`, or Connect.
+- `withHeader(key, bytes)` — raw bytes, you own the format.
+- `withHeader(key, 10)` / `withHeader(key, type, value)` — the SDK's binary type encodings, decoded losslessly on the read side by `valueAsInt()`, `valueAsLong()`, `valueAsFloat()`, `valueAsDouble()`, `valueAsBoolean()`, or `valueAs(Type<T>)`.
+
+Every read accessor shares one production-safety contract: a null or undecodable value returns `null` — never an exception inside a live function invocation.
+
+## What happens to null header values?
+
+They stay null. This detail is easy to get wrong: Kafka's wire format distinguishes a header whose value is **null** from one whose value is **empty** (a null value encodes as length `-1`), and `Header#value()` in the Kafka client legitimately returns `null`. Protobuf — which carries StateFun's remote-function protocol — cannot represent null bytes.
+
+We bridged that with the same idiom StateFun's protocol already used for exactly this problem: an explicit `has_value` flag, mirroring `TypedValue.has_value`. A null-valued header goes in as null and comes out as null, byte-for-byte verified in the Kubernetes end-to-end suite. Echoing headers is therefore lossless:
+
+```java
+message.headers().forEach(h -> egress.withHeader(h.key(), h.value()));
+```
+
+## How did this land without touching the runtime's hot path?
+
+The interesting design constraint: an ingress record's payload crosses the whole Flink runtime — router, internal message envelope, feedback loop, request-reply dispatcher — as a single `TypedValue` protobuf, which the dispatcher copies verbatim into the remote function invocation. There is no side channel.
+
+So the headers ride the `TypedValue` itself, as a new repeated `metadata` field. Additive protobuf, preserved by every serialization boundary in between, delivered to the SDK with **zero changes to flink-core**. Old SDKs parse and ignore the field; new SDKs against old runtimes simply see no metadata. No lockstep upgrade, no savepoint migration, no protocol version bump.
+
+A pleasant side effect: function-to-function messages can carry headers too — `MessageBuilder` has the same header API, and forwarding via `MessageBuilder.fromMessage(...)` preserves them.
+
+## Doesn't this bloat every record?
+
+Only if you ask for it. Ingress header forwarding is **opt-in per topic**, because captured headers cost bytes on every hop — the routable envelope, the Flink shuffle, the HTTP request to your function:
+
+```yaml
+kind: io.statefun.kafka.v1/ingress
+spec:
+  id: example/orders-in
+  forwardHeaders: true          # ingress-level default for all topics
+  topics:
+    - topic: orders
+      valueType: example/Order
+      targets: [example/order-fn]
+    - topic: firehose
+      forwardHeaders: false     # per-topic override wins
+      valueType: example/Event
+      targets: [example/event-fn]
+```
+
+Topics that have not opted in never capture headers — nothing enters the runtime, and `Message#headers()` returns an empty list. Records on opted-in topics that happen to carry no headers add zero overhead: the hot path guards every allocation behind a header-count check. Egress headers are always available since they are explicit builder calls.
+
+## Can I unit-test functions that use headers?
+
+Yes, without touching protobuf. The SDK testing toolkit grew alongside the feature:
+
+```java
+Message message =
+    MessageBuilder.forAddress(SELF)
+        .withValue("payload")
+        .withUtf8Header("traceparent", "00-abc...")
+        .withHeader("attempt", 3)
+        .build();
+TestContext context = TestContext.forTarget(SELF);
+
+functionUnderTest.apply(context, message).get();
+
+KafkaEgressCapture record =
+    KafkaEgressCapture.of(context.getSentEgressMessages().get(0).message());
+assertThat(record.lastHeader("traceparent").orElseThrow().valueAsUtf8String())
+    .startsWith("00-");
+```
+
+`KafkaEgressCapture` unpacks a captured egress message into topic, key, value, and headers — with `lastHeader` following Kafka's own last-wins semantics.
+
+## How is this tested?
+
+Three layers. Unit tests pin the contract at every seam — around sixty header-focused cases covering duplicate keys, ordering, all six value encodings, null-vs-empty at each boundary, and garbage bytes decoding to `null` instead of throwing. The Kubernetes end-to-end gate — the same one every release must pass — produces a record with UTF-8, binary, *and* null-valued headers into a kind cluster running the Flink Operator, has a remote function echo them, and asserts byte-exact results on the output topic. And the null-handling semantics were verified against `kafka-clients` itself before the design was fixed, not assumed from documentation.
+
+## How do I get it?
+
+`3.4.0-KZM-3.4` on [Maven Central](https://central.sonatype.com/artifact/io.github.kzmlabs.flinkstatefun/statefun-sdk-java) and [GHCR](https://github.com/kzmlabs/flink-statefun/pkgs/container/flink-statefun):
+
+```xml
+<dependency>
+    <groupId>io.github.kzmlabs.flinkstatefun</groupId>
+    <artifactId>statefun-sdk-java</artifactId>
+    <version>3.4.0-KZM-3.4</version>
+</dependency>
+```
+
+Existing deployments upgrade in place — the protocol change is strictly additive, and header forwarding stays off until a topic opts in, so nothing changes behavior until you say so.
+
+Full reference: **[the Kafka record headers guide](https://kzmlabs.github.io/flink-statefun/guides/kafka-headers/)**. Background on the fork itself: **[We forked Apache Stateful Functions for Flink 2.x — here's why](forking-statefun.md)**.
+
+[our-repo]: https://github.com/kzmlabs/flink-statefun

--- a/docs/articles/kafka-record-headers.md
+++ b/docs/articles/kafka-record-headers.md
@@ -9,7 +9,7 @@ description: StateFun Actors 3.4.0-KZM-3.4 adds end-to-end Kafka record header s
 
 Apache Stateful Functions never supported Kafka record headers. Not on the way in — a function had no way to see the headers of the record that invoked it. Not on the way out — the egress builder had topic, key, and value, and nothing else. If your platform standardized on header-borne trace context, tenant tags, or schema hints, StateFun was a black hole in the middle of your pipeline: headers went in, and they never came out.
 
-[StateFun Actors 3.4.0-KZM-3.4](https://github.com/kzmlabs/flink-statefun/releases/tag/v3.4.0-KZM-3.4) closes that gap end-to-end for remote functions built with the Java SDK. This post covers what shipped, the design decisions worth knowing about — including one protocol trick that made the whole thing possible without touching the runtime's hot path — and how to adopt it in a running deployment.
+[StateFun Actors 3.4.0-KZM-3.4](https://github.com/kzmlabs/flink-statefun/releases/tag/v3.4.0-KZM-3.4) finally closes that gap for remote functions built with the Java SDK. Here's what shipped, a couple of design decisions we sweated over more than expected (null handling took three iterations), and how to adopt it in a running deployment.
 
 ## What can StateFun functions do with Kafka headers now?
 
@@ -59,7 +59,7 @@ Every read accessor shares one production-safety contract: a null or undecodable
 
 They stay null. This detail is easy to get wrong: Kafka's wire format distinguishes a header whose value is **null** from one whose value is **empty** (a null value encodes as length `-1`), and `Header#value()` in the Kafka client legitimately returns `null`. Protobuf — which carries StateFun's remote-function protocol — cannot represent null bytes.
 
-We bridged that with the same idiom StateFun's protocol already used for exactly this problem: an explicit `has_value` flag, mirroring `TypedValue.has_value`. A null-valued header goes in as null and comes out as null, byte-for-byte verified in the Kubernetes end-to-end suite. Echoing headers is therefore lossless:
+Our first cut coerced null to empty bytes. It worked, and it was wrong — we only caught it after actually checking what `kafka-clients` does (null header values are legal and preserved; null *keys* are rejected). The fix borrows the idiom StateFun's protocol already uses for exactly this problem: an explicit `has_value` flag, same as `TypedValue.has_value`. A null-valued header now goes in as null and comes out as null, which also means echoing headers is lossless:
 
 ```java
 message.headers().forEach(h -> egress.withHeader(h.key(), h.value()));
@@ -119,7 +119,7 @@ assertThat(record.lastHeader("traceparent").orElseThrow().valueAsUtf8String())
 
 ## How is this tested?
 
-Three layers. Unit tests pin the contract at every seam — around sixty header-focused cases covering duplicate keys, ordering, all six value encodings, null-vs-empty at each boundary, and garbage bytes decoding to `null` instead of throwing. The Kubernetes end-to-end gate — the same one every release must pass — produces a record with UTF-8, binary, *and* null-valued headers into a kind cluster running the Flink Operator, has a remote function echo them, and asserts byte-exact results on the output topic. And the null-handling semantics were verified against `kafka-clients` itself before the design was fixed, not assumed from documentation.
+Around sixty unit tests pin the contract at each seam: duplicate keys, ordering, all six value encodings, null-vs-empty at every boundary, garbage bytes decoding to `null` instead of throwing. On top of that sits the Kubernetes end-to-end gate every release has to pass anyway — it now produces a record with UTF-8, binary, *and* null-valued headers into a kind cluster running the Flink Operator, has a remote function echo them, and asserts byte-exact results on the output topic.
 
 ## How do I get it?
 

--- a/docs/guides/k8s-deployment.md
+++ b/docs/guides/k8s-deployment.md
@@ -37,7 +37,7 @@ metadata:
   name: my-statefun
   namespace: my-app
 spec:
-  image: ghcr.io/kzmlabs/flink-statefun:3.4.0-KZM-3.3
+  image: ghcr.io/kzmlabs/flink-statefun:3.4.0-KZM-3.4
   flinkVersion: v2_2
   flinkConfiguration:
     state.backend.type: rocksdb

--- a/docs/index.md
+++ b/docs/index.md
@@ -116,7 +116,7 @@ Write functions in whichever language fits the team. Plug into the streaming and
 
 Apache Stateful Functions stopped releasing in **October 2024** at version 3.4.0, locked to **Flink 1.16** and **Java 11**. Anyone wanting to run it against modern Flink either pinned old dependencies or vendored their own patches. StateFun Actors is the public, actively maintained continuation — same code, modern stack, no vendor lock-in.
 
-| | Apache StateFun 3.4.0 | StateFun Actors KZM-3.3 |
+| | Apache StateFun 3.4.0 | StateFun Actors KZM-3.4 |
 |---|---|---|
 | **Flink runtime** | 1.16.2 | **2.2.1** |
 | **Java baseline** | 11 | **21** |
@@ -165,7 +165,7 @@ Releases are signed via Sigstore keyless attestation, scanned with Trivy, and tr
 Verify a release artifact with the GitHub CLI:
 
 ```bash
-gh attestation verify oci://ghcr.io/kzmlabs/flink-statefun:3.4.0-KZM-3.3 --owner kzmlabs
+gh attestation verify oci://ghcr.io/kzmlabs/flink-statefun:3.4.0-KZM-3.4 --owner kzmlabs
 ```
 
 ## Where next

--- a/docs/index.md
+++ b/docs/index.md
@@ -133,6 +133,7 @@ Apache Stateful Functions stopped releasing in **October 2024** at version 3.4.0
 -   **Per-key durable state** — read and write your function's own state without manually wiring Flink keyed-state primitives.
 -   **Exactly-once messaging** between functions and to/from external systems, riding Flink's checkpointing.
 -   **Polyglot remote functions** — write functions as HTTP endpoints in any language; the runtime owns state and routing.
+-   **Kafka record headers, end-to-end** *(new in KZM-3.4)* — functions read the headers of the record that triggered them and set headers on egress records, with Kafka-exact null semantics and per-topic opt-in. [Guide →](guides/kafka-headers.md)
 -   **Deployment flexibility** — embedded in Flink, co-located with the JobManager, or remote HTTP services scaled independently.
 -   **Production-grade releases** — every version is gated on a real K8s end-to-end run with the Flink Operator, Kafka, S3 checkpoints, and the actual remote-function pod.
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -21,7 +21,7 @@ The full module set is published to Maven Central under the `io.github.kzmlabs.f
         <dependency>
           <groupId>io.github.kzmlabs.flinkstatefun</groupId>
           <artifactId>statefun-bom</artifactId>
-          <version>3.4.0-KZM-3.3</version>
+          <version>3.4.0-KZM-3.4</version>
           <type>pom</type>
           <scope>import</scope>
         </dependency>
@@ -44,7 +44,7 @@ The full module set is published to Maven Central under the `io.github.kzmlabs.f
     <dependency>
       <groupId>io.github.kzmlabs.flinkstatefun</groupId>
       <artifactId>statefun-sdk-java</artifactId>
-      <version>3.4.0-KZM-3.3</version>
+      <version>3.4.0-KZM-3.4</version>
     </dependency>
     ```
 
@@ -52,7 +52,7 @@ The full module set is published to Maven Central under the `io.github.kzmlabs.f
 
     ```kotlin
     dependencies {
-      implementation(platform("io.github.kzmlabs.flinkstatefun:statefun-bom:3.4.0-KZM-3.3"))
+      implementation(platform("io.github.kzmlabs.flinkstatefun:statefun-bom:3.4.0-KZM-3.4"))
       implementation("io.github.kzmlabs.flinkstatefun:statefun-sdk-java")
     }
     ```
@@ -62,7 +62,7 @@ The full module set is published to Maven Central under the `io.github.kzmlabs.f
 Container images are published to GitHub Container Registry:
 
 ```bash
-docker pull ghcr.io/kzmlabs/flink-statefun:3.4.0-KZM-3.3
+docker pull ghcr.io/kzmlabs/flink-statefun:3.4.0-KZM-3.4
 ```
 
 The image bundles **Flink 2.2 + Java 21 + the StateFun distribution JARs + S3/OSS/Azure plugin filesystems**, ready to run as a `FlinkDeployment` via the Flink Kubernetes Operator.
@@ -72,7 +72,7 @@ The image bundles **Flink 2.2 + Java 21 + the StateFun distribution JARs + S3/OS
     Releases are signed with [Sigstore keyless attestation](https://docs.sigstore.dev/) and carry [SLSA build provenance](https://slsa.dev/). Verify with:
 
     ```bash
-    gh attestation verify oci://ghcr.io/kzmlabs/flink-statefun:3.4.0-KZM-3.3 --owner kzmlabs
+    gh attestation verify oci://ghcr.io/kzmlabs/flink-statefun:3.4.0-KZM-3.4 --owner kzmlabs
     ```
 
 ## Module overview
@@ -93,7 +93,8 @@ The image bundles **Flink 2.2 + Java 21 + the StateFun distribution JARs + S3/OS
 
 | Kzmlabs version | Apache StateFun base | Flink | Java | Status |
 |---|---|---|---|---|
-| **`3.4.0-KZM-3.3`** | 3.4.0 | 2.2.0 | 21 | **Latest stable** |
+| **`3.4.0-KZM-3.4`** | 3.4.0 | 2.2.1 | 21 | **Latest stable** |
+| `3.4.0-KZM-3.3` | 3.4.0 | 2.2.0 | 21 | Stable |
 | `3.4.0-KZM-3.1` | 3.4.0 | 2.2.0 | 21 | Stable |
 | `3.4.0-KZM-3.0` | 3.4.0 | 2.2.0 | 21 | Stable |
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -126,7 +126,7 @@ The runtime owns state, routing, exactly-once delivery, and checkpointing. Your 
 
 ??? failure "`pull access denied` on the GHCR image"
 
-    The image is public. If you see this, your local Docker is logged into a different GHCR account that lacks access. Run `docker logout ghcr.io` and try again, or pin to a different tag with `docker pull ghcr.io/kzmlabs/flink-statefun:3.4.0-KZM-3.3` to verify connectivity.
+    The image is public. If you see this, your local Docker is logged into a different GHCR account that lacks access. Run `docker logout ghcr.io` and try again, or pin to a different tag with `docker pull ghcr.io/kzmlabs/flink-statefun:3.4.0-KZM-3.4` to verify connectivity.
 
 ??? failure "Step 4 returns no output / consumer hangs"
 

--- a/docs/snapshots.md
+++ b/docs/snapshots.md
@@ -63,7 +63,7 @@ The `<id>` in `settings.xml` must match the `<id>` of the `<repository>` block i
 <dependency>
     <groupId>io.github.kzmlabs.flinkstatefun</groupId>
     <artifactId>statefun-sdk-java</artifactId>
-    <version>3.4.0-KZM-3.3-SNAPSHOT</version>
+    <version>3.4.0-KZM-3.4-SNAPSHOT</version>
 </dependency>
 ```
 

--- a/docs/upstream-vs-kzm.md
+++ b/docs/upstream-vs-kzm.md
@@ -9,12 +9,13 @@ description: Migration guide from Apache Stateful Functions 3.4.0 to StateFun Ac
 
 ## At a glance
 
-| | Apache StateFun 3.4.0 | StateFun Actors KZM-3.3 |
+| | Apache StateFun 3.4.0 | StateFun Actors KZM-3.4 |
 |---|---|---|
 | **Flink runtime** | 1.16.2 | **2.2.1** |
 | **Java baseline** | 11 | **21** |
 | **Maven group** | `org.apache.flink` | `io.github.kzmlabs.flinkstatefun` |
 | **Kinesis I/O** | Built for Flink 1.x Kinesis source | **Restored** on Flink 2.x's `KinesisStreamsSource`/`KinesisStreamsSink` |
+| **Kafka record headers** | Not supported | **End-to-end round-trip** — `Message#headers()` on ingress, egress builder on write, [opt-in per topic](guides/kafka-headers.md) |
 | **Active CI** | Inactive after 3.4.0 | Ongoing — Dependabot, CodeQL, Scorecard, Trivy |
 | **K8s deployment** | Examples in docs | **K8s-native E2E gate** via Flink Operator + LocalStack |
 | **Docker image** | `apache/flink-statefun:3.4.0` (Flink 1.16) | `ghcr.io/kzmlabs/flink-statefun:3.4.0-KZM-3.3` (Flink 2.2) |

--- a/docs/upstream-vs-kzm.md
+++ b/docs/upstream-vs-kzm.md
@@ -18,7 +18,7 @@ description: Migration guide from Apache Stateful Functions 3.4.0 to StateFun Ac
 | **Kafka record headers** | Not supported | **End-to-end round-trip** — `Message#headers()` on ingress, egress builder on write, [opt-in per topic](guides/kafka-headers.md) |
 | **Active CI** | Inactive after 3.4.0 | Ongoing — Dependabot, CodeQL, Scorecard, Trivy |
 | **K8s deployment** | Examples in docs | **K8s-native E2E gate** via Flink Operator + LocalStack |
-| **Docker image** | `apache/flink-statefun:3.4.0` (Flink 1.16) | `ghcr.io/kzmlabs/flink-statefun:3.4.0-KZM-3.3` (Flink 2.2) |
+| **Docker image** | `apache/flink-statefun:3.4.0` (Flink 1.16) | `ghcr.io/kzmlabs/flink-statefun:3.4.0-KZM-3.4` (Flink 2.2) |
 | **Test framework** | JUnit 4 | JUnit Jupiter 5.11 |
 | **Release cadence** | Dormant | Active (Maven Central + GHCR) |
 
@@ -32,7 +32,7 @@ description: Migration guide from Apache Stateful Functions 3.4.0 to StateFun Ac
 +  <groupId>io.github.kzmlabs.flinkstatefun</groupId>
    <artifactId>statefun-sdk-java</artifactId>
 -  <version>3.4.0</version>
-+  <version>3.4.0-KZM-3.3</version>
++  <version>3.4.0-KZM-3.4</version>
  </dependency>
 ```
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -83,6 +83,7 @@ nav:
       - End-to-end tests: architecture/e2e-tests.md
   - Articles:
       - Overview: articles/index.md
+      - Kafka record headers in Stateful Functions: articles/kafka-record-headers.md
       - We forked Apache Stateful Functions for Flink 2.x: articles/forking-statefun.md
   - Differences from Apache StateFun: upstream-vs-kzm.md
   - Release process: release-process.md


### PR DESCRIPTION
Tier-1 announcement for the KZM-3.4 headers feature: canonical article for syndication, upstream-comparison rows in README and docs, feature bullet on the docs home. Validated with mkdocs build --strict.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added end-to-end Kafka record header support, including reading incoming headers and preserving or writing headers when forwarding messages.
  - Added explicit handling for Kafka null header values and optional per-topic header forwarding.
  - Added testing guidance and tools for validating Kafka header behavior.

- **Documentation**
  - Added Kafka record headers and Flink Kubernetes Operator upgrade guides.
  - Updated installation, migration, deployment, and release documentation for version 3.4.0-KZM-3.4.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->