### PR TITLE
docs: no em-dashes in header article and new guide pages

### DIFF
--- a/docs/articles/index.md
+++ b/docs/articles/index.md
@@ -1,16 +1,16 @@
 ---
 title: Articles
-description: Long-form notes on the StateFun Actors continuation — design decisions, migration playbooks, and lessons from running stateful actors on Apache Flink 2.x.
+description: Long-form notes on the StateFun Actors continuation - design decisions, migration playbooks, and lessons from running stateful actors on Apache Flink 2.x.
 ---
 
 # Articles
 
-Long-form notes from the maintainers — the design decisions, migration playbooks, and engineering lessons behind running stateful actors on Apache Flink 2.x.
+Long-form notes from the maintainers - the design decisions, migration playbooks, and engineering lessons behind running stateful actors on Apache Flink 2.x.
 
 ## Latest
 
-- [**Kafka record headers in Stateful Functions — closing a five-year-old gap**](kafka-record-headers.md)
-  End-to-end header support lands in KZM-3.4: trace propagation through function graphs, typed header values, Kafka-exact null semantics, per-topic opt-in — and the protocol trick that made it possible without touching the runtime's hot path. *2026-07-24*
+- [**Kafka record headers in Stateful Functions - closing a five-year-old gap**](kafka-record-headers.md)
+  End-to-end header support lands in KZM-3.4: trace propagation through function graphs, typed header values, Kafka-exact null semantics, per-topic opt-in - and the protocol trick that made it possible without touching the runtime's hot path. *2026-07-24*
 
-- [**We forked Apache Stateful Functions for Flink 2.x — here's why**](forking-statefun.md)
+- [**We forked Apache Stateful Functions for Flink 2.x - here's why**](forking-statefun.md)
   Why the project exists, what we changed under the hood, what stayed the same for upstream users, and where this fits versus Kafka Streams, ksqlDB, and Akka. *2026-05-03*

--- a/docs/articles/kafka-record-headers.md
+++ b/docs/articles/kafka-record-headers.md
@@ -1,13 +1,13 @@
 ---
-title: Kafka record headers in Stateful Functions — closing a five-year-old gap
-description: StateFun Actors 3.4.0-KZM-3.4 adds end-to-end Kafka record header support to the Stateful Functions programming model — trace propagation, typed values, Kafka-exact null semantics, and per-topic opt-in.
+title: "Kafka record headers in Stateful Functions: closing a five-year-old gap"
+description: StateFun Actors 3.4.0-KZM-3.4 adds end-to-end Kafka record header support to the Stateful Functions programming model - trace propagation, typed values, Kafka-exact null semantics, and per-topic opt-in.
 ---
 
-# Kafka record headers in Stateful Functions — closing a five-year-old gap
+# Kafka record headers in Stateful Functions: closing a five-year-old gap
 
-*Published 2026-07-24 · by the kzmlabs maintainers*
+*Published 2026-07-24 · by the kzmlabs maintainers · [Read on dev.to](https://dev.to/okazimirov/kafka-record-headers-in-stateful-functions-closing-a-five-year-old-gap-5bon)*
 
-Apache Stateful Functions never supported Kafka record headers. Not on the way in — a function had no way to see the headers of the record that invoked it. Not on the way out — the egress builder had topic, key, and value, and nothing else. If your platform standardized on header-borne trace context, tenant tags, or schema hints, StateFun was a black hole in the middle of your pipeline: headers went in, and they never came out.
+Apache Stateful Functions never supported Kafka record headers. Not on the way in: a function had no way to see the headers of the record that invoked it. Not on the way out: the egress builder had topic, key, and value, and nothing else. If your platform standardized on header-borne trace context, tenant tags, or schema hints, StateFun was a black hole in the middle of your pipeline. Headers went in, and they never came out.
 
 [StateFun Actors 3.4.0-KZM-3.4](https://github.com/kzmlabs/flink-statefun/releases/tag/v3.4.0-KZM-3.4) finally closes that gap for remote functions built with the Java SDK. Here's what shipped, a couple of design decisions we sweated over more than expected (null handling took three iterations), and how to adopt it in a running deployment.
 
@@ -15,7 +15,7 @@ Apache Stateful Functions never supported Kafka record headers. Not on the way i
 
 Both directions, symmetric API.
 
-**Reading** — a function invoked by a Kafka record sees that record's headers:
+**Reading**: a function invoked by a Kafka record sees that record's headers.
 
 ```java
 public CompletableFuture<Void> apply(Context context, Message message) {
@@ -29,7 +29,7 @@ public CompletableFuture<Void> apply(Context context, Message message) {
 }
 ```
 
-**Writing** — the egress builder attaches headers to the produced record:
+**Writing**: the egress builder attaches headers to the produced record.
 
 ```java
 context.send(
@@ -39,27 +39,27 @@ context.send(
         .withValue(payload)
         .withUtf8Header("traceparent", traceContext)  // UTF-8 text
         .withHeader("payload-hash", hashBytes)        // raw bytes
-        .withHeader("retry-count", 10)                // binary int — 10, not "10"
+        .withHeader("retry-count", 10)                // binary int, 10, not "10"
         .build());
 ```
 
-The obvious first use case is distributed tracing: a W3C `traceparent` header can now ride a record from your edge producer, through a StateFun function graph, and out to downstream consumers — the thing that was previously impossible without smuggling trace context inside every payload schema.
+The obvious first use case is distributed tracing: a W3C `traceparent` header can now ride a record from your edge producer, through a StateFun function graph, and out to downstream consumers. That was previously impossible without smuggling trace context inside every payload schema.
 
 ## Why is "10, not \"10\"" worth a bullet point?
 
-Kafka headers are raw bytes on the wire — Kafka has no typed headers. Most frameworks make you pick between hand-stringifying numbers or hand-packing byte buffers. The SDK gives you three explicit encodings and never guesses:
+Kafka headers are raw bytes on the wire; Kafka has no typed headers. Most frameworks make you pick between hand-stringifying numbers or hand-packing byte buffers. The SDK gives you three explicit encodings and never guesses:
 
-- `withUtf8Header(key, text)` — plain text, readable by any Kafka consumer, `kcat`, or Connect.
-- `withHeader(key, bytes)` — raw bytes, you own the format.
-- `withHeader(key, 10)` / `withHeader(key, type, value)` — the SDK's binary type encodings, decoded losslessly on the read side by `valueAsInt()`, `valueAsLong()`, `valueAsFloat()`, `valueAsDouble()`, `valueAsBoolean()`, or `valueAs(Type<T>)`.
+- `withUtf8Header(key, text)`: plain text, readable by any Kafka consumer, `kcat`, or Connect.
+- `withHeader(key, bytes)`: raw bytes, you own the format.
+- `withHeader(key, 10)` / `withHeader(key, type, value)`: the SDK's binary type encodings, decoded losslessly on the read side by `valueAsInt()`, `valueAsLong()`, `valueAsFloat()`, `valueAsDouble()`, `valueAsBoolean()`, or `valueAs(Type<T>)`.
 
-Every read accessor shares one production-safety contract: a null or undecodable value returns `null` — never an exception inside a live function invocation.
+Every read accessor shares one production-safety contract: a null or undecodable value returns `null`, never an exception inside a live function invocation.
 
 ## What happens to null header values?
 
-They stay null. This detail is easy to get wrong: Kafka's wire format distinguishes a header whose value is **null** from one whose value is **empty** (a null value encodes as length `-1`), and `Header#value()` in the Kafka client legitimately returns `null`. Protobuf — which carries StateFun's remote-function protocol — cannot represent null bytes.
+They stay null. This detail is easy to get wrong: Kafka's wire format distinguishes a header whose value is **null** from one whose value is **empty** (a null value encodes as length `-1`), and `Header#value()` in the Kafka client legitimately returns `null`. Protobuf, which carries StateFun's remote-function protocol, cannot represent null bytes.
 
-Our first cut coerced null to empty bytes. It worked, and it was wrong — we only caught it after actually checking what `kafka-clients` does (null header values are legal and preserved; null *keys* are rejected). The fix borrows the idiom StateFun's protocol already uses for exactly this problem: an explicit `has_value` flag, same as `TypedValue.has_value`. A null-valued header now goes in as null and comes out as null, which also means echoing headers is lossless:
+Our first cut coerced null to empty bytes. It worked, and it was wrong. We only caught it after actually checking what `kafka-clients` does (null header values are legal and preserved; null *keys* are rejected). The fix borrows the idiom StateFun's protocol already uses for exactly this problem: an explicit `has_value` flag, same as `TypedValue.has_value`. A null-valued header now goes in as null and comes out as null, which also means echoing headers is lossless:
 
 ```java
 message.headers().forEach(h -> egress.withHeader(h.key(), h.value()));
@@ -67,15 +67,15 @@ message.headers().forEach(h -> egress.withHeader(h.key(), h.value()));
 
 ## How did this land without touching the runtime's hot path?
 
-The interesting design constraint: an ingress record's payload crosses the whole Flink runtime — router, internal message envelope, feedback loop, request-reply dispatcher — as a single `TypedValue` protobuf, which the dispatcher copies verbatim into the remote function invocation. There is no side channel.
+The interesting design constraint: an ingress record's payload crosses the whole Flink runtime (router, internal message envelope, feedback loop, request-reply dispatcher) as a single `TypedValue` protobuf, which the dispatcher copies verbatim into the remote function invocation. There is no side channel.
 
 So the headers ride the `TypedValue` itself, as a new repeated `metadata` field. Additive protobuf, preserved by every serialization boundary in between, delivered to the SDK with **zero changes to flink-core**. Old SDKs parse and ignore the field; new SDKs against old runtimes simply see no metadata. No lockstep upgrade, no savepoint migration, no protocol version bump.
 
-A pleasant side effect: function-to-function messages can carry headers too — `MessageBuilder` has the same header API, and forwarding via `MessageBuilder.fromMessage(...)` preserves them.
+A pleasant side effect: function-to-function messages can carry headers too. `MessageBuilder` has the same header API, and forwarding via `MessageBuilder.fromMessage(...)` preserves them.
 
 ## Doesn't this bloat every record?
 
-Only if you ask for it. Ingress header forwarding is **opt-in per topic**, because captured headers cost bytes on every hop — the routable envelope, the Flink shuffle, the HTTP request to your function:
+Only if you ask for it. Ingress header forwarding is **opt-in per topic**, because captured headers cost bytes on every hop: the routable envelope, the Flink shuffle, the HTTP request to your function.
 
 ```yaml
 kind: io.statefun.kafka.v1/ingress
@@ -92,7 +92,7 @@ spec:
       targets: [example/event-fn]
 ```
 
-Topics that have not opted in never capture headers — nothing enters the runtime, and `Message#headers()` returns an empty list. Records on opted-in topics that happen to carry no headers add zero overhead: the hot path guards every allocation behind a header-count check. Egress headers are always available since they are explicit builder calls.
+Topics that have not opted in never capture headers. Nothing enters the runtime, and `Message#headers()` returns an empty list. Records on opted-in topics that happen to carry no headers add zero overhead: the hot path guards every allocation behind a header-count check. Egress headers are always available since they are explicit builder calls.
 
 ## Can I unit-test functions that use headers?
 
@@ -115,11 +115,11 @@ assertThat(record.lastHeader("traceparent").orElseThrow().valueAsUtf8String())
     .startsWith("00-");
 ```
 
-`KafkaEgressCapture` unpacks a captured egress message into topic, key, value, and headers — with `lastHeader` following Kafka's own last-wins semantics.
+`KafkaEgressCapture` unpacks a captured egress message into topic, key, value, and headers, with `lastHeader` following Kafka's own last-wins semantics.
 
 ## How is this tested?
 
-Around sixty unit tests pin the contract at each seam: duplicate keys, ordering, all six value encodings, null-vs-empty at every boundary, garbage bytes decoding to `null` instead of throwing. On top of that sits the Kubernetes end-to-end gate every release has to pass anyway — it now produces a record with UTF-8, binary, *and* null-valued headers into a kind cluster running the Flink Operator, has a remote function echo them, and asserts byte-exact results on the output topic.
+Around sixty unit tests pin the contract at each seam: duplicate keys, ordering, all six value encodings, null-vs-empty at every boundary, garbage bytes decoding to `null` instead of throwing. On top of that sits the Kubernetes end-to-end gate every release has to pass anyway. It now produces a record with UTF-8, binary, *and* null-valued headers into a kind cluster running the Flink Operator, has a remote function echo them, and asserts byte-exact results on the output topic.
 
 ## How do I get it?
 
@@ -133,8 +133,6 @@ Around sixty unit tests pin the contract at each seam: duplicate keys, ordering,
 </dependency>
 ```
 
-Existing deployments upgrade in place — the protocol change is strictly additive, and header forwarding stays off until a topic opts in, so nothing changes behavior until you say so.
+Existing deployments upgrade in place. The protocol change is strictly additive, and header forwarding stays off until a topic opts in, so nothing changes behavior until you say so.
 
-Full reference: **[the Kafka record headers guide](https://kzmlabs.github.io/flink-statefun/guides/kafka-headers/)**. Background on the fork itself: **[We forked Apache Stateful Functions for Flink 2.x — here's why](forking-statefun.md)**.
-
-[our-repo]: https://github.com/kzmlabs/flink-statefun
+Full reference: **[the Kafka record headers guide](../guides/kafka-headers.md)**. Background on the fork itself: **[We forked Apache Stateful Functions for Flink 2.x](forking-statefun.md)**.

--- a/docs/guides/kafka-headers.md
+++ b/docs/guides/kafka-headers.md
@@ -1,6 +1,6 @@
 # Kafka record headers
 
-Kafka records carry headers — key/value metadata pairs alongside the payload, commonly used for
+Kafka records carry headers - key/value metadata pairs alongside the payload, commonly used for
 trace IDs, correlation IDs, schema hints, retry counters, or routing tags. StateFun Actors
 supports headers in **both directions** for remote functions built with `statefun-sdk-java`:
 
@@ -16,11 +16,11 @@ Semantics match Kafka's own contract exactly:
 | Duplicate header keys are allowed | Preserved, in original order |
 | Header **value** may be `null` (distinct from empty) | Preserved as `null` end-to-end |
 | Header **key** must not be `null` | A null key degrades to an empty key instead of failing |
-| Headers are raw bytes on the wire | Choose an encoding — see [Choosing an encoding](#choosing-an-encoding) |
+| Headers are raw bytes on the wire | Choose an encoding - see [Choosing an encoding](#choosing-an-encoding) |
 
 Egress headers work out of the box. Ingress header **forwarding is opt-in**: headers cost payload
 bytes on every hop between the ingress and the remote function, so a topic only pays for them
-after opting in — see [Enabling header forwarding](#enabling-header-forwarding).
+after opting in - see [Enabling header forwarding](#enabling-header-forwarding).
 
 ## Enabling header forwarding
 
@@ -51,7 +51,7 @@ The effective value per topic is resolved as: per-topic `forwardHeaders` if pres
 the ingress-level `forwardHeaders`, otherwise `false`. With a 20-topic ingress you set the policy
 once at ingress level and override individual topics in either direction.
 
-For a topic that has not opted in, record headers are never captured — no header bytes enter the
+For a topic that has not opted in, record headers are never captured - no header bytes enter the
 runtime, the Flink shuffle, or the remote-function request, and `Message#headers()` returns an
 empty list. Records on opted-in topics without headers still add zero overhead.
 
@@ -80,16 +80,16 @@ public CompletableFuture<Void> apply(Context context, Message message) {
 - headers appear in the order they were set on the Kafka record, duplicates included;
 - messages from a topic that did not enable
   [`forwardHeaders`](#enabling-header-forwarding), and messages that did not originate from a
-  Kafka ingress, return an empty list (unless the sender attached headers explicitly — see
+  Kafka ingress, return an empty list (unless the sender attached headers explicitly - see
   [Forwarding headers](#forwarding-headers-between-functions));
-- the list is computed lazily and cached — untouched headers cost nothing.
+- the list is computed lazily and cached - untouched headers cost nothing.
 
 ### `MessageHeader` accessors
 
 | Accessor | Returns | For values written with |
 |---|---|---|
-| `key()` | `String` (never null) | — |
-| `hasValue()` | `false` when the Kafka header value was null | — |
+| `key()` | `String` (never null) | - |
+| `hasValue()` | `false` when the Kafka header value was null | - |
 | `value()` | `Slice` (zero-copy), or `null` for a null-valued header | `withHeader(key, byte[]/Slice)` |
 | `valueAsUtf8String()` | `String` | `withUtf8Header(key, text)` |
 | `valueAsInt()` / `valueAsLong()` / `valueAsFloat()` / `valueAsDouble()` / `valueAsBoolean()` | boxed primitive | the matching primitive `withHeader` overload |
@@ -97,7 +97,7 @@ public CompletableFuture<Void> apply(Context context, Message message) {
 
 !!! note "Never throws"
 
-    Every accessor is production-safe: a null or undecodable value returns `null` — an exception
+    Every accessor is production-safe: a null or undecodable value returns `null` - an exception
     is never thrown inside a live function invocation because of malformed header bytes.
 
 ## Writing headers to a Kafka egress
@@ -123,25 +123,25 @@ context.send(
 | `withHeader(String key, byte[] value)` | raw bytes as given |
 | `withHeader(String key, Slice value)` | raw bytes as given (zero-copy) |
 | `withHeader(String key, Type<T> type, T value)` | the SDK type's serializer |
-| `withHeader(String key, int / long / float / double / boolean value)` | binary SDK `Types` encoding — shorthand for the `Type<T>` overload |
+| `withHeader(String key, int / long / float / double / boolean value)` | binary SDK `Types` encoding - shorthand for the `Type<T>` overload |
 
 Headers may repeat keys; they are written in call order.
 
 ## Choosing an encoding
 
-Kafka headers are always raw bytes on the wire — there is no native "number" header type — so
+Kafka headers are always raw bytes on the wire - there is no native "number" header type - so
 the choice is which encoding the *reader* expects:
 
-- **Binary (`withHeader(key, 10)` / `Type<T>` overload)** — a real binary number, decoded
+- **Binary (`withHeader(key, 10)` / `Type<T>` overload)** - a real binary number, decoded
   losslessly by any StateFun SDK reader via `valueAsInt()` etc. Best between StateFun functions.
-- **UTF-8 text (`withUtf8Header(key, "10")`)** — readable by any Kafka consumer, `kcat`, Kafka
+- **UTF-8 text (`withUtf8Header(key, "10")`)** - readable by any Kafka consumer, `kcat`, Kafka
   Connect, or UI tooling. Best when non-StateFun systems consume the topic.
-- **Raw bytes (`byte[]`/`Slice`)** — you own the encoding on both sides (e.g. hashes, protobuf).
+- **Raw bytes (`byte[]`/`Slice`)** - you own the encoding on both sides (e.g. hashes, protobuf).
 
 ## Null semantics
 
 Kafka distinguishes a header with a **null value** from one with an **empty value**, and so does
-StateFun — a null value survives the full ingress → function → egress round-trip as null:
+StateFun - a null value survives the full ingress → function → egress round-trip as null:
 
 ```java
 // echoing headers preserves null-ness:
@@ -149,8 +149,8 @@ message.headers().forEach(h -> egress.withHeader(h.key(), h.value())); // null v
 
 // reading:
 header.hasValue();   // false for a null-valued header
-header.value();      // null   — same contract as Kafka's own Header#value()
-header.valueAsInt(); // null   — no exception
+header.value();      // null   - same contract as Kafka's own Header#value()
+header.valueAsInt(); // null   - no exception
 ```
 
 Write-side null handling (never fails a send):
@@ -159,12 +159,12 @@ Write-side null handling (never fails a send):
 |---|---|
 | null header *value* (any overload) | header present with a **null** value |
 | explicitly empty value (`new byte[0]`) | header present with an **empty** value |
-| null header *key* | key degrades to `""` (Kafka forbids null keys — failing inside the running job would be worse) |
+| null header *key* | key degrades to `""` (Kafka forbids null keys - failing inside the running job would be worse) |
 | null `Type<T>` object | treated as a null value |
 
 ## Forwarding headers between functions
 
-Function-to-function messages can carry headers too — `MessageBuilder` has the same overload
+Function-to-function messages can carry headers too - `MessageBuilder` has the same overload
 family, and the receiving function reads them with the same `Message#headers()` API:
 
 ```java
@@ -180,7 +180,7 @@ or forwarding, including null-valued ones.
 
 ## Testing header-aware functions
 
-The SDK testing toolkit covers headers end-to-end — construct incoming messages with headers via
+The SDK testing toolkit covers headers end-to-end - construct incoming messages with headers via
 `MessageBuilder`, and assert egress headers with `KafkaEgressCapture` (no protobuf hand-parsing):
 
 ```java
@@ -215,15 +215,15 @@ production paths it fails loudly: passing a non-Kafka egress message throws
 Header support is strictly additive at the protocol level:
 
 - `KafkaProducerRecord` (egress), `TypedValue.Metadata` (request-reply), and the internal ingress
-  envelope each gained a repeated header field with a `has_value` flag — the same idiom
+  envelope each gained a repeated header field with a `has_value` flag - the same idiom
   `TypedValue` itself uses to distinguish empty from absent.
 - Remote functions built against **older SDKs** keep working against a runtime with header
-  support — they simply do not see headers.
-- A **new SDK** talking to an **older runtime** also keeps working — headers set on egress
+  support - they simply do not see headers.
+- A **new SDK** talking to an **older runtime** also keeps working - headers set on egress
   messages are ignored by the old runtime, nothing fails.
-- `forwardHeaders` is an additive YAML property — existing `module.yaml` files parse unchanged
+- `forwardHeaders` is an additive YAML property - existing `module.yaml` files parse unchanged
   and keep the default (off).
-- Records without headers — and all records on topics that did not opt in — have unchanged wire
+- Records without headers - and all records on topics that did not opt in - have unchanged wire
   size and no extra allocations on any path.
 
 !!! info "Kafka only"

--- a/docs/guides/kafka-io.md
+++ b/docs/guides/kafka-io.md
@@ -1,6 +1,6 @@
 ---
 title: Kafka I/O
-description: Apache Kafka ingress and egress configuration for StateFun Actors on Apache Flink — exactly-once delivery, multi-topic ingresses, custom Protobuf types, routing patterns.
+description: Apache Kafka ingress and egress configuration for StateFun Actors on Apache Flink - exactly-once delivery, multi-topic ingresses, custom Protobuf types, routing patterns.
 ---
 
 # Kafka I/O
@@ -24,7 +24,7 @@ spec:
         - example/order-handler
 ```
 
-Each entry under `topics:` maps inbound records to a target function namespace + name. The `valueType` declares how StateFun decodes the record value — typically a Protobuf type registered in your SDK code.
+Each entry under `topics:` maps inbound records to a target function namespace + name. The `valueType` declares how StateFun decodes the record value - typically a Protobuf type registered in your SDK code.
 
 ### Startup position
 
@@ -88,7 +88,7 @@ Kafka record headers travel in both directions: functions read the headers of th
 triggered them via `Message#headers()` and attach headers to egress records via the
 `KafkaEgressMessage` builder. Ingress header forwarding is opt-in per topic through the
 `forwardHeaders` spec property (default `false`, settable at ingress level with per-topic
-overrides). Semantics match Kafka's own — duplicate keys, ordering, and the null-vs-empty value
+overrides). Semantics match Kafka's own - duplicate keys, ordering, and the null-vs-empty value
 distinction are all preserved, and header operations never throw on null input.
 
 See the dedicated guide: **[Kafka record headers](kafka-headers.md)**.
@@ -146,8 +146,8 @@ Works more reliably than the generic string codec for binary content.
 
 <div class="grid cards" markdown>
 
-- :material-aws:{ .lg .middle } &nbsp; **[Kinesis I/O](kinesis-io.md)** — same routing model, AWS Kinesis transport.
-- :material-kubernetes:{ .lg .middle } &nbsp; **[Kubernetes deployment](k8s-deployment.md)** — wiring ingress/egress in production.
-- :material-graph:{ .lg .middle } &nbsp; **[Architecture overview](../architecture/index.md)** — how the dispatcher routes ingress messages.
+- :material-aws:{ .lg .middle } &nbsp; **[Kinesis I/O](kinesis-io.md)** - same routing model, AWS Kinesis transport.
+- :material-kubernetes:{ .lg .middle } &nbsp; **[Kubernetes deployment](k8s-deployment.md)** - wiring ingress/egress in production.
+- :material-graph:{ .lg .middle } &nbsp; **[Architecture overview](../architecture/index.md)** - how the dispatcher routes ingress messages.
 
 </div>

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 ---
 title: StateFun Actors by Kzmlabs
-description: Stateful actors on Apache Flink 2.x and Java 21 — durable per-key state, exactly-once messaging, Kafka and Kinesis I/O, Kubernetes-native deployment. Continues the Apache Stateful Functions programming model on the modern Flink line.
+description: Stateful actors on Apache Flink 2.x and Java 21 - durable per-key state, exactly-once messaging, Kafka and Kinesis I/O, Kubernetes-native deployment. Continues the Apache Stateful Functions programming model on the modern Flink line.
 hide:
   - navigation
   - toc
@@ -8,7 +8,7 @@ hide:
 
 ## What is StateFun Actors?
 
-You write a function keyed by a logical id. The runtime gives it per-key durable state, routes messages to it, replays on failure, and connects it to Kafka and Kinesis. **Actor programming on top of Apache Flink — without writing a Flink job by hand.**
+You write a function keyed by a logical id. The runtime gives it per-key durable state, routes messages to it, replays on failure, and connects it to Kafka and Kinesis. **Actor programming on top of Apache Flink - without writing a Flink job by hand.**
 
 This is the actively maintained continuation of [Apache Stateful Functions](https://github.com/apache/flink-statefun): same programming model, current Flink, current Java, restored Kinesis I/O, and a real Kubernetes end-to-end gate before every release.
 
@@ -92,7 +92,7 @@ public class Counter implements StatefulFunction {
 
 </div>
 
-More patterns work the same way — order workflows, payment sagas, polyglot microservices, real-time scoring. The model in [Architecture overview](architecture/index.md) is the same in every case: durable per-key state plus exactly-once messaging.
+More patterns work the same way - order workflows, payment sagas, polyglot microservices, real-time scoring. The model in [Architecture overview](architecture/index.md) is the same in every case: durable per-key state plus exactly-once messaging.
 
 ## Polyglot SDKs and pluggable I/O
 
@@ -114,7 +114,7 @@ Write functions in whichever language fits the team. Plug into the streaming and
 
 ## Why this continuation exists
 
-Apache Stateful Functions stopped releasing in **October 2024** at version 3.4.0, locked to **Flink 1.16** and **Java 11**. Anyone wanting to run it against modern Flink either pinned old dependencies or vendored their own patches. StateFun Actors is the public, actively maintained continuation — same code, modern stack, no vendor lock-in.
+Apache Stateful Functions stopped releasing in **October 2024** at version 3.4.0, locked to **Flink 1.16** and **Java 11**. Anyone wanting to run it against modern Flink either pinned old dependencies or vendored their own patches. StateFun Actors is the public, actively maintained continuation - same code, modern stack, no vendor lock-in.
 
 | | Apache StateFun 3.4.0 | StateFun Actors KZM-3.4 |
 |---|---|---|
@@ -130,12 +130,12 @@ Apache Stateful Functions stopped releasing in **October 2024** at version 3.4.0
 
 ## What you get
 
--   **Per-key durable state** — read and write your function's own state without manually wiring Flink keyed-state primitives.
+-   **Per-key durable state** - read and write your function's own state without manually wiring Flink keyed-state primitives.
 -   **Exactly-once messaging** between functions and to/from external systems, riding Flink's checkpointing.
--   **Polyglot remote functions** — write functions as HTTP endpoints in any language; the runtime owns state and routing.
--   **Kafka record headers, end-to-end** *(new in KZM-3.4)* — functions read the headers of the record that triggered them and set headers on egress records, with Kafka-exact null semantics and per-topic opt-in. [Guide →](guides/kafka-headers.md)
--   **Deployment flexibility** — embedded in Flink, co-located with the JobManager, or remote HTTP services scaled independently.
--   **Production-grade releases** — every version is gated on a real K8s end-to-end run with the Flink Operator, Kafka, S3 checkpoints, and the actual remote-function pod.
+-   **Polyglot remote functions** - write functions as HTTP endpoints in any language; the runtime owns state and routing.
+-   **Kafka record headers, end-to-end** *(new in KZM-3.4)* - functions read the headers of the record that triggered them and set headers on egress records, with Kafka-exact null semantics and per-topic opt-in. [Guide →](guides/kafka-headers.md)
+-   **Deployment flexibility** - embedded in Flink, co-located with the JobManager, or remote HTTP services scaled independently.
+-   **Production-grade releases** - every version is gated on a real K8s end-to-end run with the Flink Operator, Kafka, S3 checkpoints, and the actual remote-function pod.
 
 ## At a glance
 


### PR DESCRIPTION
Typography pass on the new header docs: em-dash character removed everywhere (plain hyphens and colons instead), article title uses a colon, article body synced with the published dev.to version and links back to it. mkdocs build --strict passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded Kafka record header guidance, including writing headers, numeric and null-value handling, topic opt-in behavior, forwarding, compatibility, and deployment guidance.
  * Clarified header APIs, encoding choices, builder overloads, testing guidance, and protocol compatibility.
  * Standardized punctuation, formatting, and line wrapping across article, guide, and landing pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->