### PR TITLE
docs+quickstart: Medium cross-link and a header in the greeter example

### DIFF
--- a/docs/articles/kafka-record-headers.md
+++ b/docs/articles/kafka-record-headers.md
@@ -5,7 +5,7 @@ description: StateFun Actors 3.4.0-KZM-3.4 adds end-to-end Kafka record header s
 
 # Kafka record headers in Stateful Functions: closing a five-year-old gap
 
-*Published 2026-07-24 · by the kzmlabs maintainers · [Read on dev.to](https://dev.to/okazimirov/kafka-record-headers-in-stateful-functions-closing-a-five-year-old-gap-5bon)*
+*Published 2026-07-24 · by the kzmlabs maintainers · [Read on dev.to](https://dev.to/okazimirov/kafka-record-headers-in-stateful-functions-closing-a-five-year-old-gap-5bon) · [Read on Medium](https://medium.com/@kazimirov.oleksandr/kafka-record-headers-in-stateful-functions-3f24c82b473f)*
 
 Apache Stateful Functions never supported Kafka record headers. Not on the way in: a function had no way to see the headers of the record that invoked it. Not on the way out: the egress builder had topic, key, and value, and nothing else. If your platform standardized on header-borne trace context, tenant tags, or schema hints, StateFun was a black hole in the middle of your pipeline. Headers went in, and they never came out.
 

--- a/examples/quickstart/greeter/src/main/java/io/github/kzmlabs/quickstart/GreeterFn.java
+++ b/examples/quickstart/greeter/src/main/java/io/github/kzmlabs/quickstart/GreeterFn.java
@@ -48,6 +48,7 @@ public final class GreeterFn implements StatefulFunction {
             .withTopic(RESULTS_TOPIC)
             .withUtf8Key(context.self().id())
             .withUtf8Value(greeting)
+            .withUtf8Header("greeted-by", "quickstart-greeter") // Kafka record header, since KZM-3.4
             .build());
 
     return context.done();


### PR DESCRIPTION
Cross-link pass after the KZM-3.4 announcements: canonical article byline gains the Medium link; the quickstart greeter sets one record header on its egress so the feature is visible in the first example users run. Quickstart smoke validates the round-trip against the published 3.4.0-KZM-3.4 artifacts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Quickstart greeting messages now include a `greeted-by` Kafka header identifying the component that produced them.

- **Documentation**
  - Updated the Kafka record headers article with publication attribution and links to read the article on dev.to and Medium.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->