### PR TITLE
chore(release): bump version to 3.4.0-KZM-3.5

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -10,7 +10,7 @@ repository-code: "https://github.com/kzmlabs/flink-statefun"
 url: "https://github.com/kzmlabs/flink-statefun"
 license: Apache-2.0
 version: "3.4.0-KZM-3.1"
-date-released: "2026-05-11"
+date-released: "2026-08-08"
 keywords:
   - apache-flink
   - stateful-functions

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Full migration notes: **[Differences from Apache StateFun](https://kzmlabs.githu
     <dependency>
       <groupId>io.github.kzmlabs.flinkstatefun</groupId>
       <artifactId>statefun-bom</artifactId>
-      <version>3.4.0-KZM-3.4</version>
+      <version>3.4.0-KZM-3.5</version>
       <type>pom</type>
       <scope>import</scope>
     </dependency>
@@ -105,7 +105,7 @@ spec:
 ```bash
 docker run --rm -p 8081:8081 \
   -v $(pwd)/module.yaml:/opt/flink/conf/module.yaml \
-  ghcr.io/kzmlabs/flink-statefun:3.4.0-KZM-3.4
+  ghcr.io/kzmlabs/flink-statefun:3.4.0-KZM-3.5
 ```
 
 Full walkthrough → **[Quickstart guide](https://kzmlabs.github.io/flink-statefun/quickstart/)**.
@@ -148,7 +148,7 @@ JobManager and TaskManager logging is configured via `spec.logConfiguration.logb
 
 | Kzmlabs version | Apache StateFun base | Flink | Java | Status |
 |---|---|---|---|---|
-| `3.4.0-KZM-3.4` | 3.4.0 | 2.2.1 | 21 | Latest |
+| `3.4.0-KZM-3.5` | 3.4.0 | 2.2.1 | 21 | Latest |
 | `3.4.0-KZM-3.3` | 3.4.0 | 2.2.0 | 21 | Stable |
 | `3.4.0-KZM-3.1` | 3.4.0 | 2.2.0 | 21 | Stable |
 | `3.4.0-KZM-3.0` | 3.4.0 | 2.2.0 | 21 | Stable |
@@ -156,7 +156,7 @@ JobManager and TaskManager logging is configured via `spec.logConfiguration.logb
 Releases are signed via Sigstore keyless attestation. Verify with:
 
 ```bash
-gh attestation verify oci://ghcr.io/kzmlabs/flink-statefun:3.4.0-KZM-3.4 --owner kzmlabs
+gh attestation verify oci://ghcr.io/kzmlabs/flink-statefun:3.4.0-KZM-3.5 --owner kzmlabs
 ```
 
 ## Branch model

--- a/pom.xml
+++ b/pom.xml
@@ -102,7 +102,7 @@
     </modules>
 
     <properties>
-        <revision>3.4.0-KZM-3.4</revision>
+        <revision>3.4.0-KZM-3.5</revision>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <java.version>21</java.version>


### PR DESCRIPTION
Release bump for 3.4.0-KZM-3.5.

Highlights of this release:
- **invalidRecordHandling on the routable Kafka ingress** (#292, ADR-0008 stage 2): `skip` (new default - job survives invalid records, per-record diagnostics, labeled metrics) and `fail` (strict contract, pinned exceptions).
- Invalid-record diagnostics with full record coordinates (#291, stage 1).
- Isolated K8s E2E scenarios for both policies (#291, #292).
- New Metrics and Alerting guides; ADR-0008 accepted.

**Breaking change:** the default behavior for invalid records (null key, tombstone) changes from crash-the-job to skip-with-log+metric. Operators alerting on job restarts should alert on `numInvalidRecordsSkipped`; `type: fail` restores the old contract.