### PR TITLE
Fix silently-ignored restart-strategy keys; make E2E image preload survive containerd store

### DIFF
--- a/docs/guides/k8s-deployment.md
+++ b/docs/guides/k8s-deployment.md
@@ -103,7 +103,7 @@ Flink 2.x renamed several configuration keys. The differences most likely to bit
 |---|---|
 | `state.backend` | `state.backend.type` |
 | `high-availability` | `high-availability.type` |
-| `restart-strategy` | `execution.restart-strategy.type` |
+| `restart-strategy` | `restart-strategy.type` |
 
 !!! warning "Use the fully-qualified keys"
 

--- a/docs/upstream-vs-kzm.md
+++ b/docs/upstream-vs-kzm.md
@@ -54,20 +54,25 @@ Flink 2.x renamed several keys. Update your `module.yaml` / Operator config:
 |---|---|
 | `state.backend` | `state.backend.type` |
 | `high-availability` | `high-availability.type` |
-| `restart-strategy` | `execution.restart-strategy.type` |
+| `restart-strategy` | `restart-strategy.type` |
 
 Flink 2.x silently ignores the short forms, so the symptom is "the cluster comes up but with default values."
 
 ### 2. Restart strategy
 
-Flink 2.x's restart strategy uses the `execution.restart-strategy.*` prefix:
+Flink 2.x's restart strategy keys use the `restart-strategy.*` prefix with an explicit `.type`:
 
 ```yaml
 flinkConfiguration:
-  execution.restart-strategy.type: fixed-delay
-  execution.restart-strategy.fixed-delay.attempts: 3
-  execution.restart-strategy.fixed-delay.delay: 10s
+  restart-strategy.type: fixed-delay
+  restart-strategy.fixed-delay.attempts: 3
+  restart-strategy.fixed-delay.delay: 10s
 ```
+
+Do not add an `execution.` prefix to these keys. Flink 2.x silently ignores
+`execution.restart-strategy.*` and falls back to the default exponential-delay strategy
+with unlimited restart attempts, which turns any poison-pill record into an infinite
+restart loop instead of a terminal job failure.
 
 ### 3. Kinesis routing (if you use Kinesis I/O)
 

--- a/examples/quickstart/docker-compose.yml
+++ b/examples/quickstart/docker-compose.yml
@@ -80,8 +80,8 @@ services:
         state.checkpoints.dir: file:///tmp/flink/checkpoints
         statefun.flink-job-name: statefun-quickstart
         statefun.remote.module-name: file:///opt/statefun/module.yaml
-        execution.restart-strategy.type: fixed-delay
-        execution.restart-strategy.fixed-delay.attempts: 3
+        restart-strategy.type: fixed-delay
+        restart-strategy.fixed-delay.attempts: 3
     healthcheck:
       test: ["CMD-SHELL", "curl -sf http://localhost:8081/overview > /dev/null"]
       interval: 5s

--- a/statefun-e2e-tests/statefun-e2e-k8s-native/scripts/setup-cluster.sh
+++ b/statefun-e2e-tests/statefun-e2e-k8s-native/scripts/setup-cluster.sh
@@ -86,9 +86,10 @@ kind load docker-image flink-statefun:e2e            --name "${CLUSTER_NAME}"
 kind load docker-image statefun-remote-function:e2e  --name "${CLUSTER_NAME}"
 
 # Pre-load infra images so kubelet doesn't pull on cold cache and overrun the
-# 180s readiness wait. Explicit --platform keeps the docker-save tarball
-# single-platform; kind load uses `ctr images import --all-platforms` and
-# otherwise fails on multi-arch manifest lists.
+# 180s readiness wait. Images go through an explicit single-platform
+# `docker save` archive: `kind load docker-image` imports with
+# --all-platforms, which fails on Docker's containerd image store where the
+# multi-arch manifest list references layers that were never pulled.
 echo "=== Pre-loading infra images into kind ==="
 # Match the kind node's actual architecture (which can differ from the host's
 # when KIND_NODE_IMAGE pins a specific platform), fall back to host uname.
@@ -102,9 +103,17 @@ PRELOAD_IMAGES=(
   "${IMAGE_REGISTRY_PREFIX}apache/kafka:3.9.0"
   "${IMAGE_REGISTRY_PREFIX}localstack/localstack:4.1"
 )
+PRELOAD_TMPDIR="$(mktemp -d)"
+trap 'rm -rf "${PRELOAD_TMPDIR}"' EXIT
 for img in "${PRELOAD_IMAGES[@]}"; do
   docker pull --platform "${PRELOAD_PLATFORM}" "${img}"
-  kind load docker-image "${img}" --name "${CLUSTER_NAME}"
+  tarball="${PRELOAD_TMPDIR}/$(echo "${img}" | tr '/:' '__').tar"
+  # --platform requires a recent engine; classic-store pulls are already
+  # single-platform, so plain save is an equivalent fallback there.
+  docker save --platform "${PRELOAD_PLATFORM}" "${img}" -o "${tarball}" 2>/dev/null \
+    || docker save "${img}" -o "${tarball}"
+  kind load image-archive "${tarball}" --name "${CLUSTER_NAME}"
+  rm -f "${tarball}"
 done
 
 # --- cert-manager + Flink Operator ------------------------------------------

--- a/statefun-e2e-tests/statefun-e2e-k8s-native/src/test/resources/k8s/flink-deployment.yaml
+++ b/statefun-e2e-tests/statefun-e2e-k8s-native/src/test/resources/k8s/flink-deployment.yaml
@@ -51,9 +51,12 @@ spec:
     statefun.flink-job-name: statefun-k8s-e2e
     statefun.remote.module-name: "file:///opt/statefun/module.yaml"
     # --- Restart strategy ---
-    execution.restart-strategy.type: fixed-delay
-    execution.restart-strategy.fixed-delay.attempts: "3"
-    execution.restart-strategy.fixed-delay.delay: "5s"
+    # NOTE: keys are restart-strategy.* (no execution. prefix) — Flink 2.x
+    # silently ignores execution.restart-strategy.* and falls back to the
+    # default exponential-delay strategy with unlimited attempts.
+    restart-strategy.type: fixed-delay
+    restart-strategy.fixed-delay.attempts: "3"
+    restart-strategy.fixed-delay.delay: "5s"
     # --- Pipeline ---
     pipeline.auto-generate-uids: "false"
     execution.savepoint.ignore-unclaimed-state: "true"

--- a/statefun-e2e-tests/statefun-smoke-e2e-embedded/src/test/java/org/apache/flink/statefun/e2e/smoke/embedded/EmbeddedSmokeHarnessTest.java
+++ b/statefun-e2e-tests/statefun-smoke-e2e-embedded/src/test/java/org/apache/flink/statefun/e2e/smoke/embedded/EmbeddedSmokeHarnessTest.java
@@ -27,9 +27,9 @@ public class EmbeddedSmokeHarnessTest {
     harness.withConfiguration(
         "classloader.parent-first-patterns.additional",
         "org.apache.flink.statefun;org.apache.kafka;com.google.protobuf");
-    harness.withConfiguration("execution.restart-strategy.type", "fixed-delay");
-    harness.withConfiguration("execution.restart-strategy.fixed-delay.attempts", "2147483647");
-    harness.withConfiguration("execution.restart-strategy.fixed-delay.delay", "1sec");
+    harness.withConfiguration("restart-strategy.type", "fixed-delay");
+    harness.withConfiguration("restart-strategy.fixed-delay.attempts", "2147483647");
+    harness.withConfiguration("restart-strategy.fixed-delay.delay", "1sec");
     harness.withConfiguration("execution.checkpointing.interval", "2sec");
     harness.withConfiguration("execution.checkpointing.mode", "EXACTLY_ONCE");
     harness.withConfiguration("execution.checkpointing.max-concurrent-checkpoints", "3");


### PR DESCRIPTION
## Two fixes surfaced by a live K8s E2E investigation

### 1. `restart-strategy.*` keys (bug, user-facing)

Flink 2.x defines `restart-strategy.type` / `restart-strategy.fixed-delay.*` with no `execution.` prefix (verified against `RestartStrategyOptions` in flink-core 2.2.0: no execution-prefixed keys exist, not even deprecated). Everywhere we used `execution.restart-strategy.*` the keys were silently dropped and the cluster fell back to the FLIP-364 default: exponential-delay with unlimited attempts.

Consequence: a poison-pill record (e.g. a null-key record on a routable Kafka ingress) restarts the job forever instead of reaching terminal FAILED after the configured attempts.

Verified live on the K8s E2E cluster:
- wrong prefix: null-key record kept the job flapping RESTARTING for 8+ minutes (10+ restarts)
- corrected keys: same record fails the job terminally after exactly 1+3 attempts (~21s), with `Recovery is suppressed by FixedDelayRestartBackoffTimeStrategy(maxNumberRestartAttempts=3)`

Fixed in: E2E FlinkDeployment, k8s-deployment guide, upstream-vs-kzm migration table (which ironically warned about silently-ignored keys while prescribing one), quickstart docker-compose, embedded smoke harness.

### 2. E2E infra-image preload vs Docker containerd image store

`kind load docker-image` imports with `--all-platforms` and fails on Docker Desktop's containerd image store (`ctr: content digest ... not found`) because the multi-arch manifest list references never-pulled layers. Preload now stages a single-platform `docker save` archive and uses `kind load image-archive`; classic-store engines fall back to plain `docker save` (equivalent there). CI runners (classic store) are unaffected; local runs on current Docker Desktop were reliably broken.

## Validation
- Full K8s E2E suite green locally with the new preload path (5/5, Kafka suite)
- FlinkDeployment with corrected keys deployed 3x during the investigation, effective config verified via REST (`restart-strategy.type=fixed-delay`)
- Embedded smoke test green locally (`mvn verify -pl statefun-e2e-tests/statefun-smoke-e2e-embedded`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Flink 2.x restart-strategy configuration keys to use the correct `restart-strategy.*` format.
  * Prevented invalid configuration prefixes from being silently ignored, avoiding unintended unlimited restart behavior.
  * Improved container image loading reliability for multi-architecture Kubernetes test environments.

* **Documentation**
  * Updated deployment and migration guidance with corrected configuration examples and warnings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->