### PR TITLE
chore(docs): bump quickstart and docs to 3.4.0-KZM-3.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,44 @@ All notable changes to **StateFun Actors by Kzmlabs** are documented in this fil
 
 ## [Unreleased]
 
+## [3.4.0-KZM-3.5] - 2026-08-08
+
+Feature release. Headline: **invalid-record handling on the routable Kafka
+ingress** (ADR-0008 stages 1-2) — one malformed record no longer crashes
+the whole job.
+
+### Added
+
+- **`invalidRecordHandling` policy on `io.statefun.kafka.v1/ingress`**:
+  ingress-level default with a wholesale per-topic override.
+  - `type: skip` (**new default**): an invalid record (null key, or null
+    value / tombstone) is dropped and the job keeps running. Every skipped
+    record is logged individually with full coordinates (defect, topic,
+    partition, offset, timestamp, key, value size) at a configurable
+    `logLevel` (`debug|info|warn|error`, default `warn`) — deliberately no
+    rate limiting.
+  - `type: fail`: the strict pre-3.5 contract — job-fatal on the first
+    invalid record, with the record coordinates in the pinned exception
+    message.
+- **Metrics**: `numInvalidRecordsSkipped` on the source operator's
+  `deserializer` scope, plus a per-topic per-defect breakdown
+  `topic.<topic>.defect.<NULL_KEY|NULL_VALUE>.numInvalidRecordsSkipped`
+  (Prometheus labels `topic`, `defect`) for producer-precise alerting.
+- The `KafkaIngressDeserializer` "return null to skip" javadoc contract is
+  now real for every deserializer, including custom embedded-SDK ones.
+- New **Metrics** and **Alerting** guides; invalid-record E2E scenarios
+  (skip and fail) against a dedicated deployment in the K8s suite.
+
+### Changed
+
+- **Breaking (behavioral)**: the default reaction to an invalid record
+  changes from crash-the-job to skip-with-log+metric. Teams alerting on
+  job restarts as their bad-data signal should alert on
+  `numInvalidRecordsSkipped`, or pin `type: fail`.
+- Invalid-record diagnostics (stage 1): the null-key rejection carries
+  topic/partition/offset/timestamp; the tombstone case is a diagnosable
+  exception instead of a bare `NullPointerException`.
+
 ## [3.4.0-KZM-3.4] - 2026-07-24
 
 Feature release. Headline: **Kafka record headers, end-to-end** — the

--- a/docs/guides/k8s-deployment.md
+++ b/docs/guides/k8s-deployment.md
@@ -37,7 +37,7 @@ metadata:
   name: my-statefun
   namespace: my-app
 spec:
-  image: ghcr.io/kzmlabs/flink-statefun:3.4.0-KZM-3.4
+  image: ghcr.io/kzmlabs/flink-statefun:3.4.0-KZM-3.5
   flinkVersion: v2_2
   flinkConfiguration:
     state.backend.type: rocksdb

--- a/docs/index.md
+++ b/docs/index.md
@@ -165,7 +165,7 @@ Releases are signed via Sigstore keyless attestation, scanned with Trivy, and tr
 Verify a release artifact with the GitHub CLI:
 
 ```bash
-gh attestation verify oci://ghcr.io/kzmlabs/flink-statefun:3.4.0-KZM-3.4 --owner kzmlabs
+gh attestation verify oci://ghcr.io/kzmlabs/flink-statefun:3.4.0-KZM-3.5 --owner kzmlabs
 ```
 
 ## Where next

--- a/docs/install.md
+++ b/docs/install.md
@@ -21,7 +21,7 @@ The full module set is published to Maven Central under the `io.github.kzmlabs.f
         <dependency>
           <groupId>io.github.kzmlabs.flinkstatefun</groupId>
           <artifactId>statefun-bom</artifactId>
-          <version>3.4.0-KZM-3.4</version>
+          <version>3.4.0-KZM-3.5</version>
           <type>pom</type>
           <scope>import</scope>
         </dependency>
@@ -44,7 +44,7 @@ The full module set is published to Maven Central under the `io.github.kzmlabs.f
     <dependency>
       <groupId>io.github.kzmlabs.flinkstatefun</groupId>
       <artifactId>statefun-sdk-java</artifactId>
-      <version>3.4.0-KZM-3.4</version>
+      <version>3.4.0-KZM-3.5</version>
     </dependency>
     ```
 
@@ -52,7 +52,7 @@ The full module set is published to Maven Central under the `io.github.kzmlabs.f
 
     ```kotlin
     dependencies {
-      implementation(platform("io.github.kzmlabs.flinkstatefun:statefun-bom:3.4.0-KZM-3.4"))
+      implementation(platform("io.github.kzmlabs.flinkstatefun:statefun-bom:3.4.0-KZM-3.5"))
       implementation("io.github.kzmlabs.flinkstatefun:statefun-sdk-java")
     }
     ```
@@ -62,7 +62,7 @@ The full module set is published to Maven Central under the `io.github.kzmlabs.f
 Container images are published to GitHub Container Registry:
 
 ```bash
-docker pull ghcr.io/kzmlabs/flink-statefun:3.4.0-KZM-3.4
+docker pull ghcr.io/kzmlabs/flink-statefun:3.4.0-KZM-3.5
 ```
 
 The image bundles **Flink 2.2 + Java 21 + the StateFun distribution JARs + S3/OSS/Azure plugin filesystems**, ready to run as a `FlinkDeployment` via the Flink Kubernetes Operator.
@@ -72,7 +72,7 @@ The image bundles **Flink 2.2 + Java 21 + the StateFun distribution JARs + S3/OS
     Releases are signed with [Sigstore keyless attestation](https://docs.sigstore.dev/) and carry [SLSA build provenance](https://slsa.dev/). Verify with:
 
     ```bash
-    gh attestation verify oci://ghcr.io/kzmlabs/flink-statefun:3.4.0-KZM-3.4 --owner kzmlabs
+    gh attestation verify oci://ghcr.io/kzmlabs/flink-statefun:3.4.0-KZM-3.5 --owner kzmlabs
     ```
 
 ## Module overview
@@ -93,7 +93,7 @@ The image bundles **Flink 2.2 + Java 21 + the StateFun distribution JARs + S3/OS
 
 | Kzmlabs version | Apache StateFun base | Flink | Java | Status |
 |---|---|---|---|---|
-| **`3.4.0-KZM-3.4`** | 3.4.0 | 2.2.1 | 21 | **Latest stable** |
+| **`3.4.0-KZM-3.5`** | 3.4.0 | 2.2.1 | 21 | **Latest stable** |
 | `3.4.0-KZM-3.3` | 3.4.0 | 2.2.0 | 21 | Stable |
 | `3.4.0-KZM-3.1` | 3.4.0 | 2.2.0 | 21 | Stable |
 | `3.4.0-KZM-3.0` | 3.4.0 | 2.2.0 | 21 | Stable |

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -126,7 +126,7 @@ The runtime owns state, routing, exactly-once delivery, and checkpointing. Your 
 
 ??? failure "`pull access denied` on the GHCR image"
 
-    The image is public. If you see this, your local Docker is logged into a different GHCR account that lacks access. Run `docker logout ghcr.io` and try again, or pin to a different tag with `docker pull ghcr.io/kzmlabs/flink-statefun:3.4.0-KZM-3.4` to verify connectivity.
+    The image is public. If you see this, your local Docker is logged into a different GHCR account that lacks access. Run `docker logout ghcr.io` and try again, or pin to a different tag with `docker pull ghcr.io/kzmlabs/flink-statefun:3.4.0-KZM-3.5` to verify connectivity.
 
 ??? failure "Step 4 returns no output / consumer hangs"
 

--- a/docs/snapshots.md
+++ b/docs/snapshots.md
@@ -63,7 +63,7 @@ The `<id>` in `settings.xml` must match the `<id>` of the `<repository>` block i
 <dependency>
     <groupId>io.github.kzmlabs.flinkstatefun</groupId>
     <artifactId>statefun-sdk-java</artifactId>
-    <version>3.4.0-KZM-3.4-SNAPSHOT</version>
+    <version>3.4.0-KZM-3.5-SNAPSHOT</version>
 </dependency>
 ```
 
@@ -71,12 +71,12 @@ Replace the version with whichever in-progress snapshot you want. Browse availab
 
 ## Maintainer flow — publishing a new snapshot
 
-1. Bump the `<revision>` in root `pom.xml` to a `-SNAPSHOT` version (e.g. `3.4.0-KZM-3.4-SNAPSHOT`)
+1. Bump the `<revision>` in root `pom.xml` to a `-SNAPSHOT` version (e.g. `3.4.0-KZM-3.5-SNAPSHOT`)
 2. Merge that bump to `release` branch
 3. Tag and push:
    ```bash
-   git tag snapshot-3.4.0-KZM-3.4 -m "Snapshot 3.4.0-KZM-3.4"
-   git push origin snapshot-3.4.0-KZM-3.4
+   git tag snapshot-3.4.0-KZM-3.5 -m "Snapshot 3.4.0-KZM-3.5"
+   git push origin snapshot-3.4.0-KZM-3.5
    ```
 4. The `Deploy Snapshot` workflow runs (~5-7 min) and publishes to GitHub Packages
 5. Verify upload at https://github.com/orgs/kzmlabs/packages?repo_name=flink-statefun

--- a/docs/upstream-vs-kzm.md
+++ b/docs/upstream-vs-kzm.md
@@ -18,7 +18,7 @@ description: Migration guide from Apache Stateful Functions 3.4.0 to StateFun Ac
 | **Kafka record headers** | Not supported | **End-to-end round-trip** — `Message#headers()` on ingress, egress builder on write, [opt-in per topic](guides/kafka-headers.md) |
 | **Active CI** | Inactive after 3.4.0 | Ongoing — Dependabot, CodeQL, Scorecard, Trivy |
 | **K8s deployment** | Examples in docs | **K8s-native E2E gate** via Flink Operator + LocalStack |
-| **Docker image** | `apache/flink-statefun:3.4.0` (Flink 1.16) | `ghcr.io/kzmlabs/flink-statefun:3.4.0-KZM-3.4` (Flink 2.2) |
+| **Docker image** | `apache/flink-statefun:3.4.0` (Flink 1.16) | `ghcr.io/kzmlabs/flink-statefun:3.4.0-KZM-3.5` (Flink 2.2) |
 | **Test framework** | JUnit 4 | JUnit Jupiter (6.x) |
 | **Release cadence** | Dormant | Active (Maven Central + GHCR) |
 
@@ -34,7 +34,7 @@ Each fork-side decision has a record explaining its context and consequences: se
 +  <groupId>io.github.kzmlabs.flinkstatefun</groupId>
    <artifactId>statefun-sdk-java</artifactId>
 -  <version>3.4.0</version>
-+  <version>3.4.0-KZM-3.4</version>
++  <version>3.4.0-KZM-3.5</version>
  </dependency>
 ```
 

--- a/examples/quickstart/greeter/pom.xml
+++ b/examples/quickstart/greeter/pom.xml
@@ -17,7 +17,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>21</maven.compiler.source>
         <maven.compiler.target>21</maven.compiler.target>
-        <statefun.version>3.4.0-KZM-3.4</statefun.version>
+        <statefun.version>3.4.0-KZM-3.5</statefun.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
Post-release bump now that 3.4.0-KZM-3.5 artifacts are published on Maven Central and GHCR (verified: dependency:get + Sigstore attestation). Docs, install matrix, quickstart example, and the changelog entry for the invalid-record-handling release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable handling for invalid Kafka ingress records, including skip or fail policies.
  * Added per-record diagnostics, configurable logging, and metrics for skipped records.
  * Improved diagnostics for null keys and tombstone records.
  * Invalid records now default to being skipped with logging and metrics.

* **Documentation**
  * Updated installation, deployment, quickstart, snapshot, and release documentation for version 3.4.0-KZM-3.5.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->