### PR TITLE
chore(examples): bump quickstart to 3.4.0-KZM-3.4

### DIFF
--- a/examples/quickstart/greeter/pom.xml
+++ b/examples/quickstart/greeter/pom.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+﻿<?xml version="1.0" encoding="UTF-8"?>
 <!-- SPDX-License-Identifier: Apache-2.0 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
@@ -17,7 +17,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>21</maven.compiler.source>
         <maven.compiler.target>21</maven.compiler.target>
-        <statefun.version>3.4.0-KZM-3.3</statefun.version>
+        <statefun.version>3.4.0-KZM-3.4</statefun.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
Post-release quickstart bump, same pattern as KZM-3.3. The 3.4.0-KZM-3.4 artifacts are live on Maven Central and GHCR; quickstart-smoke validates the round-trip against them.